### PR TITLE
Fix Docker entrypoint UID/GID handling for Synology and shared groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.9.4] - 2026-01-26
+
+### Fixed
+- **Docker entrypoint UID/GID handling** - Fixed container crash when PGID matches an existing group ID in the container (e.g., Synology with GID 101). Now checks for existing UID/GID by ID instead of name, allowing reuse of pre-existing system groups. (#4)
+
+### Changed
+- **Improved entrypoint logging** - Now shows whether existing users/groups are being reused for easier debugging of permission issues
+
+---
+
 ## [0.9.3] - 2026-01-26
 
 ### Security

--- a/src/docker/build/docker-image/entrypoint.sh
+++ b/src/docker/build/docker-image/entrypoint.sh
@@ -3,33 +3,52 @@ set -e
 
 # SeedSync Docker Entrypoint
 # Handles dynamic user creation and permission management
+#
+# Supports reusing existing host UID/GID mappings, e.g.:
+#   - PUID=1000, PGID=1000 (typical single-user setup)
+#   - PUID=1026, PGID=100  (Synology with "users" group)
+#   - Custom user:group like "torrentapp:media"
 
 # Get user/group IDs from environment (with defaults)
 USER_ID=${PUID:-1000}
 GROUP_ID=${PGID:-1000}
-USERNAME="seedsync"
 
 echo "Starting SeedSync with UID=$USER_ID, GID=$GROUP_ID"
 
-# Create group if it doesn't exist
-if ! getent group "$USERNAME" >/dev/null 2>&1; then
-    groupadd -g "$GROUP_ID" "$USERNAME"
-elif [ "$(getent group "$USERNAME" | cut -d: -f3)" != "$GROUP_ID" ]; then
-    # Group exists but with wrong GID - modify it
-    groupmod -g "$GROUP_ID" "$USERNAME"
+# Resolve group: check if GID already exists
+EXISTING_GROUP=$(getent group "$GROUP_ID" 2>/dev/null | cut -d: -f1 || true)
+if [ -n "$EXISTING_GROUP" ]; then
+    GROUPNAME="$EXISTING_GROUP"
+    echo "Using existing group: $GROUPNAME (GID=$GROUP_ID)"
+else
+    GROUPNAME="seedsync"
+    echo "Creating group: $GROUPNAME (GID=$GROUP_ID)"
+    groupadd -g "$GROUP_ID" "$GROUPNAME"
 fi
 
-# Create user if it doesn't exist
-if ! id -u "$USERNAME" >/dev/null 2>&1; then
+# Resolve user: check if UID already exists
+EXISTING_USER=$(getent passwd "$USER_ID" 2>/dev/null | cut -d: -f1 || true)
+if [ -n "$EXISTING_USER" ]; then
+    USERNAME="$EXISTING_USER"
+    echo "Using existing user: $USERNAME (UID=$USER_ID)"
+
+    # Ensure user is in the target group (may differ from their primary group)
+    if ! id -nG "$USERNAME" | grep -qw "$GROUPNAME"; then
+        usermod -aG "$GROUPNAME" "$USERNAME" 2>/dev/null || true
+    fi
+else
+    USERNAME="seedsync"
+    echo "Creating user: $USERNAME (UID=$USER_ID, GID=$GROUP_ID)"
     useradd -u "$USER_ID" -g "$GROUP_ID" -d /home/$USERNAME -m -s /bin/bash "$USERNAME"
-elif [ "$(id -u "$USERNAME")" != "$USER_ID" ]; then
-    # User exists but with wrong UID - modify it
-    usermod -u "$USER_ID" "$USERNAME"
 fi
 
-# Ensure home directory exists
-mkdir -p /home/$USERNAME
-chown "$USER_ID:$GROUP_ID" /home/$USERNAME
+# Get the user's home directory (may not be /home/$USERNAME for existing users)
+USER_HOME=$(getent passwd "$USERNAME" | cut -d: -f6)
+if [ -z "$USER_HOME" ] || [ ! -d "$USER_HOME" ]; then
+    USER_HOME="/home/$USERNAME"
+    mkdir -p "$USER_HOME"
+fi
+chown "$USER_ID:$GROUP_ID" "$USER_HOME"
 
 # Create required directories if they don't exist
 mkdir -p /config /downloads
@@ -45,12 +64,14 @@ fi
 chown "$USER_ID:$GROUP_ID" /downloads 2>/dev/null || true
 
 # Create SSH directory for the user (needed for SSH key management)
-mkdir -p /home/$USERNAME/.ssh
-chown -R "$USER_ID:$GROUP_ID" /home/$USERNAME/.ssh
-chmod 700 /home/$USERNAME/.ssh
+mkdir -p "$USER_HOME/.ssh"
+chown -R "$USER_ID:$GROUP_ID" "$USER_HOME/.ssh"
+chmod 700 "$USER_HOME/.ssh"
 
 # Set HOME environment variable
-export HOME=/home/$USERNAME
+export HOME="$USER_HOME"
 
-# Execute the command as the seedsync user
+echo "Running as: $USERNAME:$GROUPNAME (UID=$USER_ID, GID=$GROUP_ID)"
+
+# Execute the command as the resolved user
 exec gosu "$USERNAME" "$@"


### PR DESCRIPTION
## Summary

- Fixed container crash when PGID matches an existing group ID in the container
- Now checks for existing UID/GID by **ID** instead of **name**
- Allows reuse of pre-existing system groups (e.g., Synology with GID 101)
- Added clear logging showing what user/group is being used

## Problem

On Synology (and other systems), GID 101 is already used by a system group. The entrypoint script was checking for groups by name ("seedsync"), then trying to create with the user's GID, causing:
```
groupadd: GID '101' already exists
```

## Solution

Check for existing GID/UID by ID, not name. If the ID already exists, reuse it.

## Test plan

- [ ] Test with fresh UID/GID (e.g., PUID=1234, PGID=5678)
- [ ] Test with existing GID (e.g., PGID=101 on Synology)
- [ ] Verify files are created with correct ownership

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)