### PR TITLE
Fix scanfs glibc compatibility for older seedbox servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - **Docker entrypoint UID/GID handling** - Fixed container crash when PGID matches an existing group ID in the container (e.g., Synology with GID 101). Now checks for existing UID/GID by ID instead of name, allowing reuse of pre-existing system groups. (#4)
+- **scanfs glibc compatibility** - Fixed "Failed to load Python shared library" error on older seedbox servers by building scanfs on Debian Buster (glibc 2.28) instead of Bookworm (glibc 2.36). Now supports Linux systems from 2018+. (#5)
 
 ### Changed
 - **Improved entrypoint logging** - Now shows whether existing users/groups are being reused for easier debugging of permission issues

--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -14,8 +14,10 @@ RUN ./node_modules/.bin/ng build --prod --output-path /build/html
 
 # ==============================================================================
 # Stage 2: Build scanfs binary with PyInstaller
+# Use older Debian (buster) for broader glibc compatibility on remote seedboxes
+# buster has glibc 2.28, supporting most Linux systems from 2018+
 # ==============================================================================
-FROM python:3.12-slim-bookworm AS scanfs-builder
+FROM python:3.12-slim-buster AS scanfs-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     binutils \


### PR DESCRIPTION
## Summary

- Build scanfs on Debian Buster (glibc 2.28) instead of Bookworm (glibc 2.36)
- Provides compatibility with Linux systems from 2018+

## Problem

The scanfs binary is built with PyInstaller and copied to remote seedboxes for execution. When built on Debian Bookworm (glibc 2.36), it fails on older servers:

```
Failed to load Python shared library '/tmp/_MEI6TN35V/libpython3.12.so.1.0': 
/lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found
```

## Solution

Build scanfs on an older Debian base image (Buster) which has glibc 2.28, providing much broader compatibility.

| Base Image | glibc | Compatibility |
|------------|-------|---------------|
| Bookworm (old) | 2.36 | Newest systems only |
| Buster (new) | 2.28 | Systems from 2018+ |

## Test plan

- [ ] Build Docker image successfully
- [ ] Test with remote seedbox running Ubuntu 18.04/20.04
- [ ] Verify scanfs executes without glibc errors

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)