### PR TITLE
Add dark mode support with theme toggle

### DIFF
--- a/src/angular/src/app/app.config.ts
+++ b/src/angular/src/app/app.config.ts
@@ -11,6 +11,7 @@ import { ModelFileService } from './services/files/model-file.service';
 import { LogService } from './services/logs/log.service';
 import { ViewFileFilterService } from './services/files/view-file-filter.service';
 import { ViewFileSortService } from './services/files/view-file-sort.service';
+import { ThemeService } from './services/utils/theme.service';
 
 function initializeStreaming(): () => void {
   // Eagerly inject all SSE handler services so they register with StreamDispatchService.
@@ -23,6 +24,9 @@ function initializeStreaming(): () => void {
   // Eagerly inject filter/sort services so they subscribe to options changes
   inject(ViewFileFilterService);
   inject(ViewFileSortService);
+
+  // Eagerly inject theme service so it applies the saved theme on startup
+  inject(ThemeService);
 
   const streamDispatch = inject(StreamDispatchService);
   return () => streamDispatch.start();

--- a/src/angular/src/app/app.scss
+++ b/src/angular/src/app/app.scss
@@ -23,7 +23,7 @@
 }
 
 #title-bar {
-  background-color: $header-color;
+  background-color: var(--ss-header-bg);
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -40,7 +40,7 @@
 }
 
 #top-sidebar {
-  background-color: $primary-light-color;
+  background-color: var(--ss-primary-light);
   width: $sidebar-width;
   height: 100%;
   position: fixed;
@@ -69,7 +69,7 @@
       font-size: 140%;
       cursor: default;
       user-select: none;
-      color: $logo-color;
+      color: var(--ss-logo);
       font-family: $logo-font;
     }
 
@@ -126,7 +126,7 @@
   text-align: start;
 
   &:active {
-    background-color: $header-dark-color;
+    background-color: var(--ss-header-dark);
   }
 }
 

--- a/src/angular/src/app/common/_common.scss
+++ b/src/angular/src/app/common/_common.scss
@@ -27,9 +27,9 @@ $zindex-file-options: 201;
 $zindex-file-search: 100;
 
 %button {
-    background-color: $primary-color;
+    background-color: var(--ss-primary);
     color: white;
-    border: 1px solid $primary-dark-color;
+    border: 1px solid var(--ss-primary-dark);
     border-radius: 4px;
     display: flex;
     flex-direction: column;
@@ -39,16 +39,16 @@ $zindex-file-search: 100;
     user-select: none;
 
     &:active {
-        background-color: #286090;
+        background-color: var(--ss-primary-active);
     }
 
     &[disabled] {
         opacity: .65;
-        background-color: $primary-color;
+        background-color: var(--ss-primary);
     }
 
     &.selected {
-        background-color: $secondary-color;
-        border-color: $secondary-darker-color;
+        background-color: var(--ss-secondary);
+        border-color: var(--ss-secondary-darker);
     }
 }

--- a/src/angular/src/app/common/storage-keys.ts
+++ b/src/angular/src/app/common/storage-keys.ts
@@ -2,4 +2,5 @@ export class StorageKeys {
     public static readonly VIEW_OPTION_SHOW_DETAILS = "view-option-show-details";
     public static readonly VIEW_OPTION_SORT_METHOD = "view-option-sort-method";
     public static readonly VIEW_OPTION_PIN = "view-option-pin";
+    public static readonly THEME = "theme";
 }

--- a/src/angular/src/app/pages/about/about-page.component.scss
+++ b/src/angular/src/app/pages/about/about-page.component.scss
@@ -18,7 +18,7 @@
             }
             span {
                 margin-inline-start: 10px;
-                color: $logo-color;
+                color: var(--ss-logo);
                 font-family: $logo-font;
                 font-size: 300%;
                 cursor: default;

--- a/src/angular/src/app/pages/autoqueue/autoqueue-page.component.scss
+++ b/src/angular/src/app/pages/autoqueue/autoqueue-page.component.scss
@@ -50,32 +50,32 @@
             }
 
             .button {
-                background-color: red;
-                border-color: darkred;
+                background-color: var(--ss-action-remove);
+                border-color: var(--ss-action-remove-border);
 
                 &:active {
-                    background-color: darkred;
+                    background-color: var(--ss-action-remove-active);
                 }
 
                 &[disabled] {
                     opacity: .65;
-                    background-color: red;
+                    background-color: var(--ss-action-remove);
                 }
             }
         }
 
         #add-pattern {
             .button {
-                background-color: green;
-                border-color: darkgreen;
+                background-color: var(--ss-action-add);
+                border-color: var(--ss-action-add-border);
 
                 &:active {
-                    background-color: darkgreen;
+                    background-color: var(--ss-action-add-active);
                 }
 
                 &[disabled] {
                     opacity: .65;
-                    background-color: green;
+                    background-color: var(--ss-action-add);
                 }
             }
 

--- a/src/angular/src/app/pages/files/file-list.component.scss
+++ b/src/angular/src/app/pages/files/file-list.component.scss
@@ -6,11 +6,11 @@
 
 /* striped rows */
 #file-list > div:nth-child(even){
-    background-color: $primary-lighter-color;
+    background-color: var(--ss-primary-lighter);
 }
 
 /* list separator */
-#file-list > div {border-bottom: 1px solid #ddd;}
+#file-list > div {border-bottom: 1px solid var(--ss-border);}
 #file-list > div:last-child{border-bottom: none;}
 
 
@@ -39,7 +39,7 @@
     /* header color */
     #header div {
         font-weight: bold;
-        color: #fff;
-        background-color: #000;
+        color: var(--ss-file-header-text);
+        background-color: var(--ss-file-header-bg);
     }
 }

--- a/src/angular/src/app/pages/files/file-options.component.scss
+++ b/src/angular/src/app/pages/files/file-options.component.scss
@@ -3,7 +3,7 @@
 // Common dropdown template
 %dropdown {
     button {
-        background-color: $primary-color;
+        background-color: var(--ss-primary);
         color: white;
         height: 34px;
         width: 100%;
@@ -37,8 +37,8 @@
     }
 
     .dropdown-menu {
-        background-color: $primary-color;
-        border: 1px solid $primary-dark-color;
+        background-color: var(--ss-primary);
+        border: 1px solid var(--ss-primary-dark);
         color: white;
         padding: 0;
         cursor: default;
@@ -55,17 +55,17 @@
 
             &.active,
             &.active:hover {
-                background-color: $secondary-dark-color;
+                background-color: var(--ss-secondary-dark);
             }
 
             &:hover,
             &:active {
-                background-color: $primary-color;
+                background-color: var(--ss-primary);
             }
 
             &.disabled {
                 opacity: .65;
-                background-color: $primary-color;
+                background-color: var(--ss-primary);
             }
 
             .icon {
@@ -105,8 +105,8 @@
 
 
 %toggle {
-    background-color: $primary-color;
-    border: 1px solid $primary-dark-color;
+    background-color: var(--ss-primary);
+    border: 1px solid var(--ss-primary-dark);
     color: white;
     height: 34px;
     cursor: default;
@@ -119,18 +119,18 @@
 
     &.active,
     &.active:hover{
-        background-color: $secondary-dark-color;
-        border-color: $secondary-darker-color;
+        background-color: var(--ss-secondary-dark);
+        border-color: var(--ss-secondary-darker);
     }
 
     &:hover,
     &:active {
-        background-color: $primary-color;
+        background-color: var(--ss-primary);
     }
 
     &.disabled {
         opacity: .65;
-        background-color: $primary-color;
+        background-color: var(--ss-primary);
     }
 
     .selection {
@@ -157,7 +157,7 @@
 #file-options {
     position: static;
     z-index: $zindex-file-options;
-    background-color: $header-color;
+    background-color: var(--ss-header-bg);
     padding: 0 8px 8px 8px;
 
     display: flex;

--- a/src/angular/src/app/pages/files/file.component.scss
+++ b/src/angular/src/app/pages/files/file.component.scss
@@ -6,7 +6,7 @@
 
 /* selected file */
 .file.selected {
-    background-color: $secondary-color;
+    background-color: var(--ss-secondary);
 }
 
 /* content */
@@ -59,7 +59,7 @@
             flex-direction: column;
 
             .details-text {
-                color: darkgray;
+                color: var(--ss-text-muted);
                 font-size: 80%;
                 line-height: 120%;
 
@@ -170,8 +170,8 @@
 
     .loader {
         display: none;
-        border: 5px solid white;
-        border-top: 5px solid $secondary-dark-color;
+        border: 5px solid var(--ss-loader-border);
+        border-top: 5px solid var(--ss-secondary-dark);
         border-radius: 50%;
         width: 25px;
         height: 25px;
@@ -186,8 +186,8 @@
     // Show loader icon when loading
     &.loading {
         opacity: 1.0;
-        background-color: $secondary-dark-color;
-        border-color: $secondary-darker-color;
+        background-color: var(--ss-secondary-dark);
+        border-color: var(--ss-secondary-darker);
 
         img {
             display: none;
@@ -208,13 +208,13 @@
 
 /* Delete confirmation dialog */
 .delete-confirmation {
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: var(--ss-overlay);
     padding: 15px;
     margin-top: 10px;
     border-radius: 4px;
 
     .confirmation-content {
-        background-color: white;
+        background-color: var(--ss-confirmation-bg);
         padding: 20px;
         border-radius: 4px;
 
@@ -242,7 +242,7 @@
 @media only screen and (min-width: $medium-min-width) {
     /* enable row hover */
     .file:not(.selected):hover {
-        background-color: $secondary-light-color;
+        background-color: var(--ss-secondary-light);
     }
 
     /* width */

--- a/src/angular/src/app/pages/logs/logs-page.component.scss
+++ b/src/angular/src/app/pages/logs/logs-page.component.scss
@@ -40,23 +40,23 @@
         word-break: break-all;
 
         &.debug {
-            color: darkgray;
+            color: var(--ss-log-debug);
         }
 
         &.info {
-            color: black;
+            color: var(--ss-log-info);
         }
 
         &.warning {
-            color: #8a6d3b;
-            background-color: #fcf8e3;
-            border-color: #faebcc;
+            color: var(--ss-log-warning-text);
+            background-color: var(--ss-log-warning-bg);
+            border-color: var(--ss-log-warning-border);
         }
 
         &.error, &.critical {
-            color: #a94442;
-            background-color: #f2dede;
-            border-color: #ebccd1;
+            color: var(--ss-log-error-text);
+            background-color: var(--ss-log-error-bg);
+            border-color: var(--ss-log-error-border);
         }
 
         span.traceback {
@@ -75,11 +75,11 @@
         height: 12px;
         width: 100%;
         text-align: center;
-        border-bottom: 1px solid #e3e3e3;
+        border-bottom: 1px solid var(--ss-log-divider);
         margin-bottom: 15px;
 
         span {
-            background-color: #f5f5f5;
+            background-color: var(--ss-log-divider-bg);
             font-size: 10px;
             padding: 5px;
         }

--- a/src/angular/src/app/pages/main/sidebar.component.html
+++ b/src/angular/src/app/pages/main/sidebar.component.html
@@ -16,4 +16,9 @@
     <img src="assets/icons/refresh.svg" />
     <span class="text">Restart</span>
   </a>
+
+  <a class="button" (click)="onToggleTheme()">
+    <i class="fa-icon" [class.fa-solid]="true" [class.fa-moon]="theme === 'light'" [class.fa-sun]="theme === 'dark'"></i>
+    <span class="text">{{ theme === 'light' ? 'Dark Mode' : 'Light Mode' }}</span>
+  </a>
 </div>

--- a/src/angular/src/app/pages/main/sidebar.component.scss
+++ b/src/angular/src/app/pages/main/sidebar.component.scss
@@ -18,13 +18,13 @@
     user-select: none;
 
     &:active {
-      background-color: $primary-color;
+      background-color: var(--ss-primary);
     }
 
     &.selected {
-      background-color: $secondary-color;
+      background-color: var(--ss-secondary);
       color: white;
-      border-color: #6ac19e;
+      border-color: var(--ss-sidebar-selected-border);
 
       img {
         filter: invert(1.0);
@@ -42,11 +42,29 @@
       margin-inline-end: 4px;
       margin-bottom: 2px;
     }
+
+    .fa-icon {
+      display: inline-block;
+      width: 18px;
+      height: 18px;
+      margin-inline-end: 4px;
+      margin-bottom: 2px;
+      text-align: center;
+      font-size: 16px;
+      line-height: 18px;
+    }
   }
 
   hr {
     margin-top: 3px;
     margin-bottom: 3px;
-    border: 1px solid $header-dark-color;
+    border: 1px solid var(--ss-header-dark);
   }
+}
+
+:host-context([data-bs-theme="dark"]) #sidebar .button img {
+  filter: invert(0.85);
+}
+:host-context([data-bs-theme="dark"]) #sidebar .button.selected img {
+  filter: invert(1.0);
 }

--- a/src/angular/src/app/pages/main/sidebar.component.ts
+++ b/src/angular/src/app/pages/main/sidebar.component.ts
@@ -5,6 +5,7 @@ import { ROUTE_INFOS } from '../../routes';
 import { ServerCommandService } from '../../services/server/server-command.service';
 import { LoggerService } from '../../services/utils/logger.service';
 import { ConnectedService } from '../../services/utils/connected.service';
+import { ThemeService, Theme } from '../../services/utils/theme.service';
 
 @Component({
   selector: 'app-sidebar',
@@ -17,15 +18,23 @@ export class SidebarComponent implements OnInit {
   routeInfos = ROUTE_INFOS;
 
   public commandsEnabled = false;
+  public theme: Theme = 'light';
 
   private readonly _logger = inject(LoggerService);
   private readonly _connectedService = inject(ConnectedService);
   private readonly _commandService = inject(ServerCommandService);
+  private readonly _themeService = inject(ThemeService);
 
   ngOnInit() {
     this._connectedService.connected$.subscribe({
       next: (connected: boolean) => {
         this.commandsEnabled = connected;
+      }
+    });
+
+    this._themeService.theme$.subscribe({
+      next: (theme: Theme) => {
+        this.theme = theme;
       }
     });
   }
@@ -40,5 +49,9 @@ export class SidebarComponent implements OnInit {
         }
       }
     });
+  }
+
+  onToggleTheme() {
+    this._themeService.toggle();
   }
 }

--- a/src/angular/src/app/pages/settings/option.component.scss
+++ b/src/angular/src/app/pages/settings/option.component.scss
@@ -7,9 +7,9 @@
 }
 
 .error {
-    background-color: #f2dede;
-    color: #a94442;
-    border: 1px solid #a94442;
+    background-color: var(--ss-option-error-bg);
+    color: var(--ss-option-error-text);
+    border: 1px solid var(--ss-option-error-border);
 }
 
 label {
@@ -21,7 +21,7 @@ label {
 }
 
 span.description {
-    color: darkgrey;
+    color: var(--ss-text-description);
     font-size: 80%;
     line-height: initial;
     width: 100%;

--- a/src/angular/src/app/services/index.ts
+++ b/src/angular/src/app/services/index.ts
@@ -5,6 +5,8 @@ export type { WebReaction } from './utils/rest.service';
 export { ConnectedService } from './utils/connected.service';
 export { DomService } from './utils/dom.service';
 export { NotificationService } from './utils/notification.service';
+export { ThemeService } from './utils/theme.service';
+export type { Theme } from './utils/theme.service';
 
 // Base
 export { StreamDispatchService } from './base/stream-dispatch.service';

--- a/src/angular/src/app/services/utils/theme.service.spec.ts
+++ b/src/angular/src/app/services/utils/theme.service.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TestBed } from "@angular/core/testing";
+import { ThemeService, Theme } from "./theme.service";
+import { LoggerService } from "./logger.service";
+import { StorageKeys } from "../../common/storage-keys";
+
+describe("ThemeService", () => {
+  let service: ThemeService;
+  let store: Record<string, string> = {};
+  let matchMediaResult = false;
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    store = {};
+    matchMediaResult = false;
+
+    // Save and replace matchMedia (may not exist in happy-dom)
+    originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn((query: string) => ({
+      matches: matchMediaResult,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+
+    // Mock localStorage methods directly
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) => store[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+      clear: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    });
+
+    // Reset the document attribute before each test
+    document.documentElement.removeAttribute("data-bs-theme");
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function createService(): ThemeService {
+    TestBed.configureTestingModule({
+      providers: [
+        ThemeService,
+        {
+          provide: LoggerService,
+          useValue: {
+            debug: vi.fn(),
+            error: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+          },
+        },
+      ],
+    });
+    return TestBed.inject(ThemeService);
+  }
+
+  function latestTheme(): Theme {
+    let result: Theme | undefined;
+    service.theme$.subscribe((t) => (result = t));
+    return result!;
+  }
+
+  // --- Initialization ---
+
+  it("should default to light when system prefers light", () => {
+    matchMediaResult = false;
+    service = createService();
+
+    expect(latestTheme()).toBe("light");
+    expect(document.documentElement.getAttribute("data-bs-theme")).toBe(
+      "light",
+    );
+  });
+
+  it("should default to dark when system prefers dark", () => {
+    matchMediaResult = true;
+    service = createService();
+
+    expect(latestTheme()).toBe("dark");
+    expect(document.documentElement.getAttribute("data-bs-theme")).toBe("dark");
+  });
+
+  it("should respect stored localStorage preference over system preference", () => {
+    matchMediaResult = true; // system says dark
+    store[StorageKeys.THEME] = "light"; // user chose light
+    service = createService();
+
+    expect(latestTheme()).toBe("light");
+    expect(document.documentElement.getAttribute("data-bs-theme")).toBe(
+      "light",
+    );
+  });
+
+  it("should respect stored dark preference from localStorage", () => {
+    matchMediaResult = false; // system says light
+    store[StorageKeys.THEME] = "dark"; // user chose dark
+    service = createService();
+
+    expect(latestTheme()).toBe("dark");
+    expect(document.documentElement.getAttribute("data-bs-theme")).toBe("dark");
+  });
+
+  // --- Toggle ---
+
+  it("should toggle from light to dark and persist", () => {
+    matchMediaResult = false;
+    service = createService();
+
+    service.toggle();
+
+    expect(latestTheme()).toBe("dark");
+    expect(store[StorageKeys.THEME]).toBe("dark");
+    expect(document.documentElement.getAttribute("data-bs-theme")).toBe("dark");
+  });
+
+  it("should toggle from dark to light and persist", () => {
+    store[StorageKeys.THEME] = "dark";
+    service = createService();
+
+    service.toggle();
+
+    expect(latestTheme()).toBe("light");
+    expect(store[StorageKeys.THEME]).toBe("light");
+    expect(document.documentElement.getAttribute("data-bs-theme")).toBe(
+      "light",
+    );
+  });
+
+  it("should set data-bs-theme on document element", () => {
+    service = createService();
+
+    expect(document.documentElement.getAttribute("data-bs-theme")).toBe(
+      "light",
+    );
+
+    service.toggle();
+    expect(document.documentElement.getAttribute("data-bs-theme")).toBe("dark");
+
+    service.toggle();
+    expect(document.documentElement.getAttribute("data-bs-theme")).toBe(
+      "light",
+    );
+  });
+});

--- a/src/angular/src/app/services/utils/theme.service.ts
+++ b/src/angular/src/app/services/utils/theme.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+import { LoggerService } from './logger.service';
+import { StorageKeys } from '../../common/storage-keys';
+
+export type Theme = 'light' | 'dark';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private readonly logger = inject(LoggerService);
+
+  private readonly themeSubject: BehaviorSubject<Theme>;
+
+  readonly theme$: Observable<Theme>;
+
+  constructor() {
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem(StorageKeys.THEME);
+    } catch {
+      // localStorage may be unavailable (private browsing, test environments)
+    }
+
+    let initial: Theme;
+    if (stored === 'light' || stored === 'dark') {
+      initial = stored;
+    } else {
+      try {
+        initial = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      } catch {
+        initial = 'light';
+      }
+    }
+
+    this.themeSubject = new BehaviorSubject<Theme>(initial);
+    this.theme$ = this.themeSubject.asObservable();
+    this.applyTheme(initial);
+  }
+
+  toggle(): void {
+    const next: Theme = this.themeSubject.getValue() === 'dark' ? 'light' : 'dark';
+    this.themeSubject.next(next);
+    try {
+      localStorage.setItem(StorageKeys.THEME, next);
+    } catch {
+      // localStorage may be unavailable
+    }
+    this.applyTheme(next);
+    this.logger.debug('Theme set to: ' + next);
+  }
+
+  private applyTheme(theme: Theme): void {
+    document.documentElement.setAttribute('data-bs-theme', theme);
+  }
+}

--- a/src/angular/src/index.html
+++ b/src/angular/src/index.html
@@ -7,6 +7,16 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="assets/favicon.png">
+    <script>
+        (function() {
+            var t = localStorage.getItem('theme');
+            if (t === 'dark' || t === 'light') {
+                document.documentElement.setAttribute('data-bs-theme', t);
+            } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                document.documentElement.setAttribute('data-bs-theme', 'dark');
+            }
+        })();
+    </script>
 </head>
 <body>
     <app-root></app-root>

--- a/src/angular/src/styles.scss
+++ b/src/angular/src/styles.scss
@@ -1,5 +1,134 @@
 @use 'app/common/common' as *;
 
+// ── Light-mode custom properties (default) ──
+:root {
+    --ss-primary: #337BB7;
+    --ss-primary-dark: #2e6da4;
+    --ss-primary-light: #D7E7F4;
+    --ss-primary-lighter: #F6F6F6;
+    --ss-primary-active: #286090;
+
+    --ss-secondary: #79DFB6;
+    --ss-secondary-light: #C5F0DE;
+    --ss-secondary-dark: #32AD7B;
+    --ss-secondary-darker: #077F4F;
+
+    --ss-header-bg: #DDDDDD;
+    --ss-header-dark: #D3D3D3;
+
+    --ss-logo: #118247;
+
+    --ss-text: #212529;
+    --ss-text-muted: darkgray;
+    --ss-text-description: darkgrey;
+
+    --ss-bg: #ffffff;
+    --ss-bg-surface: #ffffff;
+    --ss-border: #ddd;
+
+    --ss-sidebar-selected-border: #6ac19e;
+
+    // File list header
+    --ss-file-header-bg: #000;
+    --ss-file-header-text: #fff;
+
+    // Delete confirmation
+    --ss-overlay: rgba(0, 0, 0, 0.5);
+    --ss-confirmation-bg: #ffffff;
+
+    // Log severity
+    --ss-log-debug: darkgray;
+    --ss-log-info: black;
+    --ss-log-warning-text: #8a6d3b;
+    --ss-log-warning-bg: #fcf8e3;
+    --ss-log-warning-border: #faebcc;
+    --ss-log-error-text: #a94442;
+    --ss-log-error-bg: #f2dede;
+    --ss-log-error-border: #ebccd1;
+
+    // Log connected divider
+    --ss-log-divider: #e3e3e3;
+    --ss-log-divider-bg: #f5f5f5;
+
+    // Settings option error
+    --ss-option-error-bg: #f2dede;
+    --ss-option-error-text: #a94442;
+    --ss-option-error-border: #a94442;
+
+    // Autoqueue action buttons
+    --ss-action-remove: red;
+    --ss-action-remove-border: darkred;
+    --ss-action-remove-active: darkred;
+    --ss-action-add: green;
+    --ss-action-add-border: darkgreen;
+    --ss-action-add-active: darkgreen;
+
+    // Button loader
+    --ss-loader-border: white;
+    --ss-loader-spin: #32AD7B;
+}
+
+// ── Dark-mode overrides ──
+[data-bs-theme="dark"] {
+    --ss-primary: #4a9fd8;
+    --ss-primary-dark: #3a7fb8;
+    --ss-primary-light: #1e2d3d;
+    --ss-primary-lighter: #2a2a2a;
+    --ss-primary-active: #3580b0;
+
+    --ss-secondary: #5cbf96;
+    --ss-secondary-light: #1a3d2e;
+    --ss-secondary-dark: #3ab88a;
+    --ss-secondary-darker: #1a9e6a;
+
+    --ss-header-bg: #2b2b2b;
+    --ss-header-dark: #333333;
+
+    --ss-logo: #3ec97d;
+
+    --ss-text: #e0e0e0;
+    --ss-text-muted: #888888;
+    --ss-text-description: #999999;
+
+    --ss-bg: #1a1a1a;
+    --ss-bg-surface: #242424;
+    --ss-border: #444;
+
+    --ss-sidebar-selected-border: #3aaa7e;
+
+    --ss-file-header-bg: #333;
+    --ss-file-header-text: #e0e0e0;
+
+    --ss-overlay: rgba(0, 0, 0, 0.7);
+    --ss-confirmation-bg: #2a2a2a;
+
+    --ss-log-debug: #888888;
+    --ss-log-info: #e0e0e0;
+    --ss-log-warning-text: #e0c56e;
+    --ss-log-warning-bg: #3a3520;
+    --ss-log-warning-border: #5a4e2a;
+    --ss-log-error-text: #e87c7a;
+    --ss-log-error-bg: #3a2020;
+    --ss-log-error-border: #5a3030;
+
+    --ss-log-divider: #444;
+    --ss-log-divider-bg: #2a2a2a;
+
+    --ss-option-error-bg: #3a2020;
+    --ss-option-error-text: #e87c7a;
+    --ss-option-error-border: #5a3030;
+
+    --ss-action-remove: #cc3333;
+    --ss-action-remove-border: #992222;
+    --ss-action-remove-active: #992222;
+    --ss-action-add: #22aa44;
+    --ss-action-add-border: #118833;
+    --ss-action-add-active: #118833;
+
+    --ss-loader-border: #444;
+    --ss-loader-spin: #3ab88a;
+}
+
 html {
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
@@ -11,6 +140,8 @@ html, body {
     font-size: 15px;
     line-height: 1.5;
     margin: 0;
+    color: var(--ss-text);
+    background-color: var(--ss-bg);
 }
 
 /* show the input search cancel button */


### PR DESCRIPTION
## Summary

- Add dark mode support leveraging Bootstrap 5.3's `data-bs-theme` attribute, closing #133
- Introduce `ThemeService` with localStorage persistence and `prefers-color-scheme` system preference fallback
- Define 40+ CSS custom properties (`--ss-*`) with light/dark palettes in `styles.scss`
- Migrate all component SCSS files from hardcoded/SCSS color variables to CSS custom properties
- Add sidebar toggle button (moon/sun icon) for switching between light and dark modes
- Add FOUC prevention inline script in `index.html` to apply theme before CSS loads
- Include 7 unit tests for `ThemeService`

## Test plan

- [ ] Run `cd src/angular && npx ng test` — 120 tests pass (12 pre-existing failures in `view-file-options.service.spec.ts` unrelated)
- [ ] `ng serve` and verify all 5 pages render correctly in both light and dark themes
- [ ] Verify persistence: set dark mode → reload → stays dark (no flash)
- [ ] Verify system preference: clear localStorage → theme follows OS setting
- [ ] Verify sidebar toggle works at all responsive breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)