### PR TITLE
Fix staging directory not moving completed downloads

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -1,7 +1,8 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
+import os
 from abc import ABC, abstractmethod
-from typing import List, Callable
+from typing import List, Callable, Set
 from threading import Lock
 from queue import Queue
 from enum import Enum
@@ -104,6 +105,8 @@ class Controller:
         # Determine effective local path: use staging_path when staging is enabled
         if self.__context.config.controller.use_staging and self.__context.config.controller.staging_path:
             self.__effective_local_path = self.__context.config.controller.staging_path
+            # Ensure the staging directory exists so scanners don't crash
+            os.makedirs(self.__effective_local_path, exist_ok=True)
         else:
             self.__effective_local_path = self.__context.config.lftp.local_path
 
@@ -179,6 +182,8 @@ class Controller:
         # Keep track of active files
         self.__active_downloading_file_names = []
         self.__active_extracting_file_names = []
+        # Track previous cycle's downloading files to detect completed downloads
+        self.__prev_downloading_file_names: Set[str] = set()
 
         # Keep track of active command processes
         self.__active_command_processes = []
@@ -318,18 +323,33 @@ class Controller:
 
         # Update list of active file names
         if lftp_statuses is not None:
-            self.__active_downloading_file_names = [
+            current_downloading = set(
                 s.name for s in lftp_statuses if s.state == LftpJobStatus.State.RUNNING
-            ]
+            )
+            # Detect files that just completed downloading (were in previous cycle but not now)
+            just_completed = self.__prev_downloading_file_names - current_downloading
+            if just_completed:
+                for name in just_completed:
+                    self.logger.info("Download completed (LFTP job finished): {}".format(name))
+                # Force a local scan so the completed file is picked up
+                self.__local_scan_process.force_scan()
+
+            self.__active_downloading_file_names = list(current_downloading)
+            self.__prev_downloading_file_names = current_downloading
+        else:
+            just_completed = set()
+
         if latest_extract_statuses is not None:
             self.__active_extracting_file_names = [
                 s.name for s in latest_extract_statuses.statuses if s.state == ExtractStatus.State.EXTRACTING
             ]
 
         # Update the active scanner's state
-        self.__active_scanner.set_active_files(
-            self.__active_downloading_file_names + self.__active_extracting_file_names
-        )
+        # Include just-completed downloads for one extra scan cycle so their final
+        # local file sizes are captured before they leave the active scanner
+        active_files = self.__active_downloading_file_names + self.__active_extracting_file_names
+        active_files += list(just_completed)
+        self.__active_scanner.set_active_files(active_files)
 
         # Update model builder state
         if latest_remote_scan is not None:

--- a/src/python/controller/scan/local_scanner.py
+++ b/src/python/controller/scan/local_scanner.py
@@ -1,5 +1,6 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
+import os
 import logging
 from typing import List
 
@@ -13,6 +14,7 @@ class LocalScanner(IScanner):
     Scanner implementation to scan the local filesystem
     """
     def __init__(self, local_path: str, use_temp_file: bool):
+        self.__local_path = local_path
         self.__scanner = SystemScanner(local_path)
         if use_temp_file:
             self.__scanner.set_lftp_temp_suffix(Constants.LFTP_TEMP_FILE_SUFFIX)
@@ -24,6 +26,11 @@ class LocalScanner(IScanner):
 
     @overrides(IScanner)
     def scan(self) -> List[SystemFile]:
+        # If the scan path doesn't exist yet (e.g. staging directory not created),
+        # return empty results instead of crashing the scanner process
+        if not os.path.isdir(self.__local_path):
+            self.logger.warning("Scan path does not exist: {}".format(self.__local_path))
+            return []
         try:
             result = self.__scanner.scan()
         except SystemScannerError:


### PR DESCRIPTION
## Summary

Fixes two issues with the staging directory feature:

### Fix 1: Move not triggered for non-extractable files (commit 21f32ea)
Non-extractable files were never moved from staging to the final directory because the move logic only ran after extraction completed.

### Fix 2: Race condition losing completed download state (commit 2b8cb4e)
When LFTP finished a download, the file was immediately removed from the active scanner list. If the local scanner (10s interval) hadn't found the file yet, the model lost all local data and could never transition to DOWNLOADED — so the move was never triggered.

Changes:
- **Race condition fix**: Keep completed downloads in active scanner for one extra cycle to capture final file sizes
- **Forced local scan**: Force a local scan when a download completes so the file is picked up promptly
- **Auto-create staging directory**: Create the staging path on startup if it doesn't exist, preventing scanner crashes
- **Resilient LocalScanner**: If the scan path doesn't exist, return empty results instead of killing the scanner process permanently

## Test plan

- [ ] Deploy to Docker container with staging enabled
- [ ] Queue a file download and verify it moves to the final directory after completion
- [ ] Verify "Download completed (LFTP job finished)" appears in logs
- [ ] Verify staging directory is auto-created on startup
- [ ] Run existing unit tests: `python -m pytest tests/unittests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)