### PR TITLE
Fix Advanced LFTP settings not editable for existing configs

### DIFF
--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -47,6 +47,7 @@ class Seedsync:
         if os.path.isfile(self.config_path):
             try:
                 config = Config.from_file(self.config_path)
+                Seedsync._backfill_config_defaults(config)
             except (ConfigError, PersistError) as e:
                 logging.warning("Failed to load config ({}), backing up and using defaults".format(str(e)))
                 Seedsync.__backup_file(self.config_path)
@@ -328,6 +329,27 @@ class Seedsync:
         config.lftp.net_reconnect_interval_multiplier = 1
 
         return config
+
+    @staticmethod
+    def _backfill_config_defaults(config: Config):
+        """
+        Backfill default values for config properties added after the initial release.
+        Called when loading an existing config file that predates newer properties.
+        """
+        if config.lftp.net_socket_buffer is None:
+            config.lftp.net_socket_buffer = 8388608
+        if config.lftp.pget_min_chunk_size is None:
+            config.lftp.pget_min_chunk_size = "100M"
+        if config.lftp.mirror_parallel_directories is None:
+            config.lftp.mirror_parallel_directories = True
+        if config.lftp.net_timeout is None:
+            config.lftp.net_timeout = 20
+        if config.lftp.net_max_retries is None:
+            config.lftp.net_max_retries = 2
+        if config.lftp.net_reconnect_interval_base is None:
+            config.lftp.net_reconnect_interval_base = 3
+        if config.lftp.net_reconnect_interval_multiplier is None:
+            config.lftp.net_reconnect_interval_multiplier = 1
 
     @staticmethod
     def _detect_incomplete_config(config: Config) -> bool:


### PR DESCRIPTION
## Summary
- Existing config files created before the Advanced LFTP feature don't contain the 7 new keys (`net_socket_buffer`, `pget_min_chunk_size`, `mirror_parallel_directories`, `net_timeout`, `net_max_retries`, `net_reconnect_interval_base`, `net_reconnect_interval_multiplier`)
- `from_dict()` correctly keeps these as `None` for missing keys, but the UI disables inputs when `value == null`
- Added `_backfill_config_defaults()` in `seedsync.py` that sets sensible defaults for any `None` advanced LFTP properties after loading an existing config file

## Test plan
- [ ] Deploy updated `develop` image on UAT system with existing config
- [ ] Open Settings > Advanced LFTP — fields should show default values and be editable
- [ ] Change a value, restart — verify it persists
- [ ] Fresh install (no existing config) — verify defaults still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)