### PR TITLE
Change socket buffer size to accept suffixed values (8M, 16M, etc.)

### DIFF
--- a/src/angular/src/app/models/config.ts
+++ b/src/angular/src/app/models/config.ts
@@ -23,7 +23,7 @@ export interface Lftp {
   num_max_total_connections: number | null;
   use_temp_file: boolean | null;
   net_limit_rate: string | null;
-  net_socket_buffer: number | null;
+  net_socket_buffer: string | null;
   pget_min_chunk_size: string | null;
   mirror_parallel_directories: boolean | null;
   net_timeout: number | null;

--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -232,7 +232,8 @@ export const OPTIONS_CONTEXT_ADVANCED_LFTP: IOptionsContext = {
       label: 'Socket Buffer Size',
       valuePath: ['lftp', 'net_socket_buffer'],
       description:
-        'Size of the socket buffer in bytes. Larger values improve throughput on fast links.\n' +
+        'Socket buffer size. Supports suffixes: K, M (e.g. 8M, 16M). ' +
+        'Larger values improve throughput on fast links.\n' +
         '(net:socket-buffer)',
     },
     {

--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -249,7 +249,7 @@ class Config(Persist):
         num_max_total_connections = PROP("num_max_total_connections", Checkers.int_non_negative, Converters.int)
         use_temp_file = PROP("use_temp_file", Checkers.null, Converters.bool)
         net_limit_rate = PROP("net_limit_rate", Checkers.string_allow_empty, Converters.null)
-        net_socket_buffer = PROP("net_socket_buffer", Checkers.int_non_negative, Converters.int)
+        net_socket_buffer = PROP("net_socket_buffer", Checkers.string_allow_empty, Converters.null)
         pget_min_chunk_size = PROP("pget_min_chunk_size", Checkers.string_allow_empty, Converters.null)
         mirror_parallel_directories = PROP("mirror_parallel_directories", Checkers.null, Converters.bool)
         net_timeout = PROP("net_timeout", Checkers.int_non_negative, Converters.int)

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -128,7 +128,7 @@ class Controller:
         self.__lftp.temp_file_name = "*" + Constants.LFTP_TEMP_FILE_SUFFIX
         if self.__context.config.lftp.net_limit_rate:
             self.__lftp.rate_limit = self.__context.config.lftp.net_limit_rate
-        if self.__context.config.lftp.net_socket_buffer is not None:
+        if self.__context.config.lftp.net_socket_buffer:
             self.__lftp.net_socket_buffer = self.__context.config.lftp.net_socket_buffer
         if self.__context.config.lftp.pget_min_chunk_size:
             self.__lftp.min_chunk_size = self.__context.config.lftp.pget_min_chunk_size

--- a/src/python/lftp/lftp.py
+++ b/src/python/lftp/lftp.py
@@ -319,14 +319,12 @@ class Lftp:
         self.__set(Lftp.__SET_SFTP_CONNECT_PROGRAM, program)
 
     @property
-    def net_socket_buffer(self) -> int:
-        return int(self.__get(Lftp.__SET_NET_SOCKET_BUFFER))
+    def net_socket_buffer(self) -> str:
+        return self.__get(Lftp.__SET_NET_SOCKET_BUFFER)
 
     @net_socket_buffer.setter
-    def net_socket_buffer(self, value: int):
-        if value < 0:
-            raise ValueError("Socket buffer size must be zero or greater")
-        self.__set(Lftp.__SET_NET_SOCKET_BUFFER, str(value))
+    def net_socket_buffer(self, value: str):
+        self.__set(Lftp.__SET_NET_SOCKET_BUFFER, value)
 
     @property
     def mirror_parallel_directories(self) -> bool:

--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -320,7 +320,7 @@ class Seedsync:
         config.autoqueue.auto_delete_remote = False
 
         config.lftp.net_limit_rate = ""
-        config.lftp.net_socket_buffer = 8388608
+        config.lftp.net_socket_buffer = "8M"
         config.lftp.pget_min_chunk_size = "100M"
         config.lftp.mirror_parallel_directories = True
         config.lftp.net_timeout = 20
@@ -337,7 +337,7 @@ class Seedsync:
         Called when loading an existing config file that predates newer properties.
         """
         if config.lftp.net_socket_buffer is None:
-            config.lftp.net_socket_buffer = 8388608
+            config.lftp.net_socket_buffer = "8M"
         if config.lftp.pget_min_chunk_size is None:
             config.lftp.pget_min_chunk_size = "100M"
         if config.lftp.mirror_parallel_directories is None:

--- a/src/python/tests/unittests/test_common/test_config.py
+++ b/src/python/tests/unittests/test_common/test_config.py
@@ -193,7 +193,7 @@ class TestConfig(unittest.TestCase):
             "num_max_total_connections": "7",
             "use_temp_file": "True",
             "net_limit_rate": "500K",
-            "net_socket_buffer": "8388608",
+            "net_socket_buffer": "8M",
             "pget_min_chunk_size": "100M",
             "mirror_parallel_directories": "True",
             "net_timeout": "20",
@@ -217,7 +217,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(7, lftp.num_max_total_connections)
         self.assertEqual(True, lftp.use_temp_file)
         self.assertEqual("500K", lftp.net_limit_rate)
-        self.assertEqual(8388608, lftp.net_socket_buffer)
+        self.assertEqual("8M", lftp.net_socket_buffer)
         self.assertEqual("100M", lftp.pget_min_chunk_size)
         self.assertEqual(True, lftp.mirror_parallel_directories)
         self.assertEqual(20, lftp.net_timeout)
@@ -241,7 +241,6 @@ class TestConfig(unittest.TestCase):
                               "num_max_connections_per_dir_file",
                               "num_max_total_connections",
                               "use_temp_file",
-                              "net_socket_buffer",
                               "mirror_parallel_directories",
                               "net_timeout",
                               "net_max_retries",
@@ -260,6 +259,12 @@ class TestConfig(unittest.TestCase):
         empty_rate_dict["net_limit_rate"] = ""
         lftp_empty_rate = Config.Lftp.from_dict(empty_rate_dict)
         self.assertEqual("", lftp_empty_rate.net_limit_rate)
+
+        # net_socket_buffer allows empty values and suffixed values
+        empty_buf_dict = dict(good_dict)
+        empty_buf_dict["net_socket_buffer"] = ""
+        lftp_empty_buf = Config.Lftp.from_dict(empty_buf_dict)
+        self.assertEqual("", lftp_empty_buf.net_socket_buffer)
 
         # pget_min_chunk_size allows empty values
         empty_chunk_dict = dict(good_dict)
@@ -283,7 +288,6 @@ class TestConfig(unittest.TestCase):
         self.check_bad_value_error(Config.Lftp, good_dict, "num_max_total_connections", "-1")
         self.check_bad_value_error(Config.Lftp, good_dict, "use_temp_file", "-1")
         self.check_bad_value_error(Config.Lftp, good_dict, "use_temp_file", "SomeString")
-        self.check_bad_value_error(Config.Lftp, good_dict, "net_socket_buffer", "-1")
         self.check_bad_value_error(Config.Lftp, good_dict, "mirror_parallel_directories", "-1")
         self.check_bad_value_error(Config.Lftp, good_dict, "mirror_parallel_directories", "SomeString")
         self.check_bad_value_error(Config.Lftp, good_dict, "net_timeout", "-1")
@@ -499,7 +503,7 @@ class TestConfig(unittest.TestCase):
         config.lftp.num_max_total_connections = 4
         config.lftp.use_temp_file = True
         config.lftp.net_limit_rate = "500K"
-        config.lftp.net_socket_buffer = 8388608
+        config.lftp.net_socket_buffer = "8M"
         config.lftp.pget_min_chunk_size = "100M"
         config.lftp.mirror_parallel_directories = True
         config.lftp.net_timeout = 20
@@ -544,7 +548,7 @@ class TestConfig(unittest.TestCase):
         num_max_total_connections = 4
         use_temp_file = True
         net_limit_rate = 500K
-        net_socket_buffer = 8388608
+        net_socket_buffer = 8M
         pget_min_chunk_size = 100M
         mirror_parallel_directories = True
         net_timeout = 20
@@ -704,7 +708,7 @@ class TestConfig(unittest.TestCase):
         config.lftp.num_max_total_connections = 0
         config.lftp.use_temp_file = False
         config.lftp.net_limit_rate = ""
-        config.lftp.net_socket_buffer = 8388608
+        config.lftp.net_socket_buffer = "8M"
         config.lftp.pget_min_chunk_size = "100M"
         config.lftp.mirror_parallel_directories = True
         config.lftp.net_timeout = 20
@@ -796,7 +800,7 @@ class TestConfig(unittest.TestCase):
         config.lftp.num_max_total_connections = 0
         config.lftp.use_temp_file = False
         config.lftp.net_limit_rate = ""
-        config.lftp.net_socket_buffer = 8388608
+        config.lftp.net_socket_buffer = "8M"
         config.lftp.pget_min_chunk_size = "100M"
         config.lftp.mirror_parallel_directories = True
         config.lftp.net_timeout = 20


### PR DESCRIPTION
## Summary
- LFTP's `net:socket-buffer` accepts suffixed values like `8M`, `16M`, `32M` but `net_socket_buffer` was typed as `int`, rejecting them with "must be an integer value"
- Changed type from int to string across all layers: config PROP, lftp.py property, controller wiring, TypeScript interface, tests
- Default changed from `8388608` to `"8M"`
- Updated UI description: "Socket buffer size. Supports suffixes: K, M (e.g. 8M, 16M)."

## Test plan
- [ ] Set socket buffer to `32M` in Settings — should save without error
- [ ] Restart — verify value persists
- [ ] Existing configs with numeric values (e.g. `8388608`) should still load fine (string type accepts any value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)