### PR TITLE
Clarify that 0 means unlimited for Max Total Connections

### DIFF
--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -109,7 +109,7 @@ export const OPTIONS_CONTEXT_CONNECTIONS: IOptionsContext = {
       label: 'Max Total Connections',
       valuePath: ['lftp', 'num_max_total_connections'],
       description:
-        'Maximum number of connections.\n' + '(net:connection-limit)',
+        'Maximum number of connections. 0 for unlimited.\n' + '(net:connection-limit)',
     },
     {
       type: OptionType.Text,


### PR DESCRIPTION
## Summary
- Updated the description for Max Total Connections to note that 0 means unlimited

🤖 Generated with [Claude Code](https://claude.com/claude-code)