### PR TITLE
Fix dashboard status sort order and use oldest-first within groups

### DIFF
--- a/src/angular/src/app/services/files/view-file-sort.service.ts
+++ b/src/angular/src/app/services/files/view-file-sort.service.ts
@@ -12,15 +12,21 @@ const StatusComparator: ViewFileComparator = (a: ViewFile, b: ViewFile): number 
       [ViewFileStatus.EXTRACTING]: 0,
       [ViewFileStatus.DOWNLOADING]: 1,
       [ViewFileStatus.QUEUED]: 2,
-      [ViewFileStatus.EXTRACTED]: 3,
-      [ViewFileStatus.DOWNLOADED]: 4,
-      [ViewFileStatus.STOPPED]: 5,
-      [ViewFileStatus.DEFAULT]: 6,
-      [ViewFileStatus.DELETED]: 6, // intermix deleted and default
+      [ViewFileStatus.STOPPED]: 3,
+      [ViewFileStatus.DEFAULT]: 4,
+      [ViewFileStatus.DELETED]: 4, // intermix deleted and default
+      [ViewFileStatus.DOWNLOADED]: 5,
+      [ViewFileStatus.EXTRACTED]: 5, // intermix with downloaded
     };
     if (statusPriorities[a.status] !== statusPriorities[b.status]) {
       return statusPriorities[a.status] - statusPriorities[b.status];
     }
+  }
+  // Within same status group, sort oldest first by remote timestamp
+  const aTime = a.remoteCreatedTimestamp?.getTime() ?? 0;
+  const bTime = b.remoteCreatedTimestamp?.getTime() ?? 0;
+  if (aTime !== bTime) {
+    return aTime - bTime;
   }
   return a.name.localeCompare(b.name);
 };


### PR DESCRIPTION
## Summary
- **Reordered status groups**: Extracting → Downloading → Queued → Stopped → Default → Downloaded/Extracted
  - Previously: completed items appeared above unqueued (Default) items
  - Now: active work first, then idle, then completed at the bottom
- **Oldest first within groups**: Files within the same status group now sort by `remoteCreatedTimestamp` (oldest first) instead of alphabetically. Falls back to name when timestamps are equal.

## Test plan
- [ ] Downloading files appear at the top
- [ ] Queued files appear after downloading
- [ ] Default (idle) files appear after queued
- [ ] Completed/extracted files appear at the bottom
- [ ] Within each group, older files appear before newer ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)