### PR TITLE
Fix crash when remote file is removed during sync

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -412,7 +412,8 @@ class Controller:
 
                 # Clear move tracking when a file is re-queued for download
                 # so that a fresh download to staging will trigger a new move
-                if diff.new_file.state in (ModelFile.State.QUEUED, ModelFile.State.DOWNLOADING):
+                if diff.new_file is not None and \
+                        diff.new_file.state in (ModelFile.State.QUEUED, ModelFile.State.DOWNLOADING):
                     self.__moved_file_names.discard(diff.new_file.name)
 
                 # Detect if a file was just Downloaded


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'NoneType' object has no attribute 'state'` crash at controller.py line 415
- When auto-delete-remote removes a file from the remote server, the scanner creates a REMOVED diff where `new_file` is `None`
- The moved-file tracking code unconditionally accessed `diff.new_file.state` without checking for `None`
- Added a `None` guard before accessing `diff.new_file` properties

## Test plan
- [ ] Enable auto-delete-remote in settings
- [ ] Download a file and let it complete
- [ ] Verify the file is deleted from remote without crashing the controller
- [ ] Verify normal downloads still work (ADDED/UPDATED diffs unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)