### PR TITLE
Preserve DOWNLOADED state after remote file is auto-deleted

### DIFF
--- a/src/python/controller/model_builder.py
+++ b/src/python/controller/model_builder.py
@@ -296,6 +296,15 @@ class ModelBuilder:
                     if all_downloaded:
                         model_file.state = ModelFile.State.DOWNLOADED
 
+            # next we check if file was previously downloaded but remote was deleted
+            # (e.g. auto-delete-remote). The file still exists locally but we can
+            # no longer verify local_size >= remote_size, so use the persist.
+            if model_file.state == ModelFile.State.DEFAULT and \
+                    model_file.local_size is not None and \
+                    model_file.remote_size is None and \
+                    model_file.name in self.__downloaded_files:
+                model_file.state = ModelFile.State.DOWNLOADED
+
             # next we determine if root was Deleted
             # root is Deleted if it does not exist locally, but was downloaded in the past
             if model_file.state == ModelFile.State.DEFAULT and \


### PR DESCRIPTION
## Summary
- When auto-delete-remote deletes a file from the remote server, the model builder could no longer verify `local_size >= remote_size` (since `remote_size` becomes `None`)
- This caused downloaded files to silently revert to `DEFAULT` state
- On the dashboard with status sort, these "completed" files mixed alphabetically with un-queued files instead of sorting into their own group
- Fix: use the `downloaded_file_names` persist to restore `DOWNLOADED` state for files that exist locally but no longer have a remote copy

## Test plan
- [ ] Enable auto-delete-remote in settings
- [ ] Download a file and let it complete (verify it shows as Downloaded)
- [ ] Wait for auto-delete to remove the remote copy
- [ ] Verify the file still shows as Downloaded (not Default) on the dashboard
- [ ] Switch to Status sort — verify Downloaded files sort separately from Default files
- [ ] Restart the service — verify Downloaded state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)