### PR TITLE
Redesign dark mode with 3-surface elevation system

### DIFF
--- a/src/angular/src/app/app.scss
+++ b/src/angular/src/app/app.scss
@@ -162,3 +162,25 @@
     display: none;
   }
 }
+
+// ── Dark mode refinements ──
+:host-context([data-bs-theme="dark"]) {
+  #top-sidebar {
+    border-right: 1px solid #252C37;
+    box-shadow: none;
+  }
+
+  #outside-sidebar {
+    opacity: 0.6;
+  }
+
+  #title-bar {
+    border-bottom: 1px solid #252C37;
+  }
+
+  #sidebar-btn-open {
+    &:active {
+      background-color: #252C37;
+    }
+  }
+}

--- a/src/angular/src/app/pages/autoqueue/autoqueue-page.component.scss
+++ b/src/angular/src/app/pages/autoqueue/autoqueue-page.component.scss
@@ -85,3 +85,31 @@
         }
     }
 }
+
+// ── Dark mode refinements ──
+:host-context([data-bs-theme="dark"]) {
+    #autoqueue #controls {
+        .pattern .text {
+            color: #C7CEDB;
+        }
+
+        #add-pattern input {
+            background-color: #1D222B;
+            border: 1px solid #252C37;
+            color: #E6EAF2;
+
+            &::placeholder {
+                color: #525A6B;
+            }
+
+            &:focus {
+                border-color: #4C8DFF;
+                box-shadow: none;
+            }
+        }
+
+        .button span {
+            color: white;
+        }
+    }
+}

--- a/src/angular/src/app/pages/files/file-list.component.scss
+++ b/src/angular/src/app/pages/files/file-list.component.scss
@@ -43,3 +43,23 @@
         background-color: var(--ss-file-header-bg);
     }
 }
+
+// ── Dark mode refinements ──
+:host-context([data-bs-theme="dark"]) {
+    #file-list > div:nth-child(even) {
+        background-color: rgba(255, 255, 255, 0.02);
+    }
+
+    #file-list > div {
+        border-bottom-color: rgba(255, 255, 255, 0.04);
+        transition: background 120ms ease;
+    }
+
+    #file-list > div:last-child {
+        border-bottom: none;
+    }
+
+    #header div {
+        border-bottom: 1px solid #252C37;
+    }
+}

--- a/src/angular/src/app/pages/files/file-options.component.scss
+++ b/src/angular/src/app/pages/files/file-options.component.scss
@@ -325,3 +325,88 @@
         padding-top: 8px;
     }
 }
+
+// ── Dark mode refinements ──
+:host-context([data-bs-theme="dark"]) {
+    #filter-status,
+    #sort-status {
+        button {
+            background-color: #1D222B;
+            border: 1px solid #252C37;
+            color: #C7CEDB;
+        }
+
+        .dropdown-menu {
+            background-color: #1D222B;
+            border-color: #252C37;
+
+            .dropdown-item {
+                color: #C7CEDB;
+
+                &:hover {
+                    background-color: #252C37;
+                }
+
+                &.active,
+                &.active:hover {
+                    background-color: #3ECF8E;
+                    color: #0F1115;
+                }
+
+                &.disabled {
+                    background-color: #1D222B;
+                    color: #525A6B;
+                }
+            }
+        }
+
+        .icon img {
+            filter: brightness(0) saturate(100%) invert(85%) sepia(5%) saturate(400%) hue-rotate(190deg);
+        }
+    }
+
+    #toggle-details {
+        background-color: #1D222B;
+        border-color: #252C37;
+        color: #C7CEDB;
+
+        &.active,
+        &.active:hover {
+            background-color: #3ECF8E;
+            color: #0F1115;
+            border-color: #2BA86E;
+        }
+    }
+
+    #filter-search {
+        input {
+            background-color: #1D222B;
+            border: 1px solid #252C37;
+            color: #E6EAF2;
+
+            &::placeholder {
+                color: #525A6B;
+            }
+
+            &:focus {
+                border-color: #4C8DFF;
+                box-shadow: none;
+            }
+        }
+
+        img {
+            filter: brightness(0) saturate(100%) invert(85%) sepia(5%) saturate(400%) hue-rotate(190deg);
+        }
+    }
+
+    #small-buttons #pin-filter {
+        background-color: #1D222B;
+        border-color: #252C37;
+
+        &.active,
+        &.active:hover {
+            background-color: #3ECF8E;
+            border-color: #2BA86E;
+        }
+    }
+}

--- a/src/angular/src/app/pages/files/file.component.scss
+++ b/src/angular/src/app/pages/files/file.component.scss
@@ -271,3 +271,126 @@
     .content .eta {display: inline;}
     .content .speed .speed-eta {display: none;}
 }
+
+// ── Dark mode refinements ──
+@keyframes subtlePulse {
+    0%   { opacity: 0.9; }
+    50%  { opacity: 1; }
+    100% { opacity: 0.9; }
+}
+
+:host-context([data-bs-theme="dark"]) {
+    // Row hover with transition
+    .file:not(.selected) {
+        transition: background 120ms ease;
+    }
+    .file:not(.selected):hover {
+        background-color: var(--ss-surface-hover, #252C37);
+    }
+
+    // Selected file - muted for dark
+    .file.selected {
+        background-color: #252C37;
+    }
+
+    // ── Typography hierarchy ──
+    .content .name .text .title {
+        color: #E6EAF2;
+    }
+
+    .content .eta {
+        color: #C7CEDB;
+        font-weight: 500;
+    }
+
+    .content .speed {
+        color: #8A93A6;
+    }
+
+    .content .size_info {
+        color: #6B7280;
+    }
+
+    .content .status .text {
+        color: #8A93A6;
+    }
+
+    // ── File type icons ──
+    .content .name > img {
+        filter: brightness(0) saturate(100%) invert(85%) sepia(5%) saturate(400%) hue-rotate(190deg);
+    }
+
+    // ── Progress bar redesign ──
+    .content .progress {
+        background-color: #2A3140;
+        border-radius: 6px;
+        overflow: hidden;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.6);
+    }
+
+    .content .progress-bar {
+        background-color: #4C8DFF;
+        border-radius: 6px;
+        // Remove Bootstrap stripe/animation in dark mode
+        background-image: none;
+        animation: none;
+
+        // Subtle pulse for active downloads
+        &.progress-bar-animated {
+            background-image: none;
+            animation: subtlePulse 2.4s infinite;
+        }
+    }
+
+    // ── Status icon semantic tinting ──
+    .content .status {
+        img#downloading {
+            filter: brightness(0) saturate(100%) invert(52%) sepia(88%) saturate(1200%) hue-rotate(203deg) brightness(102%) contrast(101%);
+        }
+        img#downloaded {
+            filter: brightness(0) saturate(100%) invert(72%) sepia(30%) saturate(800%) hue-rotate(105deg) brightness(95%) contrast(90%);
+        }
+        img#queued {
+            filter: brightness(0) saturate(100%) invert(70%) sepia(60%) saturate(600%) hue-rotate(5deg) brightness(100%) contrast(95%);
+        }
+        img#extracted {
+            filter: brightness(0) saturate(100%) invert(72%) sepia(30%) saturate(800%) hue-rotate(105deg) brightness(95%) contrast(90%);
+        }
+        img#stopped {
+            filter: brightness(0) saturate(100%) invert(85%) sepia(5%) saturate(400%) hue-rotate(190deg);
+        }
+        img#default-remote {
+            filter: brightness(0) saturate(100%) invert(60%) sepia(5%) saturate(300%) hue-rotate(190deg);
+        }
+        img#deleted {
+            filter: brightness(0) saturate(100%) invert(50%) sepia(40%) saturate(800%) hue-rotate(320deg) brightness(100%) contrast(95%);
+        }
+        img#extracting {
+            filter: brightness(0) saturate(100%) invert(52%) sepia(88%) saturate(1200%) hue-rotate(203deg) brightness(102%) contrast(101%);
+        }
+    }
+
+    // ── Dim 0% progress rows ──
+    .file:has(.progress-bar[aria-valuenow="0"]) {
+        opacity: 0.85;
+    }
+
+    // ── Action buttons ──
+    .actions .button {
+        background-color: #1D222B;
+        border-color: #252C37;
+
+        &:active {
+            background-color: #252C37;
+        }
+
+        img {
+            filter: brightness(0) saturate(100%) invert(85%) sepia(5%) saturate(400%) hue-rotate(190deg);
+        }
+    }
+
+    // ── Delete confirmation ──
+    .delete-confirmation .confirmation-content {
+        border: 1px solid #252C37;
+    }
+}

--- a/src/angular/src/app/pages/logs/logs-page.component.scss
+++ b/src/angular/src/app/pages/logs/logs-page.component.scss
@@ -92,3 +92,21 @@
         font-size: 95%;
     }
 }
+
+// ── Dark mode refinements ──
+:host-context([data-bs-theme="dark"]) {
+    #logs {
+        .connected span {
+            background-color: #161A21;
+        }
+
+        .btn-scroll {
+            background-color: #1D222B;
+            border-color: #252C37;
+
+            &:active {
+                background-color: #252C37;
+            }
+        }
+    }
+}

--- a/src/angular/src/app/pages/main/sidebar.component.scss
+++ b/src/angular/src/app/pages/main/sidebar.component.scss
@@ -62,9 +62,41 @@
   }
 }
 
-:host-context([data-bs-theme="dark"]) #sidebar .button img {
-  filter: invert(0.85);
-}
-:host-context([data-bs-theme="dark"]) #sidebar .button.selected img {
-  filter: invert(1.0);
+// ── Dark mode sidebar ──
+:host-context([data-bs-theme="dark"]) #sidebar {
+  .button {
+    color: #8A93A6;
+    transition: background 120ms ease, color 120ms ease;
+
+    &:hover {
+      background-color: #202634;
+      color: #C7CEDB;
+    }
+
+    &:active {
+      background-color: #252C37;
+    }
+
+    &.selected {
+      background-color: #252C37;
+      color: #FFFFFF;
+      border-color: #3ECF8E;
+
+      img {
+        filter: invert(1.0);
+      }
+    }
+
+    img {
+      filter: brightness(0) saturate(100%) invert(85%) sepia(5%) saturate(400%) hue-rotate(190deg);
+    }
+
+    .fa-icon {
+      color: #C7CEDB;
+    }
+  }
+
+  hr {
+    border-color: #252C37;
+  }
 }

--- a/src/angular/src/app/pages/settings/option.component.scss
+++ b/src/angular/src/app/pages/settings/option.component.scss
@@ -48,3 +48,26 @@ input[type="checkbox"] {
 input[type="text"] {
     width: 100%;
 }
+
+// ── Dark mode refinements ──
+:host-context([data-bs-theme="dark"]) {
+    input[type="text"] {
+        background-color: #1D222B;
+        border: 1px solid #252C37;
+        color: #E6EAF2;
+
+        &::placeholder {
+            color: #525A6B;
+        }
+
+        &:focus {
+            border-color: #4C8DFF;
+            outline: none;
+            box-shadow: none;
+        }
+    }
+
+    input[type="checkbox"] {
+        accent-color: #3ECF8E;
+    }
+}

--- a/src/angular/src/app/pages/settings/settings-page.component.scss
+++ b/src/angular/src/app/pages/settings/settings-page.component.scss
@@ -100,3 +100,37 @@
         }
     }
 }
+
+// ── Dark mode refinements ──
+:host-context([data-bs-theme="dark"]) {
+    #settings #accordion #left,
+    #settings #accordion #right {
+        .card {
+            background-color: transparent;
+            border: 1px solid #252C37;
+
+            .card-header {
+                background-color: #161A21;
+                border-bottom: 1px solid #252C37;
+                color: #8A93A6;
+            }
+
+            .collapsible-header:hover {
+                opacity: 0.9;
+            }
+        }
+    }
+
+    #settings #commands .button {
+        background-color: #1D222B;
+        border-color: #252C37;
+
+        &:active {
+            background-color: #252C37;
+        }
+
+        img {
+            filter: brightness(0) saturate(100%) invert(85%) sepia(5%) saturate(400%) hue-rotate(190deg);
+        }
+    }
+}

--- a/src/angular/src/styles.scss
+++ b/src/angular/src/styles.scss
@@ -69,64 +69,100 @@
 }
 
 // ── Dark-mode overrides ──
+// 3-surface elevation system for proper luminance hierarchy
 [data-bs-theme="dark"] {
-    --ss-primary: #4a9fd8;
-    --ss-primary-dark: #3a7fb8;
-    --ss-primary-light: #1e2d3d;
-    --ss-primary-lighter: #2a2a2a;
-    --ss-primary-active: #3580b0;
+    // ── Elevation surfaces ──
+    --ss-surface-app: #0F1115;
+    --ss-surface-primary: #161A21;
+    --ss-surface-secondary: #1D222B;
+    --ss-surface-hover: #252C37;
 
-    --ss-secondary: #5cbf96;
-    --ss-secondary-light: #1a3d2e;
-    --ss-secondary-dark: #3ab88a;
-    --ss-secondary-darker: #1a9e6a;
+    // ── Brand colors (muted for dark) ──
+    --ss-primary: #4C8DFF;
+    --ss-primary-dark: #3A6FCC;
+    --ss-primary-light: #151922;
+    --ss-primary-lighter: #1D222B;
+    --ss-primary-active: #3A6FCC;
 
-    --ss-header-bg: #2b2b2b;
-    --ss-header-dark: #333333;
+    --ss-secondary: #3ECF8E;
+    --ss-secondary-light: #252C37;
+    --ss-secondary-dark: #3ECF8E;
+    --ss-secondary-darker: #2BA86E;
 
-    --ss-logo: #3ec97d;
+    // ── Header / toolbar ──
+    --ss-header-bg: #161A21;
+    --ss-header-dark: #252C37;
 
-    --ss-text: #e0e0e0;
-    --ss-text-muted: #888888;
-    --ss-text-description: #999999;
+    --ss-logo: #3ECF8E;
 
-    --ss-bg: #1a1a1a;
-    --ss-bg-surface: #242424;
-    --ss-border: #444;
+    // ── Typography hierarchy ──
+    --ss-text: #E6EAF2;
+    --ss-text-muted: #8A93A6;
+    --ss-text-description: #6B7280;
+    --ss-text-eta: #C7CEDB;
+    --ss-text-speed: #8A93A6;
+    --ss-text-label: #525A6B;
 
-    --ss-sidebar-selected-border: #3aaa7e;
+    // ── Surfaces & borders ──
+    --ss-bg: #0F1115;
+    --ss-bg-surface: #161A21;
+    --ss-border: #252C37;
 
-    --ss-file-header-bg: #333;
-    --ss-file-header-text: #e0e0e0;
+    // ── Sidebar ──
+    --ss-sidebar-bg: #151922;
+    --ss-sidebar-selected-border: #3ECF8E;
 
+    // ── File list header ──
+    --ss-file-header-bg: #161A21;
+    --ss-file-header-text: #8A93A6;
+
+    // ── Overlays ──
     --ss-overlay: rgba(0, 0, 0, 0.7);
-    --ss-confirmation-bg: #2a2a2a;
+    --ss-confirmation-bg: #1D222B;
 
-    --ss-log-debug: #888888;
-    --ss-log-info: #e0e0e0;
-    --ss-log-warning-text: #e0c56e;
-    --ss-log-warning-bg: #3a3520;
-    --ss-log-warning-border: #5a4e2a;
-    --ss-log-error-text: #e87c7a;
-    --ss-log-error-bg: #3a2020;
-    --ss-log-error-border: #5a3030;
+    // ── Status semantic colors ──
+    --ss-status-downloading: #4C8DFF;
+    --ss-status-completed: #3ECF8E;
+    --ss-status-queued: #F5A524;
+    --ss-status-error: #FF5C7A;
 
-    --ss-log-divider: #444;
-    --ss-log-divider-bg: #2a2a2a;
+    // ── Progress bar ──
+    --ss-progress-track: #2A3140;
+    --ss-progress-fill: #4C8DFF;
 
-    --ss-option-error-bg: #3a2020;
-    --ss-option-error-text: #e87c7a;
-    --ss-option-error-border: #5a3030;
+    // ── Log severity ──
+    --ss-log-debug: #525A6B;
+    --ss-log-info: #C7CEDB;
+    --ss-log-warning-text: #F5A524;
+    --ss-log-warning-bg: #1D1A10;
+    --ss-log-warning-border: #3A3118;
+    --ss-log-error-text: #FF5C7A;
+    --ss-log-error-bg: #1D1015;
+    --ss-log-error-border: #3A1822;
 
-    --ss-action-remove: #cc3333;
-    --ss-action-remove-border: #992222;
-    --ss-action-remove-active: #992222;
-    --ss-action-add: #22aa44;
-    --ss-action-add-border: #118833;
-    --ss-action-add-active: #118833;
+    // ── Log divider ──
+    --ss-log-divider: #252C37;
+    --ss-log-divider-bg: #161A21;
 
-    --ss-loader-border: #444;
-    --ss-loader-spin: #3ab88a;
+    // ── Settings option error ──
+    --ss-option-error-bg: #1D1015;
+    --ss-option-error-text: #FF5C7A;
+    --ss-option-error-border: #3A1822;
+
+    // ── Action buttons ──
+    --ss-action-remove: #FF5C7A;
+    --ss-action-remove-border: #CC4A62;
+    --ss-action-remove-active: #CC4A62;
+    --ss-action-add: #3ECF8E;
+    --ss-action-add-border: #2BA86E;
+    --ss-action-add-active: #2BA86E;
+
+    // ── Loader ──
+    --ss-loader-border: #252C37;
+    --ss-loader-spin: #3ECF8E;
+
+    // ── Icons ──
+    --ss-icon-default: #C7CEDB;
 }
 
 html {


### PR DESCRIPTION
## Summary

- Overhaul dark theme with a 3-surface luminance elevation system: App (#0F1115) → Primary (#161A21) → Secondary (#1D222B) → Hover (#252C37)
- Add 5-tier typography contrast hierarchy for proper visual weight (filenames, ETA, speed, secondary, labels)
- Redesign progress bars with inset track, rounded corners, and subtle pulse animation for active downloads
- Add semantic color tinting for status icons (blue=downloading, green=completed, amber=queued, red=error)
- Style all pages for dark mode: file list, toolbar/dropdowns, sidebar, settings cards, logs, autoqueue

## Files changed (10 SCSS files)

- `styles.scss` — Complete dark mode CSS custom property overhaul
- `app.scss` — Sidebar border, shadow removal, overlay opacity
- `file-list.component.scss` — Zebra striping, luminance borders, row transitions
- `file.component.scss` — Progress bars, typography hierarchy, status icon tinting, action buttons, hover states
- `file-options.component.scss` — Toolbar dropdowns, search input, toggle buttons
- `sidebar.component.scss` — Sidebar hover/active/selected states, icon tinting
- `settings-page.component.scss` — Card borders, headers, command buttons
- `option.component.scss` — Text inputs, checkbox accent color
- `logs-page.component.scss` — Connected divider, scroll buttons
- `autoqueue-page.component.scss` — Pattern text, input fields

## Test plan

- [ ] Toggle dark mode and verify all pages render correctly
- [ ] Check file list: zebra striping, hover states, selected row
- [ ] Check progress bars: track/fill colors, pulse animation on active downloads
- [ ] Check status icons: color coding matches status (blue, green, amber, red, gray)
- [ ] Check toolbar: dropdown menus, search input, toggle buttons
- [ ] Check sidebar: hover/active states, selected item, logo
- [ ] Check settings: card headers, text inputs, checkboxes, command buttons
- [ ] Check logs: severity colors, connected divider, scroll buttons
- [ ] Check autoqueue: pattern text, add input, action buttons
- [ ] Verify light mode is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)