### PR TITLE
Fix progress bar glitch during downloads

### DIFF
--- a/src/python/controller/model_builder.py
+++ b/src/python/controller/model_builder.py
@@ -24,6 +24,7 @@ class ModelBuilder:
     def __init__(self):
         self.logger = logging.getLogger("ModelBuilder")
         self.__local_files = dict()
+        self.__active_files = dict()
         self.__remote_files = dict()
         self.__lftp_statuses = dict()
         self.__downloaded_files = set()
@@ -35,10 +36,8 @@ class ModelBuilder:
         self.logger = base_logger.getChild("ModelBuilder")
 
     def set_active_files(self, active_files: List[SystemFile]):
-        # Update the local file state with this latest information
-        for file in active_files:
-            self.__local_files[file.name] = file
-        # Invalidate the cache
+        self.__active_files = {file.name: file for file in active_files}
+        # Always invalidate when active files present (sizes change rapidly)
         if len(active_files) > 0:
             self.__cached_model = None
 
@@ -86,6 +85,7 @@ class ModelBuilder:
 
     def clear(self):
         self.__local_files.clear()
+        self.__active_files.clear()
         self.__remote_files.clear()
         self.__lftp_statuses.clear()
         self.__downloaded_files.clear()
@@ -106,12 +106,13 @@ class ModelBuilder:
 
         model = Model()
         model.set_base_logger(logging.getLogger("dummy"))  # ignore the logs for this temp model
-        all_file_names = set().union(self.__local_files.keys(),
+        effective_local = {**self.__local_files, **self.__active_files}
+        all_file_names = set().union(effective_local.keys(),
                                      self.__remote_files.keys(),
                                      self.__lftp_statuses.keys())
         for name in all_file_names:
             remote = self.__remote_files.get(name, None)
-            local = self.__local_files.get(name, None)
+            local = effective_local.get(name, None)
             status = self.__lftp_statuses.get(name, None)
 
             if remote is None and local is None and status is None:


### PR DESCRIPTION
## Summary
- **Fix race condition** in `ModelBuilder` where active download file sizes were stored in `__local_files` and wiped when `set_local_files()` replaced the dict with a new scan result
- **Store active files separately** in `__active_files` and merge at build time with active files taking precedence, so download progress is preserved between scan cycles
- Prevents the UI progress bar from randomly dropping to 0% during active downloads

## Test plan
- [x] All 46 existing `test_model_builder.py` unit tests pass with no changes
- [ ] Manual test: start a download and observe progress bar never drops to 0% mid-download

🤖 Generated with [Claude Code](https://claude.com/claude-code)