### PR TITLE
Fix scanfs timeout crash: pexpect leak, retry logic, SSH keepalive

### DIFF
--- a/src/python/tests/unittests/test_controller/test_scan/test_remote_scanner.py
+++ b/src/python/tests/unittests/test_controller/test_scan/test_remote_scanner.py
@@ -24,6 +24,11 @@ class TestRemoteScanner(unittest.TestCase):
         self.mock_ssh_cls = ssh_patcher.start()
         self.mock_ssh = self.mock_ssh_cls.return_value
 
+        # Patch time.sleep so retry delays don't slow tests
+        sleep_patcher = patch('controller.scan.remote_scanner.time.sleep')
+        self.addCleanup(sleep_patcher.stop)
+        self.mock_sleep = sleep_patcher.start()
+
         logger = logging.getLogger()
         handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(handler)
@@ -44,6 +49,42 @@ class TestRemoteScanner(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(TestRemoteScanner.temp_dir)
+
+    def _make_scanner(self, remote_path="/remote/path/to/scan",
+                      remote_script_path="/remote/path/to/scan/script"):
+        return RemoteScanner(
+            remote_address="my remote address",
+            remote_username="my remote user",
+            remote_password="my password",
+            remote_port=1234,
+            remote_path_to_scan=remote_path,
+            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
+            remote_path_to_scan_script=remote_script_path
+        )
+
+    def _make_shell_side_effect(self, responses):
+        """
+        Create a shell side_effect from a list of responses.
+        Each entry is either a bytes value to return, or an Exception to raise.
+        The shell call sequence on first scan is:
+          1. _log_remote_diagnostics()
+          2. md5sum check
+          3. scanfs (possibly retried)
+        """
+        self._shell_call_index = 0
+
+        def ssh_shell(*args):
+            idx = self._shell_call_index
+            self._shell_call_index += 1
+            if idx < len(responses):
+                resp = responses[idx]
+            else:
+                resp = pickle.dumps([])
+            if isinstance(resp, Exception):
+                raise resp
+            return resp
+
+        return ssh_shell
 
     def test_correctly_initializes_ssh(self):
         self.ssh_args = {}
@@ -70,28 +111,15 @@ class TestRemoteScanner(unittest.TestCase):
         self.assertEqual("my password", self.ssh_args["password"])
 
     def test_installs_scan_script_on_first_scan(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        scanner = self._make_scanner()
 
-        self.ssh_run_command_count = 0
-
-        # Ssh returns error for md5sum check, empty pickle dump for later commands
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # first try
-                return "".encode()
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        # Call sequence: diagnostics, md5sum (non-matching), scanfs
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                # diagnostics
+            b'',                # md5sum - doesn't match, triggers install
+            pickle.dumps([]),   # scanfs
+            pickle.dumps([]),   # second scan: scanfs (no install)
+        ])
 
         scanner.scan()
         self.mock_ssh.copy.assert_called_once_with(
@@ -105,28 +133,13 @@ class TestRemoteScanner(unittest.TestCase):
         self.mock_ssh.copy.assert_not_called()
 
     def test_copy_appends_scanfs_name_to_remote_path(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan"
-        )
+        scanner = self._make_scanner(remote_script_path="/remote/path/to/scan")
 
-        self.ssh_run_command_count = 0
-
-        # Ssh returns error for md5sum check, empty pickle dump for later commands
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # first try
-                return "".encode()
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                # diagnostics
+            b'',                # md5sum - doesn't match
+            pickle.dumps([]),   # scanfs
+        ])
 
         scanner.scan()
         # check for appended path ('script')
@@ -136,59 +149,34 @@ class TestRemoteScanner(unittest.TestCase):
         )
 
     def test_calls_correct_ssh_md5sum_command(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        scanner = self._make_scanner()
 
-        self.ssh_run_command_count = 0
-
-        # Ssh returns error for md5sum check, empty pickle dump for later commands
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # first try
-                return "".encode()
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
-
-        scanner.scan()
-        self.assertEqual(2, self.mock_ssh.shell.call_count)
-        self.mock_ssh.shell.assert_has_calls([
-            call("md5sum '/remote/path/to/scan/script' | awk '{print $1}' || echo"),
-            call(ANY)
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                # diagnostics
+            b'',                # md5sum
+            pickle.dumps([]),   # scanfs
         ])
 
-    def test_skips_install_on_md5sum_match(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
+        scanner.scan()
+        # 3 calls: diagnostics, md5sum, scanfs
+        self.assertEqual(3, self.mock_ssh.shell.call_count)
+        # Second call should be the md5sum command
+        md5sum_call = self.mock_ssh.shell.call_args_list[1]
+        self.assertEqual(
+            call("md5sum '/remote/path/to/scan/script' | awk '{print $1}' || echo"),
+            md5sum_call
         )
 
-        self.ssh_run_command_count = 0
+    def test_skips_install_on_md5sum_match(self):
+        scanner = self._make_scanner()
 
-        # Ssh returns empty on md5sum, empty pickle dump for later commands
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # first try
-                return "d41d8cd98f00b204e9800998ecf8427e".encode()
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        # md5sum of empty file
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                                        # diagnostics
+            b'd41d8cd98f00b204e9800998ecf8427e',        # md5sum - matches
+            pickle.dumps([]),                           # scanfs
+            pickle.dumps([]),                           # second scan: scanfs
+        ])
 
         scanner.scan()
         self.mock_ssh.copy.assert_not_called()
@@ -199,59 +187,27 @@ class TestRemoteScanner(unittest.TestCase):
         self.mock_ssh.copy.assert_not_called()
 
     def test_installs_scan_script_on_any_md5sum_output(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        scanner = self._make_scanner()
 
-        self.ssh_run_command_count = 0
-
-        # Ssh returns error for md5sum check, empty pickle dump for later commands
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # first try
-                return "some output from md5sum".encode()
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                        # diagnostics
+            b'some output from md5sum',  # md5sum - doesn't match
+            pickle.dumps([]),           # scanfs
+        ])
 
         scanner.scan()
         self.mock_ssh.copy.assert_called_once_with(
             local_path=TestRemoteScanner.temp_scan_script,
             remote_path="/remote/path/to/scan/script"
         )
-        self.mock_ssh.copy.reset_mock()
 
     def test_raises_nonrecoverable_error_on_md5sum_error(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        scanner = self._make_scanner()
 
-        self.ssh_run_command_count = 0
-
-        # Ssh returns error for md5sum check, empty pickle dump for later commands
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # md5sum check
-                raise SshcpError("an ssh error")
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                        # diagnostics
+            SshcpError("an ssh error"), # md5sum fails
+        ])
 
         with self.assertRaises(ScannerError) as ctx:
             scanner.scan()
@@ -259,61 +215,33 @@ class TestRemoteScanner(unittest.TestCase):
         self.assertFalse(ctx.exception.recoverable)
 
     def test_calls_correct_ssh_scan_command(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        scanner = self._make_scanner()
 
-        self.ssh_run_command_count = 0
-
-        # Ssh returns error for md5sum check, empty pickle dump for later commands
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # md5sum check
-                return b''
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                # diagnostics
+            b'',                # md5sum
+            pickle.dumps([]),   # scanfs
+        ])
 
         scanner.scan()
-        self.assertEqual(2, self.mock_ssh.shell.call_count)
+        # 3 calls: diagnostics, md5sum, scanfs
+        self.assertEqual(3, self.mock_ssh.shell.call_count)
         self.mock_ssh.shell.assert_called_with(
             "'/remote/path/to/scan/script' '/remote/path/to/scan'"
         )
 
     def test_handles_tilde_path_for_shell_expansion(self):
         """Test that paths starting with ~ are converted to $HOME for shell expansion"""
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="~/data/torrents",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        scanner = self._make_scanner(remote_path="~/data/torrents")
 
-        self.ssh_run_command_count = 0
-
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # md5sum check
-                return b''
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                # diagnostics
+            b'',                # md5sum
+            pickle.dumps([]),   # scanfs
+        ])
 
         scanner.scan()
-        self.assertEqual(2, self.mock_ssh.shell.call_count)
+        self.assertEqual(3, self.mock_ssh.shell.call_count)
         # When scan path has tilde, both paths use double quotes for consistent quoting
         # Tilde is converted to $HOME for shell expansion
         self.mock_ssh.shell.assert_called_with(
@@ -321,32 +249,14 @@ class TestRemoteScanner(unittest.TestCase):
         )
 
     def test_raises_nonrecoverable_error_on_first_failed_ssh(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        """Non-transient errors on first run are non-recoverable (no retry)"""
+        scanner = self._make_scanner()
 
-        self.ssh_run_command_count = 0
-
-        # Ssh run command fails the first time
-        # noinspection PyUnusedLocal
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # md5sum check
-                return b''
-            elif self.ssh_run_command_count == 2:
-                # first try
-                raise SshcpError("an ssh error")
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                        # diagnostics
+            b'',                        # md5sum
+            SshcpError("an ssh error"), # scanfs fails (non-transient)
+        ])
 
         with self.assertRaises(ScannerError) as ctx:
             scanner.scan()
@@ -354,35 +264,18 @@ class TestRemoteScanner(unittest.TestCase):
         self.assertFalse(ctx.exception.recoverable)
 
     def test_raises_recoverable_error_on_subsequent_failed_ssh(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        """After first successful scan, errors are recoverable (after retries exhausted)"""
+        scanner = self._make_scanner()
 
-        self.ssh_run_command_count = 0
-
-        # Ssh run command succeeds first time, raises error the second time
-        # noinspection PyUnusedLocal
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # md5sum check
-                return b''
-            elif self.ssh_run_command_count == 2:
-                # first try
-                return pickle.dumps([])
-            elif self.ssh_run_command_count == 3:
-                # second try
-                raise SshcpError("an ssh error")
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                        # diagnostics
+            b'',                        # md5sum
+            pickle.dumps([]),           # first scanfs - success
+            # second scan: 3 retry attempts all fail
+            SshcpError("an ssh error"),
+            SshcpError("an ssh error"),
+            SshcpError("an ssh error"),
+        ])
 
         scanner.scan()  # no error first time
         with self.assertRaises(ScannerError) as ctx:
@@ -391,52 +284,28 @@ class TestRemoteScanner(unittest.TestCase):
         self.assertTrue(ctx.exception.recoverable)
 
     def test_recovers_from_failed_ssh(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        """After retries exhausted and recoverable error, next scan can succeed"""
+        scanner = self._make_scanner()
 
-        self.ssh_run_command_count = 0
-
-        # Ssh run command succeeds first time, raises error the second time, fine after that
-        # noinspection PyUnusedLocal
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # md5sum check
-                return b''
-            elif self.ssh_run_command_count == 2:
-                # first try
-                return pickle.dumps([])
-            elif self.ssh_run_command_count == 3:
-                # second try
-                raise SshcpError("an ssh error")
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                        # diagnostics
+            b'',                        # md5sum
+            pickle.dumps([]),           # first scanfs - success
+            # second scan: 3 retry attempts all fail
+            SshcpError("an ssh error"),
+            SshcpError("an ssh error"),
+            SshcpError("an ssh error"),
+            # third scan: success
+            pickle.dumps([]),
+        ])
 
         scanner.scan()  # no error first time
         with self.assertRaises(ScannerError):
             scanner.scan()
-        scanner.scan()
-        self.assertEqual(4, self.mock_ssh.shell.call_count)
+        scanner.scan()  # recovers
 
     def test_raises_nonrecoverable_error_on_failed_copy(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        scanner = self._make_scanner()
 
         # noinspection PyUnusedLocal
         def ssh_copy(*args, **kwargs):
@@ -449,15 +318,7 @@ class TestRemoteScanner(unittest.TestCase):
         self.assertFalse(ctx.exception.recoverable)
 
     def test_raises_nonrecoverable_error_on_mangled_output(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        scanner = self._make_scanner()
 
         def ssh_shell(*args):
             return "mangled data".encode()
@@ -469,15 +330,7 @@ class TestRemoteScanner(unittest.TestCase):
         self.assertFalse(ctx.exception.recoverable)
 
     def test_raises_nonrecoverable_error_on_shell_detection_failure(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        scanner = self._make_scanner()
 
         self.mock_ssh.detect_shell.side_effect = SshcpError(
             "Remote user's login shell not found. "
@@ -491,61 +344,32 @@ class TestRemoteScanner(unittest.TestCase):
         self.assertFalse(ctx.exception.recoverable)
 
     def test_calls_detect_shell_on_first_scan(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        scanner = self._make_scanner()
 
-        self.ssh_run_command_count = 0
-
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                return b''
-            else:
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                # diagnostics
+            b'',                # md5sum
+            pickle.dumps([]),   # scanfs
+            pickle.dumps([]),   # second scan: scanfs
+        ])
 
         scanner.scan()
         self.mock_ssh.detect_shell.assert_called_once()
 
-        # Second scan should not call detect_shell again (it's in _install_scanfs which only runs once)
+        # Second scan should not call detect_shell again
         self.mock_ssh.detect_shell.reset_mock()
         scanner.scan()
         self.mock_ssh.detect_shell.assert_not_called()
 
     def test_raises_nonrecoverable_error_on_failed_scan(self):
-        scanner = RemoteScanner(
-            remote_address="my remote address",
-            remote_username="my remote user",
-            remote_password="my password",
-            remote_port=1234,
-            remote_path_to_scan="/remote/path/to/scan",
-            local_path_to_scan_script=TestRemoteScanner.temp_scan_script,
-            remote_path_to_scan_script="/remote/path/to/scan/script"
-        )
+        """SystemScannerError is always non-recoverable, even with retries"""
+        scanner = self._make_scanner()
 
-        self.ssh_run_command_count = 0
-
-        # Ssh run command raises error the first time, succeeds the second time
-        # noinspection PyUnusedLocal
-        def ssh_shell(*args):
-            self.ssh_run_command_count += 1
-            if self.ssh_run_command_count == 1:
-                # md5sum check
-                return b''
-            elif self.ssh_run_command_count == 2:
-                # first try
-                raise SshcpError("SystemScannerError: something failed")
-            else:
-                # later tries
-                return pickle.dumps([])
-        self.mock_ssh.shell.side_effect = ssh_shell
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                                                    # diagnostics
+            b'',                                                    # md5sum
+            SshcpError("SystemScannerError: something failed"),    # scanfs - no retry
+        ])
 
         with self.assertRaises(ScannerError) as ctx:
             scanner.scan()
@@ -554,3 +378,50 @@ class TestRemoteScanner(unittest.TestCase):
             str(ctx.exception)
         )
         self.assertFalse(ctx.exception.recoverable)
+
+    def test_retries_transient_errors_on_first_run(self):
+        """Transient errors (timeouts) are retried even on first run"""
+        scanner = self._make_scanner()
+
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                                # diagnostics
+            b'',                                # md5sum
+            SshcpError("Timed out after 180s"), # scanfs attempt 1 - transient
+            pickle.dumps([]),                   # scanfs attempt 2 - success
+        ])
+
+        scanner.scan()  # should succeed after retry
+        self.mock_sleep.assert_called_once()
+
+    def test_retries_up_to_max_attempts(self):
+        """After max retries exhausted, raises recoverable error"""
+        scanner = self._make_scanner()
+
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                                # diagnostics
+            b'',                                # md5sum
+            SshcpError("Timed out after 180s"), # attempt 1
+            SshcpError("Timed out after 180s"), # attempt 2
+            SshcpError("Timed out after 180s"), # attempt 3
+        ])
+
+        with self.assertRaises(ScannerError) as ctx:
+            scanner.scan()
+        self.assertTrue(ctx.exception.recoverable)
+        # Should have slept between attempts (max_retries - 1 times)
+        self.assertEqual(2, self.mock_sleep.call_count)
+
+    def test_no_retry_on_non_transient_first_run_error(self):
+        """Non-transient errors on first run fail immediately without retry"""
+        scanner = self._make_scanner()
+
+        self.mock_ssh.shell.side_effect = self._make_shell_side_effect([
+            b'',                                    # diagnostics
+            b'',                                    # md5sum
+            SshcpError("Incorrect password"),       # scanfs - non-transient
+        ])
+
+        with self.assertRaises(ScannerError) as ctx:
+            scanner.scan()
+        self.assertFalse(ctx.exception.recoverable)
+        self.mock_sleep.assert_not_called()


### PR DESCRIPTION
## Summary

- **Fix pexpect process leak** — `sp.close()` was never called on timeout, leaking orphaned SSH processes. Moved to `finally` block so cleanup always runs. This is likely the root cause of issue #61 (leaked connections from shell detection interfering with subsequent scanfs calls).
- **Add retry logic** — Transient scan errors (timeouts, lost connections) now retry up to 3 times with 5s delay instead of immediately crashing the app.
- **Make timeouts recoverable** — Timeouts on first run no longer kill the entire app. Only non-transient config errors (bad password, bad hostname) are non-recoverable on first run.
- **Add SSH keepalive/timeout options** — `ConnectTimeout=30`, `ServerAliveInterval=15`, `ServerAliveCountMax=3` to detect dead connections within ~45s instead of waiting the full 180s timeout.
- **Improve timeout error messages** — Now includes elapsed time and the command that timed out.
- **Fix pre-existing test gaps** — Mocks weren't accounting for the `_log_remote_diagnostics()` shell call; added 3 new tests for retry behavior.

Closes #61

## Test plan

- [x] All 20 remote_scanner unit tests pass (including 3 new tests)
- [ ] Verify with Docker build that container starts correctly
- [ ] Test with a remote seedbox that has intermittent connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)