### PR TITLE
Fix LFTP parser crash on long file paths

### DIFF
--- a/src/python/lftp/lftp.py
+++ b/src/python/lftp/lftp.py
@@ -89,6 +89,10 @@ class Lftp:
             "sftp://{}".format(self.__address)
         ]
         self.__process = pexpect.spawn("/usr/bin/lftp", args)
+        # Set a very wide terminal to prevent LFTP from wrapping long lines
+        # in 'jobs -v' output. The default 80-column pty causes paths to wrap
+        # mid-word, producing fragments the parser can't handle.
+        self.__process.setwinsize(24, 10000)
         self.__process.expect(self.__expect_pattern)
         self.__setup()
 


### PR DESCRIPTION
## Summary
- **Fix pexpect terminal width** — The default 80-column pty caused LFTP's `jobs -v` output to wrap long file paths mid-word (e.g., `~/downloads/completed/Terminator.2.Judgment.Day...` split across lines). The parser saw the continuation fragment as an unparseable line, and after 3 consecutive `LftpJobStatusParserError` failures the application crashed.
- **Root cause fix** — Set `setwinsize(24, 10000)` on the pexpect process immediately after spawn, preventing LFTP from ever wrapping its output.
- **Regression test** — Added `test_long_path_single_line` verifying the parser handles the exact long-path pattern that caused the production crash.

## Test plan
- [x] All 46 parser tests pass (`test_job_status_parser.py`)
- [x] All 50 model builder tests pass (`test_model_builder.py`)
- [ ] Deploy and verify no crashes during active downloads with long filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)