### PR TITLE
Implement post-download pipeline for extract/delete-remote ordering

### DIFF
--- a/src/python/controller/extract/__init__.py
+++ b/src/python/controller/extract/__init__.py
@@ -2,4 +2,4 @@
 
 from .extract import Extract, ExtractError
 from .dispatch import ExtractDispatch, ExtractDispatchError, ExtractListener, ExtractStatus
-from .extract_process import ExtractProcess, ExtractStatusResult, ExtractCompletedResult
+from .extract_process import ExtractProcess, ExtractStatusResult, ExtractCompletedResult, ExtractFailedResult


### PR DESCRIPTION
## Summary

- **Gate auto-delete-remote on extraction** — When `auto_extract` is ON, delete-remote is blocked for extractable DOWNLOADED files and only fires after EXTRACTED. Non-extractable files delete immediately on DOWNLOADED.
- **Extraction failure retry** — Failures are surfaced via `ExtractFailedResult` queue. Controller retries up to 3 times by cleaning persist, deleting local, and letting auto-queue re-download.
- **Delete-remote retry sweep** — Periodically re-sends DELETE_REMOTE (every 20 cycles) for DELETED files where the remote copy still exists.
- **Persist authority gated on config** — When `auto_delete_remote` is ON and remote still exists, persist is skipped so files stay DEFAULT and can be re-downloaded. Partial files (local < remote) always stay DEFAULT regardless of persist.
- **Persist cleanup** — Clears persist entries on re-queue (QUEUED/DOWNLOADING) and when files disappear from all sources (remote, local, LFTP).

## Files Changed

| File | Changes |
|------|---------|
| `model_builder.py` | `auto_delete_remote` field/setter, unified persist logic with partial detection |
| `auto_queue.py` | Delete-remote gating for extractable files, retry sweep for DELETED files |
| `controller.py` | Config propagation, persist cleanup on re-queue/both-absent, extraction retry |
| `extract_process.py` | `ExtractFailedResult` class, failure queue, `pop_failed()` method |
| `extract/__init__.py` | Export `ExtractFailedResult` |
| `test_model_builder.py` | Updated partial detection test + 7 new `auto_delete_remote` cases |
| `test_auto_queue.py` | 6 new tests for delete-remote gating and retry |

## Test plan

- [x] 108 targeted tests pass (`test_model_builder.py` + `test_auto_queue.py`)
- [x] Full controller test suite: 161 passed, 9 pre-existing failures (multiprocessing pickling in `test_extract_process`/`test_scanner_process` — unrelated)
- [ ] Manual testing with Docker container across staging/extract/delete-remote combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)