### PR TITLE
Fix persist cleanup during in-flight staging moves

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -508,11 +508,13 @@ class Controller:
             # Persist cleanup: remove entries for files absent from all sources
             # When both remote and local copies are gone, clear persist so the file vanishes.
             # If re-uploaded to seedbox later, it's treated as brand new.
+            # Exclude files with in-flight moves (staging → local) since the local scanner
+            # hasn't picked them up at the final path yet.
             if self.__remote_scan_received and self.__local_scan_received:
                 absent_names = set()
                 model_file_names = self.__model.get_file_names()
                 for name in self.__persist.downloaded_file_names:
-                    if name not in model_file_names:
+                    if name not in model_file_names and name not in self.__moved_file_names:
                         absent_names.add(name)
                 if absent_names:
                     self.logger.info("Persist cleanup (both absent): {}".format(absent_names))


### PR DESCRIPTION
## Summary

- **Fix premature persist cleanup** — During cross-device moves from staging to local (which can take 40+ seconds for large files), the "both absent" persist cleanup was firing because the file was invisible to the local scanner at the final path. This cleared the DOWNLOADED persist entry, causing the file to lose its state.

## Root Cause

The persist cleanup (Change 5 from PR #70) checks if a file is absent from all model sources (remote, LFTP, local). During a staging move:
1. Remote is deleted (auto-delete-remote)
2. LFTP job finishes (removed from LFTP model)
3. Local scanner can't see the file yet (still being copied to final path)
4. Cleanup fires prematurely

## Fix

Exclude files in `__moved_file_names` from the "both absent" check. This set tracks files with spawned move processes, so they won't be prematurely cleaned up while the move is in flight.

## Test plan

- [x] 108 targeted tests pass (test_model_builder + test_auto_queue)
- [ ] Manual verification with staging + auto-delete-remote on large file

🤖 Generated with [Claude Code](https://claude.com/claude-code)