### PR TITLE
Fix extraction timing and re-download retry for staging pipeline

### DIFF
--- a/src/python/controller/extract/dispatch.py
+++ b/src/python/controller/extract/dispatch.py
@@ -177,6 +177,8 @@ class ExtractDispatch:
                             completed = False
                             break
 
+                        self.logger.debug("Verifying {}".format(archive_path))
+                        Extract.verify_archive(archive_path)
                         self.logger.debug("Extracting {}".format(archive_path))
                         Extract.extract_archive(
                             archive_path=archive_path,


### PR DESCRIPTION
## Summary

- **Post-download pipeline** — Implements correct extract/delete-remote ordering when staging is enabled, with persist cleanup for in-flight staging moves (#70)
- **Archive verification** — Adds lightweight pre-extraction check (magic bytes + tail readability) to catch truncated files from incomplete Docker volume flushes
- **Re-download retry fix** — Explicitly queues re-download when a file returns to DEFAULT after extraction failure, instead of relying on auto-queue (which ignores unchanged `remote_size`)
- **Pending completion tracking fix** — With staging enabled, keeps files in `pending_completion` until moved to final location so ActiveScanner doesn't lose track during extraction/move phase

## Test plan

- [ ] Run existing unit tests: `cd src/python && python3 -m pytest tests/`
- [ ] Build Docker image and run with staging enabled
- [ ] Queue an extractable file and verify no "has extract status but doesn't exist locally" warning
- [ ] Simulate a truncated archive and verify verification catches it and re-download triggers
- [ ] Verify non-extractable files still move correctly from staging to local

🤖 Generated with [Claude Code](https://claude.com/claude-code)