### PR TITLE
Fix extract retry loop and staging delete

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -671,7 +671,7 @@ class Controller:
                         file_name=file.name
                     )
                     process.set_multiprocessing_logger(self.__mp_logger)
-                    def post_callback():
+                    def post_callback(delete_path=delete_path):
                         self.__local_scan_process.force_scan()
                         if delete_path != self.__context.config.lftp.local_path:
                             self.__active_scan_process.force_scan()


### PR DESCRIPTION
## Summary
- **Fix infinite extract retry loop** — Remove `extract_retry_counts.pop()` from the re-queue cleanup block (`controller.py:453`) that was resetting the retry counter on every re-download cycle, preventing files from ever reaching EXTRACT_FAILED state
- **Fix Delete Local for staged files** — Check staging path before local_path in the DELETE_LOCAL command so files still in the staging directory can be deleted correctly; also trigger active scan after staging delete
- **Fix late-binding closure bug** — Bind `delete_path` as a default argument in `post_callback` so each callback captures the correct value when multiple DELETE_LOCAL commands are queued in the same batch

## Test plan
- [ ] Run Python unit tests: `cd src/python && python3 -m pytest tests/unittests/ --ignore=tests/unittests/test_common/test_app_process.py -q`
- [ ] Build Docker image and test with a corrupt archive:
  - Extraction should fail 3 times then show EXTRACT_FAILED (red icon)
  - Delete Local should work when file is in staging path


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion so files residing in staging are removed from the correct location.
  * Added immediate local re-scan after deletions and an extra active scan when a staged file is removed to ensure the system reflects file state changes promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->