### PR TITLE
Replace unrar-free with full unrar for RAR5 support

### DIFF
--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -52,13 +52,16 @@ LABEL maintainer="nitrobass24" \
       description="SeedSync - Seedbox file synchronization tool" \
       version="0.9.0"
 
+# Enable non-free repo for full unrar (unrar-free only supports RAR1-3)
+RUN sed -i 's/Components: main/Components: main non-free/' /etc/apt/sources.list.d/debian.sources
+
 # Install only essential runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     lftp \
     openssh-client \
     p7zip \
     p7zip-full \
-    unrar-free \
+    unrar \
     gosu \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean


### PR DESCRIPTION
## Summary
- **Root cause**: Docker image installs `unrar-free` which only supports legacy RAR1-3 formats. Modern RAR archives use RAR5 format (standard since WinRAR 5.0+), causing `unrar-free` to fail with exit status 1
- **Fix**: Enable Debian's `non-free` repository and install RARLAB's full `unrar` (v6.21) which supports all RAR formats including RAR5
- **Verified**: Docker image builds successfully, `patoolib` correctly finds `/usr/bin/unrar`, version confirmed as UNRAR 6.21

Closes #84

## Test plan
- [ ] Build Docker image and verify `unrar` version is 6.21 (RARLAB)
- [ ] Test extraction of a RAR5 multi-part archive series inside container
- [ ] Verify `patoolib.find_archive_program('rar', 'extract')` returns `/usr/bin/unrar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies to improve archive extraction support. The Docker build configuration now enables access to additional packages for enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->