### PR TITLE
Parallelize CI builds and add Angular unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,30 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-test:
-    name: Build and Test
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: src/angular/package-lock.json
+
+      - name: Install dependencies
+        working-directory: src/angular
+        run: npm ci
+
+      - name: Run tests
+        working-directory: src/angular
+        run: npx ng test
+
+  build:
+    name: Build and Test (amd64)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,11 +51,12 @@ jobs:
         with:
           context: .
           file: src/docker/build/docker-image/Dockerfile
+          platforms: linux/amd64
           push: false
           load: true
           tags: seedsync:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,scope=amd64,mode=max
 
       - name: Test container starts
         run: |
@@ -43,20 +66,113 @@ jobs:
           docker logs test-container
           docker stop test-container
 
-  publish:
-    name: Publish Docker Image
+      - name: Log in to GitHub Container Registry
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push amd64 image by digest
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop'
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: src/docker/build/docker-image/Dockerfile
+          platforms: linux/amd64
+          push: true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
+          cache-from: type=gha,scope=amd64
+          provenance: false
+          sbom: false
+
+      - name: Export digest
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.push.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-amd64
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-arm64:
+    name: Build (arm64)
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop'
-    needs: [build-and-test]
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push arm64 image by digest
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: src/docker/build/docker-image/Dockerfile
+          platforms: linux/arm64
+          push: true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,scope=arm64,mode=max
+          provenance: false
+          sbom: false
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.push.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-arm64
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish Docker Image
+    if: always() && !cancelled() && needs.unit-test.result == 'success' && needs.build.result == 'success' && needs.build-arm64.result == 'success'
+    needs: [unit-test, build, build-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download amd64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-amd64
+          path: /tmp/digests
+
+      - name: Download arm64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-arm64
+          path: /tmp/digests
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -79,19 +195,12 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: src/docker/build/docker-image/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: false
-          sbom: false
+      - name: Create multi-arch manifest and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
   release:
     name: Create Release


### PR DESCRIPTION
## Summary
- Split the sequential multi-arch Docker build into parallel amd64 + arm64 jobs using digest-based push and manifest merging
- Add a dedicated `unit-test` job that runs the 132 Angular Vitest tests in CI for the first time
- On PRs, only `unit-test` and `build` (amd64) run; arm64/publish/release are skipped

## Test plan
- [ ] Push to a PR branch — verify `unit-test` and `build` run in parallel, `build-arm64`/`publish`/`release` are skipped
- [ ] Push to `develop` — verify all three build jobs run in parallel, `publish` creates the manifest
- [ ] Push a tag — verify full pipeline including `release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline with explicit multi-architecture support for amd64 and arm64 platforms
  * Reorganized unit testing and build workflows for enhanced release consistency and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->