### PR TITLE
Mask SSH password in debug log output

### DIFF
--- a/src/python/common/context.py
+++ b/src/python/common/context.py
@@ -62,6 +62,8 @@ class Context:
         for section in config_dict.keys():
             for option in config_dict[section].keys():
                 value = config_dict[section][option]
+                if option == "remote_password":
+                    value = "********" if value else ""
                 self.logger.debug("  {}.{}: {}".format(section, option, value))
 
         self.logger.debug("Args:")


### PR DESCRIPTION
## Summary
- Mask `Lftp.remote_password` in the debug config dump so it displays `********` instead of the plaintext password

Fixes #97

## Test plan
- [ ] Enable debug mode, restart container, verify password shows as `********` in `docker logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)