### PR TITLE
fix: apply UMASK env var via os.umask() at Python startup

### DIFF
--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -409,7 +409,7 @@ if __name__ == "__main__":
         try:
             os.umask(int(_umask_str, 8))
         except ValueError:
-            print("WARNING: Invalid UMASK value {!r}, ignoring".format(_umask_str), file=sys.stderr)
+            print(f"WARNING: Invalid UMASK value {_umask_str!r}, ignoring", file=sys.stderr)
 
     while True:
         try:


### PR DESCRIPTION
## Summary

- The shell `umask` set in `entrypoint.sh` is not reliably inherited by the `lftp` subprocess through the `setpriv` exec chain in all container environments
- Downloaded files were created with the system default umask (`0002` → `0664`) instead of the user-configured value
- Fix reads `UMASK` env var directly in Python and calls `os.umask()` at startup, before pexpect spawns lftp

Fixes #109

## Test plan

- [ ] Set `UMASK=000` in Docker environment variables
- [ ] Queue a file for download
- [ ] Verify downloaded files have `0666` permissions (rw-rw-rw-) instead of `0664`
- [ ] Verify downloaded directories have `0777` permissions
- [ ] Verify that omitting `UMASK` (empty string, the default) leaves system umask unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring process umask via an environment variable; the value is applied at startup and a warning is emitted for invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->