### PR TITLE
hotfix: UMASK diagnostic logging (v0.12.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.12.9] - 2026-03-02
+
+### Changed
+
+- **UMASK diagnostic logging** — Log the applied umask and previous value at startup to help diagnose permission issues (#109)
+
+---
+
 ## [0.12.8] - 2026-03-02
 
 ### Fixed

--- a/src/angular/package.json
+++ b/src/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedsync",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -407,7 +407,8 @@ if __name__ == "__main__":
     _umask_str = os.environ.get('UMASK', '').strip()
     if _umask_str:
         try:
-            os.umask(int(_umask_str, 8))
+            _prev_umask = os.umask(int(_umask_str, 8))
+            print(f"Applied umask {_umask_str} (previous: {_prev_umask:04o})", file=sys.stderr)
         except ValueError:
             print(f"WARNING: Invalid UMASK value {_umask_str!r}, ignoring", file=sys.stderr)
 


### PR DESCRIPTION
## Summary

- Adds a log line showing the applied umask and what the previous value was, e.g. `Applied umask 000 (previous: 0022)`
- This helps diagnose #109 where `UMASK=000` is still producing `0664` files despite the fix in v0.12.7 — without this log we can't tell if the Python `os.umask()` call is executing or what umask the process had before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Added diagnostic logging for UMASK configuration, displaying both the applied value and previous setting at startup.

* **Chores**
  * Version bump to 0.12.9

<!-- end of auto-generated comment: release notes by coderabbit.ai -->