### PR TITLE
fix: disable sftp permission preservation to respect UMASK (#109)

### DIFF
--- a/src/python/lftp/lftp.py
+++ b/src/python/lftp/lftp.py
@@ -44,6 +44,7 @@ class Lftp:
     __SET_TEMP_FILE_NAME = "xfer:temp-file-name"
     __SET_SFTP_AUTO_CONFIRM = "sftp:auto-confirm"
     __SET_SFTP_CONNECT_PROGRAM = "sftp:connect-program"
+    __SET_SFTP_SET_PERMISSIONS = "sftp:set-permissions"
     __SET_NET_SOCKET_BUFFER = "net:socket-buffer"
     __SET_MIRROR_PARALLEL_DIRECTORIES = "mirror:parallel-directories"
     __SET_NET_TIMEOUT = "net:timeout"
@@ -119,6 +120,10 @@ class Lftp:
         self.__set(Lftp.__SET_COMMAND_AT_EXIT, "\"kill all\"")
         # Auto-add server to known host file
         self.sftp_auto_confirm = True
+        # Do not copy remote file permissions — let the local umask determine
+        # the permissions of downloaded files instead of preserving the seedbox's
+        # permission bits (e.g. 664 → remote) which would override our umask setting
+        self.__set(Lftp.__SET_SFTP_SET_PERMISSIONS, "false")
 
     def with_check_process(method: Callable):
         """


### PR DESCRIPTION
## Root Cause

lftp's sftp backend by default copies the **remote file's permission bits** to the locally downloaded file. This is correct behaviour for sftp (preserving the original permissions), but it overrides the local process umask entirely.

In quadcom's logs from issue #109:
- `Applied umask 000 (previous: 0000)` — the umask IS being propagated correctly
- Downloaded files still arrive as `664` — because the seedbox's remote permissions are `664` and lftp stamps those onto the local file

The `.partial` temp file was `666` (written by root, umask=0, no sftp involvement) but the final lftp-downloaded file ends up `664` because lftp uses sftp's `SSH_FXP_SETSTAT` to apply remote permissions.

## Fix

Set `sftp:set-permissions false` in lftp's startup configuration:

```
set sftp:set-permissions false
```

This tells lftp **not** to copy remote permission bits, so the local process umask determines the final file permissions:
- `UMASK=000` → files `666`, dirs `777`  
- `UMASK=002` → files `664`, dirs `775` (default-ish)
- `UMASK=022` → files `644`, dirs `755`

The setting is also written to `__settings_cache` so it is replayed automatically when the lftp process restarts.

## Test Plan

- [ ] Set `UMASK=000` in docker-compose, download a file, verify it lands as `666`
- [ ] Set `UMASK=002`, verify `664`
- [ ] Verify normal download still works (no regression)
- [ ] Close issue #109 once confirmed by reporter

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SFTP file transfers now use local umask settings instead of copying remote file permissions, ensuring consistent permission handling across systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->