### PR TITLE
feat: add ignore/exclude patterns for syncing (#26)

### DIFF
--- a/src/angular/src/app/models/config.ts
+++ b/src/angular/src/app/models/config.ts
@@ -5,6 +5,7 @@
 
 export interface General {
   debug: boolean | null;
+  exclude_patterns: string | null;
 }
 
 export interface Lftp {
@@ -78,6 +79,7 @@ export interface Config {
 
 export const DEFAULT_GENERAL: General = {
   debug: null,
+  exclude_patterns: null,
 };
 
 export const DEFAULT_LFTP: Lftp = {

--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -74,6 +74,14 @@ export const OPTIONS_CONTEXT_DISCOVERY: IOptionsContext = {
   options: [
     {
       type: OptionType.Text,
+      label: 'Exclude Patterns',
+      valuePath: ['general', 'exclude_patterns'],
+      description:
+        'Comma-separated glob patterns for files to ignore (e.g. ".*,*.nfo,*.txt"). ' +
+        'Matching remote files will be hidden and never synced.',
+    },
+    {
+      type: OptionType.Text,
       label: 'Remote Scan Interval (ms)',
       valuePath: ['controller', 'interval_ms_remote_scan'],
       description: 'How often the remote server is scanned for new files',

--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -237,11 +237,13 @@ class Config(Persist):
     class General(IC):
         debug = PROP("debug", Checkers.null, Converters.bool)
         verbose = PROP("verbose", Checkers.null, Converters.bool)
+        exclude_patterns = PROP("exclude_patterns", Checkers.string_allow_empty, Converters.null)
 
         def __init__(self):
             super().__init__()
             self.debug = None
             self.verbose = None
+            self.exclude_patterns = ""
 
     class Lftp(IC):
         remote_address = PROP("remote_address", Checkers.string_nonempty, Converters.null)

--- a/src/python/controller/__init__.py
+++ b/src/python/controller/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
-from .controller import Controller
+from .controller import Controller, filter_excluded_files
 from .controller_job import ControllerJob
 from .controller_persist import ControllerPersist
 from .model_builder import ModelBuilder

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -1,6 +1,7 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
 import os
+import fnmatch
 from abc import ABC, abstractmethod
 from typing import Dict, List, Callable, Set
 from threading import Lock
@@ -18,6 +19,16 @@ from lftp import Lftp, LftpError, LftpJobStatus
 from .controller_persist import ControllerPersist
 from .delete import DeleteLocalProcess, DeleteRemoteProcess
 from .move import MoveProcess
+
+
+def filter_excluded_files(files: List, exclude_patterns_str: str) -> List:
+    if not exclude_patterns_str or not exclude_patterns_str.strip():
+        return files
+    patterns = [p.strip() for p in exclude_patterns_str.split(",") if p.strip()]
+    if not patterns:
+        return files
+    return [f for f in files
+            if not any(fnmatch.fnmatch(f.name.lower(), p.lower()) for p in patterns)]
 
 
 class ControllerError(AppError):
@@ -415,7 +426,8 @@ class Controller:
 
         # Update model builder state
         if latest_remote_scan is not None:
-            self.__model_builder.set_remote_files(latest_remote_scan.files)
+            remote_files = self._apply_exclude_patterns(latest_remote_scan.files)
+            self.__model_builder.set_remote_files(remote_files)
         if latest_local_scan is not None:
             self.__model_builder.set_local_files(latest_local_scan.files)
         if latest_active_scan is not None:
@@ -819,3 +831,7 @@ class Controller:
                 # Force a local scan so the moved file is detected in its final location
                 self.__local_scan_process.force_scan()
         self.__active_move_processes = still_active_moves
+
+    def _apply_exclude_patterns(self, files: List) -> List:
+        raw = self.__context.config.general.exclude_patterns
+        return filter_excluded_files(files, raw)

--- a/src/python/tests/unittests/test_common/test_config.py
+++ b/src/python/tests/unittests/test_common/test_config.py
@@ -534,6 +534,7 @@ class TestConfig(unittest.TestCase):
         [General]
         debug = True
         verbose = False
+        exclude_patterns =
 
         [Lftp]
         remote_address = server.remote.com
@@ -570,12 +571,23 @@ class TestConfig(unittest.TestCase):
 
         [Web]
         port = 13
+        api_key =
 
         [AutoQueue]
         enabled = True
         patterns_only = True
         auto_extract = False
         auto_delete_remote = True
+
+        [Logging]
+        log_format = standard
+
+        [Notifications]
+        webhook_url =
+        notify_on_download_complete = True
+        notify_on_extraction_complete = True
+        notify_on_extraction_failed = True
+        notify_on_delete_complete = True
         """
 
         golden_lines = [s.strip() for s in golden_str.splitlines()]

--- a/src/python/tests/unittests/test_controller/test_exclude_patterns.py
+++ b/src/python/tests/unittests/test_controller/test_exclude_patterns.py
@@ -1,0 +1,88 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import unittest
+
+from system import SystemFile
+from controller import filter_excluded_files
+
+
+class TestFilterExcludedFiles(unittest.TestCase):
+    def test_empty_pattern_returns_all(self):
+        files = [SystemFile("a.txt", 10, False), SystemFile("b.nfo", 20, False)]
+        result = filter_excluded_files(files, "")
+        self.assertEqual(["a.txt", "b.nfo"], [f.name for f in result])
+
+    def test_none_pattern_returns_all(self):
+        files = [SystemFile("a.txt", 10, False)]
+        result = filter_excluded_files(files, None)
+        self.assertEqual(["a.txt"], [f.name for f in result])
+
+    def test_single_pattern(self):
+        files = [
+            SystemFile("movie.mkv", 100, False),
+            SystemFile("info.nfo", 10, False),
+            SystemFile("readme.txt", 5, False),
+        ]
+        result = filter_excluded_files(files, "*.nfo")
+        self.assertEqual(["movie.mkv", "readme.txt"], [f.name for f in result])
+
+    def test_multiple_patterns(self):
+        files = [
+            SystemFile("movie.mkv", 100, False),
+            SystemFile("info.nfo", 10, False),
+            SystemFile("readme.txt", 5, False),
+            SystemFile("sub.srt", 15, False),
+        ]
+        result = filter_excluded_files(files, "*.nfo,*.txt")
+        self.assertEqual(["movie.mkv", "sub.srt"], [f.name for f in result])
+
+    def test_dotfile_pattern(self):
+        files = [
+            SystemFile(".hidden", 10, False),
+            SystemFile("visible", 20, False),
+            SystemFile(".config", 5, False),
+        ]
+        result = filter_excluded_files(files, ".*")
+        self.assertEqual(["visible"], [f.name for f in result])
+
+    def test_case_insensitive(self):
+        files = [
+            SystemFile("INFO.NFO", 10, False),
+            SystemFile("movie.mkv", 100, False),
+        ]
+        result = filter_excluded_files(files, "*.nfo")
+        self.assertEqual(["movie.mkv"], [f.name for f in result])
+
+    def test_whitespace_in_patterns(self):
+        files = [
+            SystemFile("info.nfo", 10, False),
+            SystemFile("readme.txt", 5, False),
+            SystemFile("movie.mkv", 100, False),
+        ]
+        result = filter_excluded_files(files, " *.nfo , *.txt ")
+        self.assertEqual(["movie.mkv"], [f.name for f in result])
+
+    def test_directories_can_be_excluded(self):
+        files = [
+            SystemFile("Sample", 50, True),
+            SystemFile("movie.mkv", 100, False),
+        ]
+        result = filter_excluded_files(files, "Sample")
+        self.assertEqual(["movie.mkv"], [f.name for f in result])
+
+    def test_wildcard_pattern(self):
+        files = [
+            SystemFile("sample_video", 50, True),
+            SystemFile("movie.mkv", 100, False),
+        ]
+        result = filter_excluded_files(files, "sample*")
+        self.assertEqual(["movie.mkv"], [f.name for f in result])
+
+    def test_no_files_returns_empty(self):
+        result = filter_excluded_files([], "*.nfo")
+        self.assertEqual([], result)
+
+    def test_whitespace_only_pattern_returns_all(self):
+        files = [SystemFile("a.txt", 10, False)]
+        result = filter_excluded_files(files, "  ,  , ")
+        self.assertEqual(["a.txt"], [f.name for f in result])


### PR DESCRIPTION
## Summary

- Add configurable `exclude_patterns` setting (comma-separated glob patterns) to `Config.General`
- Remote files matching any pattern are filtered out before entering the model — they are hidden from the UI and never synced
- New Settings UI field in the **File Discovery** section with description explaining the syntax
- Pattern matching is case-insensitive and uses Python's `fnmatch` (supports `*`, `?`, `[seq]`, `[!seq]`)

### Usage Examples

| Pattern | Effect |
|---------|--------|
| `.*` | Ignore dotfiles (`.DS_Store`, `.nfo`, etc.) |
| `*.nfo,*.txt` | Ignore `.nfo` and `.txt` files |
| `Sample` | Ignore directories/files named "Sample" |
| `sample*,*.nfo,*.txt` | Combine multiple patterns |

## Test plan

- [x] 11 unit tests for `filter_excluded_files()` covering: empty/None patterns, single/multiple patterns, case insensitivity, dotfiles, directories, wildcards, whitespace handling
- [x] All 25 existing config tests pass (including fixed `test_to_file` golden string)
- [x] All 138 Angular tests pass

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exclude patterns configuration allowing users to specify comma-separated glob patterns
  * Matching files are automatically filtered and excluded from scanning results
  * Settings UI now displays the exclude patterns field for easy configuration

* **Tests**
  * Comprehensive unit tests added covering pattern matching and filtering scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->