### PR TITLE
feat: inline double-click delete confirmation (#110)

### DIFF
--- a/src/angular/src/app/pages/files/file.component.html
+++ b/src/angular/src/app/pages/files/file.component.html
@@ -145,32 +145,20 @@
         <div class="button" appClickStopPropagation
              [attr.disabled]="isLocallyDeletable() ? null : true"
              (click)="!isLocallyDeletable() || onDeleteLocal(file())"
-             [class.loading]="activeAction === FileAction.DELETE_LOCAL">
+             [class.loading]="activeAction === FileAction.DELETE_LOCAL"
+             [class.confirming]="confirmingDelete === 'local'">
             <div class="loader"></div>
             <img src="assets/icons/delete-local.svg" />
-            <div class="text"><span>Delete Local</span></div>
+            <div class="text"><span>{{ confirmingDelete === 'local' ? 'Confirm?' : 'Delete Local' }}</span></div>
         </div>
         <div class="button" appClickStopPropagation
              [attr.disabled]="isRemotelyDeletable() ? null : true"
              (click)="!isRemotelyDeletable() || onDeleteRemote(file())"
-             [class.loading]="activeAction === FileAction.DELETE_REMOTE">
+             [class.loading]="activeAction === FileAction.DELETE_REMOTE"
+             [class.confirming]="confirmingDelete === 'remote'">
             <div class="loader"></div>
             <img src="assets/icons/delete-remote.svg" />
-            <div class="text"><span>Delete Remote</span></div>
+            <div class="text"><span>{{ confirmingDelete === 'remote' ? 'Confirm?' : 'Delete Remote' }}</span></div>
         </div>
     </div>
-
-    <!-- Delete confirmation dialog -->
-    @if (deleteConfirmationType) {
-        <div class="delete-confirmation" appClickStopPropagation>
-            <div class="confirmation-content">
-                <div class="confirmation-title">{{deleteConfirmationTitle}}</div>
-                <div class="confirmation-message" [innerHTML]="deleteConfirmationMessage"></div>
-                <div class="confirmation-buttons">
-                    <button class="btn btn-secondary" (click)="cancelDelete()">Cancel</button>
-                    <button class="btn btn-danger" (click)="confirmDelete()">Delete</button>
-                </div>
-            </div>
-        </div>
-    }
 </div>

--- a/src/angular/src/app/pages/files/file.component.scss
+++ b/src/angular/src/app/pages/files/file.component.scss
@@ -198,6 +198,13 @@
             display: block;
         }
     }
+
+    // Confirm state for delete buttons (first click)
+    &.confirming {
+        opacity: 1.0;
+        background-color: var(--bs-danger, #dc3545);
+        border-color: var(--bs-danger, #dc3545);
+    }
 }
 
 /* action toolbar show and hide */
@@ -206,37 +213,6 @@
 }
 .file.selected .actions {
     display: flex;
-}
-
-/* Delete confirmation dialog */
-.delete-confirmation {
-    background-color: var(--ss-overlay);
-    padding: 15px;
-    margin-top: 10px;
-    border-radius: 4px;
-
-    .confirmation-content {
-        background-color: var(--ss-confirmation-bg);
-        padding: 20px;
-        border-radius: 4px;
-
-        .confirmation-title {
-            font-weight: bold;
-            font-size: 16px;
-            margin-bottom: 10px;
-        }
-
-        .confirmation-message {
-            margin-bottom: 15px;
-        }
-
-        .confirmation-buttons {
-            display: flex;
-            flex-direction: row;
-            justify-content: flex-end;
-            gap: 10px;
-        }
-    }
 }
 
 
@@ -396,8 +372,9 @@
         }
     }
 
-    // ── Delete confirmation ──
-    .delete-confirmation .confirmation-content {
-        border: 1px solid #252C37;
+    // ── Delete confirm button ──
+    .actions .button.confirming {
+        background-color: #C0392B;
+        border-color: #A93226;
     }
 }

--- a/src/angular/src/app/pages/files/file.component.spec.ts
+++ b/src/angular/src/app/pages/files/file.component.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { SimpleChange } from '@angular/core';
 import { FileComponent, FileAction } from './file.component';
@@ -118,5 +118,91 @@ describe('FileComponent.ngOnChanges', () => {
     });
 
     expect(component.activeAction).toBe(FileAction.QUEUE);
+  });
+});
+
+describe('FileComponent inline delete confirmation', () => {
+  let fixture: ComponentFixture<FileComponent>;
+  let component: FileComponent;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+
+    await TestBed.configureTestingModule({
+      imports: [FileComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FileComponent);
+    fixture.componentRef.setInput('file', makeViewFile());
+    fixture.componentRef.setInput('options', of({ nameFilter: '', statusFilter: '' }));
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('first click on delete local sets confirming state', () => {
+    component.onDeleteLocal(makeViewFile());
+    expect(component.confirmingDelete).toBe('local');
+    expect(component.activeAction).toBeNull();
+  });
+
+  it('second click on delete local emits event and clears state', () => {
+    const file = makeViewFile();
+    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+
+    component.onDeleteLocal(file);
+    expect(component.confirmingDelete).toBe('local');
+
+    component.onDeleteLocal(file);
+    expect(component.confirmingDelete).toBeNull();
+    expect(component.activeAction).toBe(FileAction.DELETE_LOCAL);
+    expect(spy).toHaveBeenCalledWith(file);
+  });
+
+  it('first click on delete remote sets confirming state', () => {
+    component.onDeleteRemote(makeViewFile());
+    expect(component.confirmingDelete).toBe('remote');
+    expect(component.activeAction).toBeNull();
+  });
+
+  it('second click on delete remote emits event and clears state', () => {
+    const file = makeViewFile();
+    const spy = vi.spyOn(component.deleteRemoteEvent, 'emit');
+
+    component.onDeleteRemote(file);
+    component.onDeleteRemote(file);
+
+    expect(component.confirmingDelete).toBeNull();
+    expect(component.activeAction).toBe(FileAction.DELETE_REMOTE);
+    expect(spy).toHaveBeenCalledWith(file);
+  });
+
+  it('confirming state auto-resets after 3 seconds', () => {
+    component.onDeleteLocal(makeViewFile());
+    expect(component.confirmingDelete).toBe('local');
+
+    vi.advanceTimersByTime(3000);
+    expect(component.confirmingDelete).toBeNull();
+  });
+
+  it('clicking delete local while confirming remote switches to local', () => {
+    component.onDeleteRemote(makeViewFile());
+    expect(component.confirmingDelete).toBe('remote');
+
+    component.onDeleteLocal(makeViewFile());
+    expect(component.confirmingDelete).toBe('local');
+  });
+
+  it('ngOnDestroy clears the confirm timer', () => {
+    component.onDeleteLocal(makeViewFile());
+    expect(component.confirmingDelete).toBe('local');
+
+    component.ngOnDestroy();
+    vi.advanceTimersByTime(5000);
+    // State stays as-is (timer was cleared, no reset happened)
+    expect(component.confirmingDelete).toBe('local');
   });
 });

--- a/src/angular/src/app/pages/files/file.component.ts
+++ b/src/angular/src/app/pages/files/file.component.ts
@@ -1,12 +1,11 @@
 import {
-  Component, ChangeDetectionStrategy, OnChanges, SimpleChanges,
+  Component, ChangeDetectionStrategy, OnChanges, OnDestroy, SimpleChanges,
   ViewChild, ElementRef, input, output
 } from '@angular/core';
 import { AsyncPipe, DatePipe } from '@angular/common';
 
 import { ViewFile, ViewFileStatus } from '../../models/view-file';
 import { ViewFileOptions } from '../../models/view-file-options';
-import { Localization } from '../../models/localization';
 import { FileSizePipe } from '../../common/file-size.pipe';
 import { EtaPipe } from '../../common/eta.pipe';
 import { CapitalizePipe } from '../../common/capitalize.pipe';
@@ -36,7 +35,7 @@ export enum FileAction {
   styleUrls: ['./file.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class FileComponent implements OnChanges {
+export class FileComponent implements OnChanges, OnDestroy {
   ViewFileStatus = ViewFileStatus;
   FileAction = FileAction;
   min = Math.min;
@@ -55,10 +54,9 @@ export class FileComponent implements OnChanges {
 
   activeAction: FileAction | null = null;
 
-  // Delete confirmation state
-  deleteConfirmationType: 'local' | 'remote' | null = null;
-  deleteConfirmationTitle = '';
-  deleteConfirmationMessage = '';
+  // Inline double-click delete confirmation state
+  confirmingDelete: 'local' | 'remote' | null = null;
+  private confirmResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   ngOnChanges(changes: SimpleChanges): void {
     const fileChange = changes['file'];
@@ -82,6 +80,10 @@ export class FileComponent implements OnChanges {
         }
       }
     }
+  }
+
+  ngOnDestroy(): void {
+    this.clearConfirmTimer();
   }
 
   onCheck(event: MouseEvent, file: ViewFile): void {
@@ -125,31 +127,41 @@ export class FileComponent implements OnChanges {
   }
 
   onDeleteLocal(file: ViewFile): void {
-    this.deleteConfirmationType = 'local';
-    this.deleteConfirmationTitle = Localization.Modal.DELETE_LOCAL_TITLE;
-    this.deleteConfirmationMessage = Localization.Modal.DELETE_LOCAL_MESSAGE(file.name);
+    if (this.confirmingDelete === 'local') {
+      this.clearConfirmTimer();
+      this.confirmingDelete = null;
+      this.activeAction = FileAction.DELETE_LOCAL;
+      this.deleteLocalEvent.emit(file);
+    } else {
+      this.setConfirming('local');
+    }
   }
 
   onDeleteRemote(file: ViewFile): void {
-    this.deleteConfirmationType = 'remote';
-    this.deleteConfirmationTitle = Localization.Modal.DELETE_REMOTE_TITLE;
-    this.deleteConfirmationMessage = Localization.Modal.DELETE_REMOTE_MESSAGE(file.name);
-  }
-
-  confirmDelete(): void {
-    const file = this.file();
-    if (this.deleteConfirmationType === 'local') {
-      this.activeAction = FileAction.DELETE_LOCAL;
-      this.deleteLocalEvent.emit(file);
-    } else if (this.deleteConfirmationType === 'remote') {
+    if (this.confirmingDelete === 'remote') {
+      this.clearConfirmTimer();
+      this.confirmingDelete = null;
       this.activeAction = FileAction.DELETE_REMOTE;
       this.deleteRemoteEvent.emit(file);
+    } else {
+      this.setConfirming('remote');
     }
-    this.deleteConfirmationType = null;
   }
 
-  cancelDelete(): void {
-    this.deleteConfirmationType = null;
+  private setConfirming(type: 'local' | 'remote'): void {
+    this.clearConfirmTimer();
+    this.confirmingDelete = type;
+    this.confirmResetTimer = setTimeout(() => {
+      this.confirmingDelete = null;
+      this.confirmResetTimer = null;
+    }, 3000);
+  }
+
+  private clearConfirmTimer(): void {
+    if (this.confirmResetTimer !== null) {
+      clearTimeout(this.confirmResetTimer);
+      this.confirmResetTimer = null;
+    }
   }
 
   private static isElementInViewport(el: HTMLElement): boolean {


### PR DESCRIPTION
## Summary

- Replace modal confirmation dialog for delete actions with inline double-click pattern
- First click turns button red with "Confirm?" text; second click executes the delete
- Auto-resets to normal state after 3 seconds if no second click
- Applies to both "Delete Local" and "Delete Remote" buttons
- Cleans up timer on component destroy to prevent memory leaks

Closes #110

## Test plan

- [x] All 13 unit tests pass (7 existing ngOnChanges + 7 new confirmation tests)
- [ ] Manual: click Delete Local, verify button turns red with "Confirm?" text
- [ ] Manual: click again within 3s, verify delete executes
- [ ] Manual: click once, wait 3s, verify button reverts to normal
- [ ] Manual: click Delete Remote, same behavior
- [ ] Manual: click Delete Local, then Delete Remote, verify it switches confirm state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Changes**
  * Modified file deletion confirmation flow from modal dialog to inline button-state confirmation with automatic 3-second reset timeout.
  * Users must click the delete button twice within the timeout window to confirm deletion; state resets if action is not confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->