### PR TITLE
fix: enforce unique path pair names (#169)

### DIFF
--- a/src/angular/src/app/pages/settings/path-pairs.component.html
+++ b/src/angular/src/app/pages/settings/path-pairs.component.html
@@ -6,6 +6,9 @@
     }
   </div>
   <div class="restart-note">Restart the app after making changes to path pairs.</div>
+  @if (errorMessage) {
+    <div class="error-message">{{ errorMessage }}</div>
+  }
 
   @if (adding) {
     <div class="pair-form">

--- a/src/angular/src/app/pages/settings/path-pairs.component.scss
+++ b/src/angular/src/app/pages/settings/path-pairs.component.scss
@@ -27,6 +27,13 @@
     border-bottom: 1px solid var(--ss-border);
   }
 
+  .error-message {
+    padding: 6px 15px;
+    font-size: 80%;
+    color: var(--bs-danger, #dc3545);
+    border-bottom: 1px solid var(--ss-border);
+  }
+
   .empty-state {
     padding: 15px 20px;
     color: var(--ss-text-muted);

--- a/src/angular/src/app/pages/settings/path-pairs.component.ts
+++ b/src/angular/src/app/pages/settings/path-pairs.component.ts
@@ -1,7 +1,9 @@
 import { Component, ChangeDetectionStrategy, ChangeDetectorRef, inject, OnDestroy } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { AsyncPipe } from '@angular/common';
-import { Subscription } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { EMPTY, Subscription } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 import { PathPairsService } from '../../services/settings/path-pairs.service';
 import { PathPair } from '../../models/path-pair';
@@ -27,6 +29,9 @@ export class PathPairsComponent implements OnDestroy {
   adding = false;
   addForm: Omit<PathPair, 'id'> = this.emptyForm();
 
+  // Error message
+  errorMessage: string | null = null;
+
   // Double-click delete confirmation
   confirmingDeleteId: string | null = null;
   private confirmResetTimer: ReturnType<typeof setTimeout> | null = null;
@@ -45,17 +50,28 @@ export class PathPairsComponent implements OnDestroy {
     this.cancelEdit();
     this.adding = true;
     this.addForm = this.emptyForm();
+    this.errorMessage = null;
   }
 
   onCancelAdd(): void {
     this.adding = false;
     this.addForm = this.emptyForm();
+    this.errorMessage = null;
   }
 
   onSaveAdd(): void {
     if (!this.addForm.name.trim()) return;
+    this.errorMessage = null;
     this.subscriptions.push(
-      this.pathPairsService.create(this.addForm).subscribe((created) => {
+      this.pathPairsService.create(this.addForm).pipe(
+        catchError((err: HttpErrorResponse) => {
+          if (err.status === 409) {
+            this.errorMessage = 'A path pair with that name already exists.';
+          }
+          this.cdr.markForCheck();
+          return EMPTY;
+        }),
+      ).subscribe((created) => {
         if (!created) {
           this.cdr.markForCheck();
           return;
@@ -85,12 +101,22 @@ export class PathPairsComponent implements OnDestroy {
   onCancelEdit(): void {
     this.editingId = null;
     this.editForm = this.emptyForm();
+    this.errorMessage = null;
   }
 
   onSaveEdit(): void {
     if (!this.editingId || !this.editForm.name.trim()) return;
+    this.errorMessage = null;
     this.subscriptions.push(
-      this.pathPairsService.update({ id: this.editingId, ...this.editForm }).subscribe((updated) => {
+      this.pathPairsService.update({ id: this.editingId, ...this.editForm }).pipe(
+        catchError((err: HttpErrorResponse) => {
+          if (err.status === 409) {
+            this.errorMessage = 'A path pair with that name already exists.';
+          }
+          this.cdr.markForCheck();
+          return EMPTY;
+        }),
+      ).subscribe((updated) => {
         if (!updated) {
           this.cdr.markForCheck();
           return;

--- a/src/angular/src/app/services/settings/path-pairs.service.ts
+++ b/src/angular/src/app/services/settings/path-pairs.service.ts
@@ -44,6 +44,9 @@ export class PathPairsService {
       }),
       catchError((err: HttpErrorResponse) => {
         this.logger.warn('Failed to create path pair: %O', err);
+        if (err.status === 409) {
+          throw err;
+        }
         return of(null);
       }),
     );
@@ -59,6 +62,9 @@ export class PathPairsService {
       }),
       catchError((err: HttpErrorResponse) => {
         this.logger.warn('Failed to update path pair: %O', err);
+        if (err.status === 409) {
+          throw err;
+        }
         return of(null);
       }),
     );

--- a/src/python/common/path_pairs_config.py
+++ b/src/python/common/path_pairs_config.py
@@ -111,12 +111,16 @@ class PathPairsConfig(Persist):
         with self._lock:
             if any(p.id == pair.id for p in self._pairs):
                 raise ValueError("PathPair with id '{}' already exists".format(pair.id))
+            if any(p.name == pair.name for p in self._pairs):
+                raise ValueError("PathPair with name '{}' already exists".format(pair.name))
             self._pairs.append(pair)
 
     def update_pair(self, pair: PathPair):
         with self._lock:
             for i, p in enumerate(self._pairs):
                 if p.id == pair.id:
+                    if any(other.name == pair.name and other.id != pair.id for other in self._pairs):
+                        raise ValueError("PathPair with name '{}' already exists".format(pair.name))
                     self._pairs[i] = pair
                     return
             raise ValueError("PathPair with id '{}' not found".format(pair.id))

--- a/src/python/web/handler/path_pairs.py
+++ b/src/python/web/handler/path_pairs.py
@@ -60,7 +60,12 @@ class PathPairsHandler(IHandler):
             enabled=enabled,
             auto_queue=auto_queue,
         )
-        self.__config.add_pair(pair)
+        try:
+            self.__config.add_pair(pair)
+        except ValueError as e:
+            if "name" in str(e) and "already exists" in str(e):
+                return HTTPResponse(body=str(e), status=409)
+            raise
         return HTTPResponse(
             body=json.dumps(pair.to_dict()),
             status=201,
@@ -108,7 +113,9 @@ class PathPairsHandler(IHandler):
         )
         try:
             self.__config.update_pair(updated)
-        except ValueError:
+        except ValueError as e:
+            if "name" in str(e) and "already exists" in str(e):
+                return HTTPResponse(body=str(e), status=409)
             return HTTPResponse(body="Path pair not found", status=404)
         return HTTPResponse(
             body=json.dumps(updated.to_dict()),


### PR DESCRIPTION
## Summary

- PathPairsConfig rejects duplicate pair names on add and update
- REST handler returns 409 Conflict with descriptive message
- Angular UI catches 409 and shows inline error, clears on cancel/new action

Closes #169

## Test plan

- [ ] Create two pairs with the same name → expect 409 and error message
- [ ] Rename a pair to match an existing name → expect 409 and error message
- [ ] Create/update with unique names → works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Error messages now display when adding or editing path pairs with duplicate names, providing clear user feedback on conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->