### PR TITLE
ci: publish develop images to ghcr.io on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # Only publish Docker images on version tags.
+  # Publish Docker images on version tags (full release) or develop pushes (dev image).
   SHOULD_PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  IS_DEVELOP: ${{ github.ref == 'refs/heads/develop' && github.event_name == 'push' }}
 
 jobs:
   unit-test:
@@ -245,6 +246,43 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+  publish-develop:
+    name: Publish develop (${{ matrix.variant }})
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+    needs: [unit-test, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        variant: [debian, alpine]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push develop image (amd64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.variant == 'alpine' && 'src/docker/build/docker-image/Dockerfile.alpine' || 'src/docker/build/docker-image/Dockerfile' }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ matrix.variant == 'debian' && format('{0}/{1}:develop', env.REGISTRY, env.IMAGE_NAME) || format('{0}/{1}:develop-alpine', env.REGISTRY, env.IMAGE_NAME) }}
+          cache-from: type=gha,scope=${{ matrix.variant }}-amd64
+          provenance: false
+          sbom: false
 
   release:
     name: Create Release


### PR DESCRIPTION
## Summary
- Adds a `publish-develop` job that builds and pushes amd64-only Docker images on every push to `develop`
- Tags: `ghcr.io/nitrobass24/seedsync:develop` (debian) and `ghcr.io/nitrobass24/seedsync:develop-alpine`
- Skips arm64 build (QEMU is slow and unnecessary for dev testing)
- Existing tag-based multi-arch release flow is unchanged

## Usage
```bash
docker pull ghcr.io/nitrobass24/seedsync:develop
```

## Test plan
- [ ] Merge to develop and verify `publish-develop` job runs
- [ ] Verify image is pullable: `docker pull ghcr.io/nitrobass24/seedsync:develop`
- [ ] Verify tag-based releases still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to automatically publish development container images for Debian and Alpine platforms, enabling easier access to pre-release builds from development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->