### PR TITLE
ci: parallel arm64 builds on develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # Publish Docker images on version tags (full release) or develop pushes (dev image).
-  SHOULD_PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') }}
-  IS_DEVELOP: ${{ github.ref == 'refs/heads/develop' && github.event_name == 'push' }}
+  # Should we publish Docker images? True on version tags or develop pushes.
+  SHOULD_PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop' && github.event_name == 'push') }}
 
 jobs:
   unit-test:
@@ -39,13 +38,30 @@ jobs:
         working-directory: src/angular
         run: npx ng test
 
+  angular-build:
+    name: Build Angular
+    if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop' && github.event_name == 'push')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: src/angular/package-lock.json
+
+      - name: Install dependencies
+        working-directory: src/angular
+        run: npm ci
+
       - name: Build Angular frontend
-        if: env.SHOULD_PUBLISH == 'true'
         working-directory: src/angular
         run: npx ng build --configuration=production --output-path /tmp/angular-output/build
 
       - name: Upload Angular build artifact
-        if: env.SHOULD_PUBLISH == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: angular-build
@@ -125,8 +141,8 @@ jobs:
 
   build-arm64:
     name: Build (${{ matrix.variant }}, arm64)
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    needs: [unit-test]
+    if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop' && github.event_name == 'push')
+    needs: [angular-build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -186,7 +202,12 @@ jobs:
 
   publish:
     name: Publish (${{ matrix.variant }})
-    if: always() && !cancelled() && needs.unit-test.result == 'success' && needs.build.result == 'success' && needs.build-arm64.result == 'success'
+    if: >-
+      always() && !cancelled()
+      && (startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop' && github.event_name == 'push'))
+      && needs.unit-test.result == 'success'
+      && needs.build.result == 'success'
+      && needs.build-arm64.result == 'success'
     needs: [unit-test, build, build-arm64]
     runs-on: ubuntu-latest
     permissions:
@@ -218,9 +239,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (debian)
-        if: matrix.variant == 'debian'
-        id: meta-debian
+      - name: Extract metadata (debian, release)
+        if: matrix.variant == 'debian' && startsWith(github.ref, 'refs/tags/v')
+        id: meta-debian-release
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -229,9 +250,9 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Extract metadata (alpine)
-        if: matrix.variant == 'alpine'
-        id: meta-alpine
+      - name: Extract metadata (alpine, release)
+        if: matrix.variant == 'alpine' && startsWith(github.ref, 'refs/tags/v')
+        id: meta-alpine-release
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -240,49 +261,30 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}-alpine
             type=raw,value=alpine
 
+      - name: Extract metadata (debian, develop)
+        if: matrix.variant == 'debian' && github.ref == 'refs/heads/develop'
+        id: meta-debian-develop
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=develop
+
+      - name: Extract metadata (alpine, develop)
+        if: matrix.variant == 'alpine' && github.ref == 'refs/heads/develop'
+        id: meta-alpine-develop
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=develop-alpine
+
       - name: Create multi-arch manifest and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
-
-  publish-develop:
-    name: Publish develop (${{ matrix.variant }})
-    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
-    needs: [unit-test, build]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        variant: [debian, alpine]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push develop image (amd64)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ${{ matrix.variant == 'alpine' && 'src/docker/build/docker-image/Dockerfile.alpine' || 'src/docker/build/docker-image/Dockerfile' }}
-          platforms: linux/amd64
-          push: true
-          tags: ${{ matrix.variant == 'debian' && format('{0}/{1}:develop', env.REGISTRY, env.IMAGE_NAME) || format('{0}/{1}:develop-alpine', env.REGISTRY, env.IMAGE_NAME) }}
-          cache-from: type=gha,scope=${{ matrix.variant }}-amd64
-          provenance: false
-          sbom: false
 
   release:
     name: Create Release


### PR DESCRIPTION
## Summary
- Extract Angular build into its own job so it runs in parallel with unit tests and amd64 builds
- Enable arm64 builds on develop pushes (previously only on release tags)
- Unify `publish-develop` into the main `publish` job with branch-aware tagging (develop vs semver)

### New flow (develop push)
```
unit-test ──────────────────────────────────┐
angular-build ──→ build-arm64 ──────────────┼──→ publish (multi-arch: develop/develop-alpine)
build (amd64) ──────────────────────────────┘
```

All three top-level jobs start immediately in parallel. arm64 only waits for the Angular build artifact (~30s), not the full test suite.

## Test plan
- [ ] Verify CI passes on this PR (unit-test + build only, no publish)
- [ ] After merge to develop, verify all jobs run including arm64 build and multi-arch publish
- [ ] Verify `develop` and `develop-alpine` tags are multi-arch (amd64 + arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration pipeline with consolidated publishing conditions and streamlined build job dependencies
  * Enhanced automated build and release workflow to support multiple deployment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->