### PR TITLE
fix: skip spurious staging moves on container restart

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -965,6 +965,14 @@ class Controller:
         # Use per-pair staging subdirectory
         staging_source = os.path.join(self.__context.config.controller.staging_path, pair_id) \
             if pair_id else self.__context.config.controller.staging_path
+
+        # Skip if the file doesn't exist in staging (e.g. already moved in a prior session)
+        staging_file = os.path.join(staging_source, file_name)
+        if not os.path.exists(staging_file):
+            self.logger.debug("Skipping move for {} - not found in staging".format(file_name))
+            self.__moved_file_keys.add(move_key)
+            return
+
         self.__moved_file_keys.add(move_key)
         process = MoveProcess(
             source_path=staging_source,


### PR DESCRIPTION
## Summary
- On container restart with staging enabled, the controller was spawning a move (staging → local) for every file that appeared as newly DOWNLOADED in the model
- These files were already in the final download path from a prior session — staging was empty, so every move failed with "source does not exist"
- Fix: check if the file exists in the staging directory before spawning the move process

Fixes #177

## Test plan
- [ ] CI passes
- [ ] With staging enabled: restart container with files already synced — no spurious "Move failed" errors in logs
- [ ] With staging enabled: download a new file — move from staging to local still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where missing staging files during move operations would cause errors. The system now gracefully handles and completes these operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->