### PR TITLE
ci: group @angular/* dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "weekly"
     target-branch: "develop"
     open-pull-requests-limit: 10
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
 
   - package-ecosystem: "npm"
     directory: "/website"


### PR DESCRIPTION
## Summary

- Add Dependabot grouping for `@angular/*` packages so they're bumped together in a single PR
- Angular requires all `@angular/*` packages at the exact same version; individual bumps cause peer dependency conflicts (`ERESOLVE`)
- Closed 9 failing Dependabot PRs (#187-#195) that each bumped one Angular package independently

## Test plan
- [ ] Next Dependabot run opens a single grouped PR for all Angular packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)