### PR TITLE
fix: resolve CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ env:
   # Should we publish Docker images? True on version tags or develop pushes.
   SHOULD_PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop' && github.event_name == 'push') }}
 
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     name: Unit Tests
@@ -71,6 +74,9 @@ jobs:
   build:
     name: Build and Test (${{ matrix.variant }}, amd64)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         variant: [debian, alpine]
@@ -144,6 +150,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop' && github.event_name == 'push')
     needs: [angular-build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         variant: [debian, alpine]

--- a/src/python/tests/unittests/test_common/test_config.py
+++ b/src/python/tests/unittests/test_common/test_config.py
@@ -392,7 +392,9 @@ class TestConfig(unittest.TestCase):
 
     def test_from_file(self):
         # Create empty config file
-        config_file = open(tempfile.mktemp(suffix="test_config"), "w")
+        fd, config_file_path = tempfile.mkstemp(suffix="test_config")
+        os.close(fd)
+        config_file = open(config_file_path, "w")
 
         config_file.write("""
         [General]
@@ -486,7 +488,8 @@ class TestConfig(unittest.TestCase):
         os.remove(config_file.name)
 
     def test_to_file(self):
-        config_file_path = tempfile.mktemp(suffix="test_config")
+        fd, config_file_path = tempfile.mkstemp(suffix="test_config")
+        os.close(fd)
 
         config = Config()
         config.general.debug = True


### PR DESCRIPTION
## Summary
- Add explicit `permissions` block to CI workflow (top-level `contents: read`, job-level `packages: write` where needed) — resolves alerts #1, #7, #8, #9
- Replace insecure `tempfile.mktemp()` with `tempfile.mkstemp()` in `test_config.py` — resolves alerts #4, #5

## Test plan
- [ ] CI passes (workflow permissions don't break any jobs)
- [ ] Python unit tests still pass with `mkstemp` change
- [ ] CodeQL re-scan shows alerts resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow configuration with refined permission scoping across build and deployment processes to strengthen security controls.
  * Improved test infrastructure security by implementing more robust temporary file handling practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->