### PR TITLE
Fix auto-delete remote not working with path pairs

### DIFF
--- a/src/python/controller/auto_queue.py
+++ b/src/python/controller/auto_queue.py
@@ -2,7 +2,7 @@
 
 import json
 from abc import ABC, abstractmethod
-from typing import Dict, Set, List, Callable, Tuple
+from typing import Dict, Optional, Set, List, Callable, Tuple
 import fnmatch
 
 from common import overrides, Constants, Context, Persist, PersistError, Serializable
@@ -160,7 +160,7 @@ class AutoQueue:
         self.__patterns_only = context.config.autoqueue.patterns_only
         self.__auto_extract_enabled = context.config.autoqueue.auto_extract
         self.__auto_delete_remote_enabled = context.config.autoqueue.auto_delete_remote
-        self.__delete_remote_retry_cycles: Dict[str, int] = {}
+        self.__delete_remote_retry_cycles: Dict[Tuple[str, Optional[str]], int] = {}
 
         # Build per-pair auto_queue lookup.
         # When path pairs are active, per-pair auto_queue overrides the global setting.
@@ -350,7 +350,7 @@ class AutoQueue:
 
     def __filter_candidates(self,
                             candidates: List[ModelFile],
-                            accept: Callable[[ModelFile], bool]) -> List[Tuple[str, str, AutoQueuePattern]]:
+                            accept: Callable[[ModelFile], bool]) -> List[Tuple[str, Optional[str], AutoQueuePattern]]:
         """
         Given a list of candidate files, filter out those that match the accept criteria
         Also takes into consideration new patterns that were added


### PR DESCRIPTION
## Summary

- **Fixes #205** — Auto-delete-remote (and auto-queue/auto-extract) commands from `AutoQueue` were missing `pair_id`, causing file lookup failures for secondary path pairs
- `__filter_candidates()` now returns `(filename, pair_id, pattern)` tuples instead of `(filename, pattern)`
- All command construction sites (QUEUE, EXTRACT, DELETE_REMOTE) and the delete-remote retry loop now pass `pair_id`

## Root Cause

`AutoQueue.__filter_candidates()` keyed matched files by `file.name` alone and returned `(filename, pattern)` tuples — losing `pair_id`. Commands sent without `pair_id` defaulted to the first pair context, so `model.get_file()` failed with "File not found" for any file belonging to a secondary path pair. Manual delete worked because the UI sends commands through the web handler which resolves `pair_id` from the model directly.

## Test plan

- [ ] Verify auto-delete-remote works for files downloaded via a secondary path pair
- [ ] Verify auto-queue and auto-extract also work correctly with path pairs
- [ ] Verify default (single path) behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-pair auto-queue enablement, allowing users to configure auto-queue settings on a pair-by-pair basis while maintaining the global setting as a fallback for flexibility and granular control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->