### PR TITLE
Fix pending_completion not clearing with staging for terminal states

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -576,7 +576,9 @@ class Controller:
                         move_key = _persist_key(diff.new_file.pair_id, diff.new_file.name)
                         if move_key in self.__moved_file_keys:
                             pc.pending_completion.discard(diff.new_file.name)
-                        elif diff.new_file.state == ModelFile.State.DELETED:
+                        elif diff.new_file.state in (ModelFile.State.DELETED,
+                                                      ModelFile.State.EXTRACTED,
+                                                      ModelFile.State.EXTRACT_FAILED):
                             pc.pending_completion.discard(diff.new_file.name)
                     else:
                         if diff.new_file.state in (ModelFile.State.DOWNLOADED,


### PR DESCRIPTION
## Summary

Fixes the model being rebuilt every ~1 second with repeated "Adding file" debug logs for all files in a pair.

### Root Cause

With staging enabled, `pending_completion` only cleared when:
1. The file's move key was in `__moved_file_keys` (move completed), OR
2. The file state was `DELETED`

Files reaching `EXTRACTED` or `EXTRACT_FAILED` stayed in `pending_completion` forever. This kept the active scanner running every cycle, which called `model_builder.set_active_files()` with a non-empty list, which **always invalidates the model cache**, triggering a full model rebuild for every file in the pair (~once per second).

The non-staging code path already handled all four terminal states (`DOWNLOADED`, `EXTRACTED`, `EXTRACT_FAILED`, `DELETED`).

### Fix

Add `EXTRACTED` and `EXTRACT_FAILED` to the staging `pending_completion` clear conditions.

## Test plan

- [ ] With staging enabled, verify extraction failure marks file as EXTRACT_FAILED and stops the active scanner cycle
- [ ] Verify "Adding file" debug logs stop repeating after file reaches a terminal state
- [ ] Verify normal download→move→complete flow still works with staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file cleanup handling during extraction and deletion workflows to ensure files in certain completion states are properly processed, regardless of staging status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->