### PR TITLE
Improve 7z extraction error diagnostics

### DIFF
--- a/src/python/controller/extract/extract.py
+++ b/src/python/controller/extract/extract.py
@@ -182,8 +182,15 @@ class Extract:
             raise ExtractError("7z binary not found; cannot extract archive")
 
         if result.returncode != 0:
+            # 7z puts some diagnostics in stdout, some in stderr — include both
+            details = result.stderr.strip()
+            if result.stdout.strip():
+                # Extract the tail of stdout (last 20 lines) to catch the error summary
+                stdout_lines = result.stdout.strip().splitlines()
+                stdout_tail = "\n".join(stdout_lines[-20:])
+                details = "{}\n--- stdout (last 20 lines) ---\n{}".format(details, stdout_tail)
             raise ExtractError(
-                "7z failed (exit {}): {}".format(result.returncode, result.stderr.strip())
+                "7z failed (exit {}): {}".format(result.returncode, details)
             )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Include 7z stdout (last 20 lines) alongside stderr in extraction error messages
- Currently `_run_7z` only reports stderr, but 7z puts important diagnostics (missing volumes, CRC errors, format details) in stdout
- This will help diagnose the ongoing extraction failures with multivolume RAR archives

## Context
Extraction is still failing with exit code 2 on certain RAR archives (#204). The current error message only shows `ERROR: /path/to/file.rar` with no actionable detail. With this change, the next failure will include the full 7z diagnostic output.

## Test plan
- [ ] Deploy and trigger extraction on a known-failing archive
- [ ] Verify error log now contains the actual 7z diagnostic details

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for extraction failures by including additional diagnostic information from the extraction process, providing more context when troubleshooting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->