### PR TITLE
Use official 7-Zip binary with RAR codec support

### DIFF
--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -68,7 +68,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && curl -sL https://www.7-zip.org/a/7z2600-src.tar.xz | tar -xJ -C /tmp/7z-src \
     && cd /tmp/7z-src/CPP/7zip/Bundles/Alone2 \
     && make -f makefile.gcc -j$(nproc) \
-    && cp _o/7zz /usr/local/bin/7zz
+    && cp _o/7zz /usr/local/bin/7zz \
+    && /usr/local/bin/7zz i | grep -q Rar5
 
 # ==============================================================================
 # Stage 4: Final Runtime Image

--- a/src/docker/build/docker-image/Dockerfile.alpine
+++ b/src/docker/build/docker-image/Dockerfile.alpine
@@ -66,7 +66,8 @@ RUN apk add --no-cache build-base curl xz \
     && curl -sL https://www.7-zip.org/a/7z2600-src.tar.xz | tar -xJ -C /tmp/7z-src \
     && cd /tmp/7z-src/CPP/7zip/Bundles/Alone2 \
     && make -f makefile.gcc -j$(nproc) \
-    && cp _o/7zz /usr/local/bin/7zz
+    && cp _o/7zz /usr/local/bin/7zz \
+    && /usr/local/bin/7zz i | grep -q Rar5
 
 # ==============================================================================
 # Stage 4: Final Runtime Image

--- a/src/python/controller/extract/extract.py
+++ b/src/python/controller/extract/extract.py
@@ -36,6 +36,16 @@ class Extract:
     _7Z_TIMEOUT_SECS = 3600
 
     @staticmethod
+    def _format_7z_error(result: subprocess.CompletedProcess, prefix: str) -> str:
+        """Format a 7z failure message with both stderr and stdout details."""
+        details = result.stderr.strip()
+        if result.stdout.strip():
+            stdout_lines = result.stdout.strip().splitlines()
+            stdout_tail = "\n".join(stdout_lines[-20:])
+            details = "{}\n--- stdout (last 20 lines) ---\n{}".format(details, stdout_tail)
+        return "{} (exit {}): {}".format(prefix, result.returncode, details)
+
+    @staticmethod
     def verify_archive(archive_path: str):
         """
         Verify archive integrity using 7z test command.
@@ -61,9 +71,7 @@ class Extract:
             raise ExtractError("7z binary not found; cannot verify archive")
 
         if result.returncode != 0:
-            raise ExtractError(
-                "Archive verification failed (exit {}): {}".format(result.returncode, result.stderr.strip())
-            )
+            raise ExtractError(Extract._format_7z_error(result, "Archive verification failed"))
 
     @staticmethod
     def _detect_format(archive_path: str) -> str:
@@ -182,15 +190,7 @@ class Extract:
             raise ExtractError("7z binary not found; cannot extract archive")
 
         if result.returncode != 0:
-            # 7z puts some diagnostics in stdout, some in stderr — include both
-            details = result.stderr.strip()
-            if result.stdout.strip():
-                stdout_lines = result.stdout.strip().splitlines()
-                stdout_tail = "\n".join(stdout_lines[-20:])
-                details = "{}\n--- stdout (last 20 lines) ---\n{}".format(details, stdout_tail)
-            raise ExtractError(
-                "7z failed (exit {}): {}".format(result.returncode, details)
-            )
+            raise ExtractError(Extract._format_7z_error(result, "7z failed"))
 
     @staticmethod
     def _extract_compressed_archive(archive_path: str, out_dir_path: str):


### PR DESCRIPTION
## Summary
- **Root cause**: The Debian/Alpine `7zip` packages strip the proprietary RAR codec, causing ALL RAR extractions to fail with "Cannot open the file as archive"
- **Fix**: Download the official `7zz` binary from 7-zip.org (which includes RAR support) in a new build stage, replacing the distro package
- Both Debian and Alpine Dockerfiles updated
- Also includes improved 7z error diagnostics (stdout included in error messages)

## Details
Confirmed via `7z i | grep -i rar` — zero RAR codec entries in the container. The `.rar` file has valid RAR4 magic bytes and all 18 multivolume parts are present, but 7z simply can't parse RAR format without the codec.

Fixes #204

## Test plan
- [ ] Build Docker image and verify `docker exec seedsync 7z i | grep -i rar` shows RAR codec
- [ ] Test extraction of a multivolume RAR archive
- [ ] Verify non-RAR formats (zip, 7z, tar.gz) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive extraction error messages by consolidating stderr and recent stdout lines for clearer diagnostics.

* **Chores**
  * Updated container build to include a self-built 7-Zip binary (with RAR codec) and use it in the final runtime images instead of installing the distro package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->