### PR TITLE
Use pre-built docker-7zip image for RAR support

### DIFF
--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -55,24 +55,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt \
     && find /usr/local/lib/python3.12 -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 # ==============================================================================
-# Stage 3: Build 7-Zip 26.00 from source (includes RAR codec)
-# ==============================================================================
-# The Debian 7zip package strips the proprietary RAR codec.
-# Building from source includes full RAR1-5 support.
-FROM debian:bookworm-slim AS archive-tools
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential curl xz-utils ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /tmp/7z-src \
-    && curl -sL https://www.7-zip.org/a/7z2600-src.tar.xz | tar -xJ -C /tmp/7z-src \
-    && cd /tmp/7z-src/CPP/7zip/Bundles/Alone2 \
-    && make -f makefile.gcc -j$(nproc) \
-    && cp _o/7zz /usr/local/bin/7zz \
-    && /usr/local/bin/7zz i | grep -q Rar5
-
-# ==============================================================================
-# Stage 4: Final Runtime Image
+# Stage 3: Final Runtime Image
 # ==============================================================================
 FROM debian:bookworm-slim AS runtime
 
@@ -82,8 +65,8 @@ LABEL maintainer="nitrobass24" \
 # Copy stripped Python runtime from python-deps stage
 COPY --from=python-deps /usr/local/ /usr/local/
 
-# Copy 7zz binary built from source (with RAR codec support)
-COPY --from=archive-tools /usr/local/bin/7zz /usr/bin/7zz
+# Copy pre-built 7zz binary with RAR codec support (ghcr.io/nitrobass24/docker-7zip)
+COPY --from=ghcr.io/nitrobass24/docker-7zip:debian /7zz /usr/bin/7zz
 RUN ln -sf /usr/bin/7zz /usr/bin/7z
 
 # Install runtime deps in a single layer.

--- a/src/docker/build/docker-image/Dockerfile.alpine
+++ b/src/docker/build/docker-image/Dockerfile.alpine
@@ -55,22 +55,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt \
     && find /usr/local/lib/python3.12 -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 # ==============================================================================
-# Stage 3: Build 7-Zip 26.00 from source (includes RAR codec)
-# ==============================================================================
-# The Alpine 7zip package strips the proprietary RAR codec.
-# Building from source includes full RAR1-5 support.
-FROM alpine:3.21 AS archive-tools
-
-RUN apk add --no-cache build-base curl xz \
-    && mkdir -p /tmp/7z-src \
-    && curl -sL https://www.7-zip.org/a/7z2600-src.tar.xz | tar -xJ -C /tmp/7z-src \
-    && cd /tmp/7z-src/CPP/7zip/Bundles/Alone2 \
-    && make -f makefile.gcc -j$(nproc) \
-    && cp _o/7zz /usr/local/bin/7zz \
-    && /usr/local/bin/7zz i | grep -q Rar5
-
-# ==============================================================================
-# Stage 4: Final Runtime Image
+# Stage 3: Final Runtime Image
 # ==============================================================================
 FROM alpine:3.21 AS runtime
 
@@ -80,8 +65,8 @@ LABEL maintainer="nitrobass24" \
 # Copy stripped Python runtime from python-deps stage
 COPY --from=python-deps /usr/local/ /usr/local/
 
-# Copy 7zz binary built from source (with RAR codec support)
-COPY --from=archive-tools /usr/local/bin/7zz /usr/bin/7zz
+# Copy pre-built 7zz binary with RAR codec support (ghcr.io/nitrobass24/docker-7zip)
+COPY --from=ghcr.io/nitrobass24/docker-7zip:alpine /7zz /usr/bin/7zz
 RUN ln -sf /usr/bin/7zz /usr/bin/7z
 
 # Install runtime dependencies.


### PR DESCRIPTION
## Summary
- Replace the `archive-tools` build stage (7z source compilation) with a single `COPY --from=ghcr.io/nitrobass24/docker-7zip`
- Both Debian and Alpine Dockerfiles updated
- Eliminates 7z compilation from SeedSync CI entirely

## Dependencies
- https://github.com/nitrobass24/docker-7zip — new repo that builds multi-arch 7z 26.00 with RAR codec
- Images: `ghcr.io/nitrobass24/docker-7zip:alpine` and `ghcr.io/nitrobass24/docker-7zip:debian`
- CI build must complete before this PR can be merged

## Test plan
- [ ] Verify `docker-7zip` CI completes and images are published
- [ ] Build SeedSync Docker images locally
- [ ] Verify `7z i | grep -i rar` shows RAR codec in both images
- [ ] Test RAR extraction on a multivolume archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Docker build pipeline for both standard and Alpine container images by leveraging a pre-built 7-Zip binary with RAR codec support instead of compiling from source, reducing build time and complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->