### PR TITLE
Add recommended hard link setup to FAQ and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Fix:
 
 ### Recommended Setup with Hard Links
 
-The preferred way to use SeedSync is with a dedicated completion directory using **hard links**. Configure your torrent client to hard link completed downloads to a separate folder (e.g., `/downloads/complete`), point SeedSync at that folder, and enable auto-delete of remote files after syncing. Hard links don't use extra disk space, and your originals remain intact for seeding.
+The preferred way to use SeedSync is with a dedicated completion directory using **hard links**. Configure your torrent client to hard link completed downloads to a separate folder (e.g., `/downloads/complete`), point SeedSync at that folder, and enable auto-delete of remote files after syncing. Hard links don't use extra disk space, and your originals remain intact for seeding. Note: both directories must be on the same filesystem for hard links to work.
 
 See the [FAQ](https://nitrobass24.github.io/seedsync/faq#what-is-the-recommended-way-to-set-up-seedsync-with-my-torrent-client) for a detailed setup guide and [qbit-hardlinker](https://github.com/gravelfreeman/qbit-hardlinker) for qBittorrent integration.
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -88,16 +88,20 @@ The best approach is to use **hard links** with a dedicated completion directory
 2. **Point SeedSync** at the completion directory (`/downloads/complete`).
 3. **Enable Auto-Queue** and turn on **"Delete remote file after syncing"** in SeedSync settings.
 
+:::note
+Hard links only work when both directories are on the **same filesystem**. If your download and completion directories are on different mounts, use a bind mount to place them on the same filesystem, or use a copy-on-complete script instead (at the cost of extra disk space).
+:::
+
 Hard links don't consume extra disk space on the seedbox — they create another reference to the same data on disk. When SeedSync finishes syncing and deletes from `/downloads/complete`, only the hard link is removed. The original file stays intact for seeding.
 
 ### Setting up hard links
 
 - **qBittorrent**: Use [qbit-hardlinker](https://github.com/gravelfreeman/qbit-hardlinker) to automatically hard link completed downloads to your SeedSync directory.
-- **ruTorrent**: Use the "Autotools" plugin with the "Move to" option, or a post-completion script that creates hard links.
+- **ruTorrent**: Use a post-completion script that creates hard links. Note that the Autotools "Move to" option performs a *move*, not a hard link — this would break seeding since the original file is relocated.
 
 ### Example directory layout
 
-```
+```text
 /downloads/
 ├── tv/              ← Sonarr downloads here, torrents continue seeding
 ├── movies/          ← Radarr downloads here


### PR DESCRIPTION
## Summary
- Added FAQ entry explaining the recommended hard link setup for using SeedSync with torrent clients
- Added short summary in README Troubleshooting section linking to the full FAQ
- Covers qBittorrent (qbit-hardlinker) and ruTorrent setup, with example directory layout

## Test plan
- [ ] Verify FAQ anchor link from README resolves correctly on the docs site
- [ ] Review rendered markdown on both README and docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added recommended setup guidance describing how to use SeedSync with hard links and a dedicated completion directory for efficient disk usage
  * Expanded FAQ section with detailed setup steps and configuration examples for optimal integration with torrent clients

<!-- end of auto-generated comment: release notes by coderabbit.ai -->