### PR TITLE
Add unit tests for plain gzip and bzip2 extraction support

### DIFF
--- a/src/python/tests/unittests/test_controller/test_extract/test_extract.py
+++ b/src/python/tests/unittests/test_controller/test_extract/test_extract.py
@@ -168,9 +168,9 @@ class TestExtractTwoPassTarVsPlain(unittest.TestCase):
                 with tarfile.open(tar_inner, 'w') as tar:
                     tar.add(self.inner_file, arcname="inner_file.txt")
             else:
-                # Second pass: extract the tar contents
-                with tarfile.open(archive_path) as tar:
-                    tar.extractall(out_dir_path)
+                # Second pass: simulate 7z extracting the tar contents
+                with open(os.path.join(out_dir_path, "inner_file.txt"), 'wb') as f:
+                    f.write(self.file_content)
 
         with patch.object(Extract, '_run_7z', side_effect=fake_run_7z):
             Extract.extract_archive(self.tar_gz_path, self.out_dir)


### PR DESCRIPTION
## Summary
- Verified the extraction pipeline already handles plain `.gz` and `.bz2` files end-to-end (no code changes needed)
- Added 21 unit tests covering plain gzip, plain bzip2, tar-vs-plain distinction, and error cases
- Removed unused `MagicMock` import

Partial fix for #171

## Test plan
- [x] 5 plain gzip tests (extension, magic bytes, format ID, routing, end-to-end)
- [x] 5 plain bzip2 tests (same coverage)
- [x] 3 tar-vs-plain two-pass distinction tests
- [x] 7 error-case tests (nonexistent file, unknown format, corrupt archives)
- [x] `.tar.bz2` detection test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for extraction functionality covering handling of gzip and bzip2 files, nested tar archives, and error conditions to ensure reliable file decompression and extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #171