### PR TITLE
Use takeUntilDestroyed for Angular subscription cleanup

### DIFF
--- a/src/angular/src/app/pages/files/file-list.component.ts
+++ b/src/angular/src/app/pages/files/file-list.component.ts
@@ -1,4 +1,5 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AsyncPipe } from '@angular/common';
 import { Observable } from 'rxjs';
 
@@ -23,6 +24,7 @@ export class FileListComponent {
   private readonly logger = inject(LoggerService);
   private readonly viewFileService = inject(ViewFileService);
   private readonly viewFileOptionsService = inject(ViewFileOptionsService);
+  private readonly destroyRef = inject(DestroyRef);
 
   files: Observable<ViewFile[]> = this.viewFileService.filteredFiles$;
   options: Observable<ViewFileOptions> = this.viewFileOptionsService.options$;
@@ -42,31 +44,41 @@ export class FileListComponent {
   }
 
   onQueue(file: ViewFile): void {
-    this.viewFileService.queue(file).subscribe(data => {
+    this.viewFileService.queue(file).pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(data => {
       this.logger.info(data);
     });
   }
 
   onStop(file: ViewFile): void {
-    this.viewFileService.stop(file).subscribe(data => {
+    this.viewFileService.stop(file).pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(data => {
       this.logger.info(data);
     });
   }
 
   onExtract(file: ViewFile): void {
-    this.viewFileService.extract(file).subscribe(data => {
+    this.viewFileService.extract(file).pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(data => {
       this.logger.info(data);
     });
   }
 
   onDeleteLocal(file: ViewFile): void {
-    this.viewFileService.deleteLocal(file).subscribe(data => {
+    this.viewFileService.deleteLocal(file).pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(data => {
       this.logger.info(data);
     });
   }
 
   onDeleteRemote(file: ViewFile): void {
-    this.viewFileService.deleteRemote(file).subscribe(data => {
+    this.viewFileService.deleteRemote(file).pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(data => {
       this.logger.info(data);
     });
   }
@@ -93,7 +105,9 @@ export class FileListComponent {
   onBulkDeleteRemote(): void { this.handleBulkResponse(this.viewFileService.bulkDeleteRemote()); }
 
   private handleBulkResponse(action$: Observable<WebReaction[]>): void {
-    action$.subscribe({
+    action$.pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
       next: (reactions) => {
         let failures = 0;
         reactions.forEach(r => {

--- a/src/angular/src/app/pages/logs/logs-page.component.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   ElementRef,
   HostListener,
   OnInit,
@@ -10,9 +11,10 @@ import {
   ViewChild,
   inject,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Subject, Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
 import { debounceTime, switchMap, catchError } from 'rxjs/operators';
 import { of } from 'rxjs';
 
@@ -35,6 +37,7 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   private readonly changeDetector = inject(ChangeDetectorRef);
   private readonly logService = inject(LogService);
   private readonly domService = inject(DomService);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly headerHeight$ = this.domService.headerHeight$;
 
@@ -51,12 +54,12 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   @ViewChild('logTail') logTail!: ElementRef<HTMLElement>;
 
   private pendingScrollToBottom = false;
-  private logsSub!: Subscription;
-  private historySub!: Subscription;
   private readonly searchChange$ = new Subject<void>();
 
   ngOnInit(): void {
-    this.logsSub = this.logService.logs$.subscribe({
+    this.logService.logs$.pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
       next: (record) => {
         const shouldScroll =
           this.elementRef.nativeElement.offsetParent != null &&
@@ -73,7 +76,7 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
       },
     });
 
-    this.historySub = this.searchChange$.pipe(
+    this.searchChange$.pipe(
       debounceTime(300),
       switchMap(() => this.logService.fetchHistory({
         search: this.searchQuery || undefined,
@@ -82,6 +85,7 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
       }).pipe(
         catchError(() => of([] as LogHistoryEntry[]))
       )),
+      takeUntilDestroyed(this.destroyRef),
     ).subscribe((entries) => {
       this.historyRecords = entries;
       this.historyLoaded = true;
@@ -93,8 +97,6 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   ngOnDestroy(): void {
-    this.logsSub?.unsubscribe();
-    this.historySub?.unsubscribe();
     this.searchChange$.complete();
   }
 

--- a/src/angular/src/app/pages/main/header.component.ts
+++ b/src/angular/src/app/pages/main/header.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
 
@@ -23,6 +24,7 @@ export class HeaderComponent implements OnInit {
   private readonly _logger = inject(LoggerService);
   private readonly _serverStatusService = inject(ServerStatusService);
   private readonly _notificationService = inject(NotificationService);
+  private readonly _destroyRef = inject(DestroyRef);
 
   private _prevServerNotification: Notification | null = null;
   private _prevWaitingForRemoteScanNotification: Notification | null = null;
@@ -39,7 +41,9 @@ export class HeaderComponent implements OnInit {
 
   ngOnInit() {
     // Set up a subscriber to show server status notifications
-    this._serverStatusService.status$.subscribe({
+    this._serverStatusService.status$.pipe(
+      takeUntilDestroyed(this._destroyRef),
+    ).subscribe({
       next: status => {
         if (status.server.up) {
           if (this._prevServerNotification != null) {
@@ -67,7 +71,9 @@ export class HeaderComponent implements OnInit {
     });
 
     // Set up a subscriber to show waiting for remote scan notification
-    this._serverStatusService.status$.subscribe({
+    this._serverStatusService.status$.pipe(
+      takeUntilDestroyed(this._destroyRef),
+    ).subscribe({
       next: status => {
         if (status.server.up && status.controller.latestRemoteScanTime == null && !status.controller.noEnabledPairs) {
           if (this._prevWaitingForRemoteScanNotification == null) {
@@ -87,7 +93,9 @@ export class HeaderComponent implements OnInit {
     });
 
     // Set up a subscriber to show remote server error notifications
-    this._serverStatusService.status$.subscribe({
+    this._serverStatusService.status$.pipe(
+      takeUntilDestroyed(this._destroyRef),
+    ).subscribe({
       next: status => {
         if (status.server.up && status.controller.latestRemoteScanFailed === true && !status.controller.noEnabledPairs) {
           const level = NotificationLevel.WARNING;
@@ -113,7 +121,9 @@ export class HeaderComponent implements OnInit {
     });
 
     // Set up a subscriber to show no-enabled-pairs notification
-    this._serverStatusService.status$.subscribe({
+    this._serverStatusService.status$.pipe(
+      takeUntilDestroyed(this._destroyRef),
+    ).subscribe({
       next: status => {
         if (status.server.up && status.controller.noEnabledPairs) {
           if (this._prevNoEnabledPairsNotification == null) {

--- a/src/angular/src/app/pages/main/sidebar.component.ts
+++ b/src/angular/src/app/pages/main/sidebar.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
 import { ROUTE_INFOS } from '../../routes';
@@ -24,15 +25,20 @@ export class SidebarComponent implements OnInit {
   private readonly _connectedService = inject(ConnectedService);
   private readonly _commandService = inject(ServerCommandService);
   private readonly _themeService = inject(ThemeService);
+  private readonly _destroyRef = inject(DestroyRef);
 
   ngOnInit() {
-    this._connectedService.connected$.subscribe({
+    this._connectedService.connected$.pipe(
+      takeUntilDestroyed(this._destroyRef),
+    ).subscribe({
       next: (connected: boolean) => {
         this.commandsEnabled = connected;
       }
     });
 
-    this._themeService.theme$.subscribe({
+    this._themeService.theme$.pipe(
+      takeUntilDestroyed(this._destroyRef),
+    ).subscribe({
       next: (theme: Theme) => {
         this.theme = theme;
       }

--- a/src/angular/src/app/pages/settings/path-pairs.component.ts
+++ b/src/angular/src/app/pages/settings/path-pairs.component.ts
@@ -1,8 +1,9 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, inject, OnDestroy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, DestroyRef, inject, OnDestroy } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { AsyncPipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { EMPTY, Subscription } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 import { PathPairsService } from '../../services/settings/path-pairs.service';
@@ -19,6 +20,7 @@ import { PathPair } from '../../models/path-pair';
 export class PathPairsComponent implements OnDestroy {
   private readonly pathPairsService = inject(PathPairsService);
   private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
   readonly pairs$ = this.pathPairsService.pairs$;
 
   // Inline editing state
@@ -35,13 +37,9 @@ export class PathPairsComponent implements OnDestroy {
   // Double-click delete confirmation
   confirmingDeleteId: string | null = null;
   private confirmResetTimer: ReturnType<typeof setTimeout> | null = null;
-  private subscriptions: Subscription[] = [];
 
   ngOnDestroy(): void {
     this.clearConfirmTimer();
-    this.subscriptions.forEach((s) => {
-      s.unsubscribe();
-    });
   }
 
   // --- Add ---
@@ -62,25 +60,24 @@ export class PathPairsComponent implements OnDestroy {
   onSaveAdd(): void {
     if (!this.addForm.name.trim()) return;
     this.errorMessage = null;
-    this.subscriptions.push(
-      this.pathPairsService.create(this.addForm).pipe(
-        catchError((err: HttpErrorResponse) => {
-          if (err.status === 409) {
-            this.errorMessage = 'A path pair with that name already exists.';
-          }
-          this.cdr.markForCheck();
-          return EMPTY;
-        }),
-      ).subscribe((created) => {
-        if (!created) {
-          this.cdr.markForCheck();
-          return;
+    this.pathPairsService.create(this.addForm).pipe(
+      catchError((err: HttpErrorResponse) => {
+        if (err.status === 409) {
+          this.errorMessage = 'A path pair with that name already exists.';
         }
-        this.adding = false;
-        this.addForm = this.emptyForm();
         this.cdr.markForCheck();
+        return EMPTY;
       }),
-    );
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((created) => {
+      if (!created) {
+        this.cdr.markForCheck();
+        return;
+      }
+      this.adding = false;
+      this.addForm = this.emptyForm();
+      this.cdr.markForCheck();
+    });
   }
 
   // --- Edit ---
@@ -107,25 +104,24 @@ export class PathPairsComponent implements OnDestroy {
   onSaveEdit(): void {
     if (!this.editingId || !this.editForm.name.trim()) return;
     this.errorMessage = null;
-    this.subscriptions.push(
-      this.pathPairsService.update({ id: this.editingId, ...this.editForm }).pipe(
-        catchError((err: HttpErrorResponse) => {
-          if (err.status === 409) {
-            this.errorMessage = 'A path pair with that name already exists.';
-          }
-          this.cdr.markForCheck();
-          return EMPTY;
-        }),
-      ).subscribe((updated) => {
-        if (!updated) {
-          this.cdr.markForCheck();
-          return;
+    this.pathPairsService.update({ id: this.editingId, ...this.editForm }).pipe(
+      catchError((err: HttpErrorResponse) => {
+        if (err.status === 409) {
+          this.errorMessage = 'A path pair with that name already exists.';
         }
-        this.editingId = null;
-        this.editForm = this.emptyForm();
         this.cdr.markForCheck();
+        return EMPTY;
       }),
-    );
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((updated) => {
+      if (!updated) {
+        this.cdr.markForCheck();
+        return;
+      }
+      this.editingId = null;
+      this.editForm = this.emptyForm();
+      this.cdr.markForCheck();
+    });
   }
 
   // --- Delete (double-click confirm) ---
@@ -134,7 +130,9 @@ export class PathPairsComponent implements OnDestroy {
     if (this.confirmingDeleteId === pairId) {
       this.clearConfirmTimer();
       this.confirmingDeleteId = null;
-      this.subscriptions.push(this.pathPairsService.remove(pairId).subscribe());
+      this.pathPairsService.remove(pairId).pipe(
+        takeUntilDestroyed(this.destroyRef),
+      ).subscribe();
     } else {
       this.setConfirming(pairId);
     }
@@ -143,15 +141,15 @@ export class PathPairsComponent implements OnDestroy {
   // --- Toggle fields ---
 
   onToggleEnabled(pair: PathPair, enabled: boolean): void {
-    this.subscriptions.push(
-      this.pathPairsService.update({ ...pair, enabled }).subscribe(),
-    );
+    this.pathPairsService.update({ ...pair, enabled }).pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe();
   }
 
   onToggleAutoQueue(pair: PathPair, autoQueue: boolean): void {
-    this.subscriptions.push(
-      this.pathPairsService.update({ ...pair, auto_queue: autoQueue }).subscribe(),
-    );
+    this.pathPairsService.update({ ...pair, auto_queue: autoQueue }).pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe();
   }
 
   // --- Helpers ---

--- a/src/angular/src/app/pages/settings/settings-page.component.ts
+++ b/src/angular/src/app/pages/settings/settings-page.component.ts
@@ -1,6 +1,7 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { Subscription, distinctUntilChanged, map } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs';
 
 import { LoggerService } from '../../services/utils/logger.service';
 import { ConfigService } from '../../services/settings/config.service';
@@ -36,7 +37,7 @@ import {
   styleUrls: ['./settings-page.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SettingsPageComponent implements OnInit, OnDestroy {
+export class SettingsPageComponent implements OnInit {
   serverContext: IOptionsContext = OPTIONS_CONTEXT_SERVER;
   autoqueueContext: IOptionsContext = OPTIONS_CONTEXT_AUTOQUEUE;
   readonly OPTIONS_CONTEXT_DISCOVERY = OPTIONS_CONTEXT_DISCOVERY;
@@ -57,6 +58,7 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
   private readonly connectedService = inject(ConnectedService);
   private readonly pathPairsService = inject(PathPairsService);
   private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly config$ = this.configService.config$;
 
@@ -67,39 +69,31 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
     Localization.Notification.CONFIG_RESTART,
   );
   private badValueNotifs = new Map<string, Notification>();
-  private subscriptions: Subscription[] = [];
 
   private static readonly OVERRIDE_NOTE = 'Overridden by Path Pairs when any pair is enabled';
 
   ngOnInit(): void {
-    this.subscriptions.push(
-      this.connectedService.connected$.subscribe({
-        next: (connected: boolean) => {
-          if (!connected) {
-            this.notifService.hide(this.configRestartNotif);
-          }
-          this.commandsEnabled = connected;
-          this.cdr.markForCheck();
-        },
-      }),
-    );
-
-    this.subscriptions.push(
-      this.pathPairsService.pairs$.pipe(
-        map((pairs) => pairs.some((p) => p.enabled)),
-        distinctUntilChanged(),
-      ).subscribe((hasEnabledPairs) => {
-        this.serverContext = SettingsPageComponent.buildServerContext(hasEnabledPairs);
-        this.autoqueueContext = SettingsPageComponent.buildAutoqueueContext(hasEnabledPairs);
+    this.connectedService.connected$.pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
+      next: (connected: boolean) => {
+        if (!connected) {
+          this.notifService.hide(this.configRestartNotif);
+        }
+        this.commandsEnabled = connected;
         this.cdr.markForCheck();
-      }),
-    );
-  }
+      },
+    });
 
-  ngOnDestroy(): void {
-    for (const s of this.subscriptions) {
-      s.unsubscribe();
-    }
+    this.pathPairsService.pairs$.pipe(
+      map((pairs) => pairs.some((p) => p.enabled)),
+      distinctUntilChanged(),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((hasEnabledPairs) => {
+      this.serverContext = SettingsPageComponent.buildServerContext(hasEnabledPairs);
+      this.autoqueueContext = SettingsPageComponent.buildAutoqueueContext(hasEnabledPairs);
+      this.cdr.markForCheck();
+    });
   }
 
   private static buildServerContext(hasEnabledPairs: boolean): IOptionsContext {


### PR DESCRIPTION
## Summary
- Converted 6 Angular components from manual `Subscription[]`/`ngOnDestroy` to `takeUntilDestroyed(destroyRef)`
- Fixed 6 memory-leaking subscriptions in HeaderComponent (4) and SidebarComponent (2) that had no cleanup at all
- Removed manual subscription tracking and unnecessary `OnDestroy` implementations

### Components updated
- `PathPairsComponent` — kept `ngOnDestroy` for timer cleanup only
- `LogsPageComponent` — kept `ngOnDestroy` for Subject completion only
- `SettingsPageComponent` — removed `ngOnDestroy` entirely
- `HeaderComponent` — fixed 4 memory leaks
- `SidebarComponent` — fixed 2 memory leaks
- `FileListComponent` — added cleanup to action method subscriptions

Partial fix for #171

## Test plan
- [x] All 182 Vitest tests pass
- [x] All `takeUntilDestroyed` calls pass explicit `destroyRef` (required since subscriptions are in `ngOnInit`, not constructor)
- [x] No unused `Subscription`/`OnDestroy` imports remain
- [x] Components retaining `ngOnDestroy` have non-subscription cleanup (timer, Subject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal lifecycle management across core components to enhance application stability and improve memory efficiency during runtime operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #171