### PR TITLE
Extract shared form template in path-pairs settings component

### DIFF
--- a/src/angular/src/app/pages/settings/path-pairs.component.html
+++ b/src/angular/src/app/pages/settings/path-pairs.component.html
@@ -1,3 +1,31 @@
+<ng-template #pairFormFields let-form="form">
+  <div class="form-row">
+    <label>Name
+      <input type="text" class="form-control form-control-sm" [(ngModel)]="form.name" placeholder="My Pair" />
+    </label>
+  </div>
+  <div class="form-row">
+    <label>Remote Path
+      <input type="text" class="form-control form-control-sm" [(ngModel)]="form.remote_path" placeholder="/remote/path" />
+    </label>
+  </div>
+  <div class="form-row">
+    <label>Local Path
+      <input type="text" class="form-control form-control-sm" [(ngModel)]="form.local_path" placeholder="/local/path" />
+    </label>
+  </div>
+  <div class="form-row toggles">
+    <label class="toggle-label">
+      <input type="checkbox" class="form-check-input" [(ngModel)]="form.enabled" />
+      Enabled
+    </label>
+    <label class="toggle-label">
+      <input type="checkbox" class="form-check-input" [(ngModel)]="form.auto_queue" />
+      Auto Queue
+    </label>
+  </div>
+</ng-template>
+
 <div class="path-pairs">
   <div class="header">
     <span>Path Pairs</span>
@@ -12,31 +40,7 @@
 
   @if (adding) {
     <div class="pair-form">
-      <div class="form-row">
-        <label>Name
-          <input type="text" class="form-control form-control-sm" [(ngModel)]="addForm.name" placeholder="My Pair" />
-        </label>
-      </div>
-      <div class="form-row">
-        <label>Remote Path
-          <input type="text" class="form-control form-control-sm" [(ngModel)]="addForm.remote_path" placeholder="/remote/path" />
-        </label>
-      </div>
-      <div class="form-row">
-        <label>Local Path
-          <input type="text" class="form-control form-control-sm" [(ngModel)]="addForm.local_path" placeholder="/local/path" />
-        </label>
-      </div>
-      <div class="form-row toggles">
-        <label class="toggle-label">
-          <input type="checkbox" class="form-check-input" [(ngModel)]="addForm.enabled" />
-          Enabled
-        </label>
-        <label class="toggle-label">
-          <input type="checkbox" class="form-check-input" [(ngModel)]="addForm.auto_queue" />
-          Auto Queue
-        </label>
-      </div>
+      <ng-container *ngTemplateOutlet="pairFormFields; context: { form: addForm }"></ng-container>
       <div class="form-actions">
         <button class="btn btn-sm btn-save" (click)="onSaveAdd()">Save</button>
         <button class="btn btn-sm btn-cancel" (click)="onCancelAdd()">Cancel</button>
@@ -52,31 +56,7 @@
     @for (pair of pairs; track pair.id) {
       @if (editingId === pair.id) {
         <div class="pair-form">
-          <div class="form-row">
-            <label>Name
-              <input type="text" class="form-control form-control-sm" [(ngModel)]="editForm.name" />
-            </label>
-          </div>
-          <div class="form-row">
-            <label>Remote Path
-              <input type="text" class="form-control form-control-sm" [(ngModel)]="editForm.remote_path" />
-            </label>
-          </div>
-          <div class="form-row">
-            <label>Local Path
-              <input type="text" class="form-control form-control-sm" [(ngModel)]="editForm.local_path" />
-            </label>
-          </div>
-          <div class="form-row toggles">
-            <label class="toggle-label">
-              <input type="checkbox" class="form-check-input" [(ngModel)]="editForm.enabled" />
-              Enabled
-            </label>
-            <label class="toggle-label">
-              <input type="checkbox" class="form-check-input" [(ngModel)]="editForm.auto_queue" />
-              Auto Queue
-            </label>
-          </div>
+          <ng-container *ngTemplateOutlet="pairFormFields; context: { form: editForm }"></ng-container>
           <div class="form-actions">
             <button class="btn btn-sm btn-save" (click)="onSaveEdit()">Save</button>
             <button class="btn btn-sm btn-cancel" (click)="onCancelEdit()">Cancel</button>

--- a/src/angular/src/app/pages/settings/path-pairs.component.ts
+++ b/src/angular/src/app/pages/settings/path-pairs.component.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy, ChangeDetectorRef, inject, OnDestroy } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { EMPTY, Subscription } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -11,7 +11,7 @@ import { PathPair } from '../../models/path-pair';
 @Component({
   selector: 'app-path-pairs',
   standalone: true,
-  imports: [FormsModule, AsyncPipe],
+  imports: [FormsModule, AsyncPipe, NgTemplateOutlet],
   templateUrl: './path-pairs.component.html',
   styleUrls: ['./path-pairs.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Summary
- Extracted 5 duplicated form fields (Name, Remote Path, Local Path, Enabled, Auto Queue) into `<ng-template #pairFormFields>`
- Both add and edit forms now use `*ngTemplateOutlet` with context binding
- Added `NgTemplateOutlet` to component imports
- Reduced template by ~20 lines with no functionality change

Partial fix for #171

## Test plan
- [x] All 182 Vitest tests pass (including 20 path-pairs component tests)
- [x] All form fields preserved with correct `[(ngModel)]` bindings
- [x] Template context bindings verified correct for Angular 21
- [x] No XSS risks (only safe Angular bindings used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicated form field markup in the settings pair configuration interface for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #171