### PR TITLE
Add integration tests for path pairs web handler

### DIFF
--- a/src/python/tests/integration/test_web/test_handler/test_path_pairs.py
+++ b/src/python/tests/integration/test_web/test_handler/test_path_pairs.py
@@ -278,7 +278,7 @@ class TestPathPairsHandler(BaseTestWebApp):
         self.assertEqual(404, resp.status_int)
 
     def test_update_duplicate_name(self):
-        p1 = self._add_pair(name="Movies")
+        self._add_pair(name="Movies")
         p2 = self._add_pair(name="TV", remote_path="/r/tv",
                             local_path="/l/tv")
         data = {"name": "Movies"}


### PR DESCRIPTION
## Summary
- 30 integration tests for the `/server/pathpairs` CRUD endpoint (previously zero coverage)
- Covers: list, create, read, update, delete with full validation
- Edge cases: missing/empty fields, duplicate names, invalid JSON, special characters in paths, boolean defaults, partial updates

Contributes to #225

## Test plan
- [x] 30 integration tests following existing `BaseTestWebApp` patterns
- [x] All HTTP status codes verified (200, 201, 204, 400, 404, 409)
- [x] Full CRUD round-trip test (create → list → update → delete → verify empty)
- [x] No unused imports, clean code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive integration test coverage for PathPairs API endpoints, including validation, error handling, and edge case scenarios across all CRUD operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->