### PR TITLE
Fix FD leak on restart causing OSError (#228 regression)

### DIFF
--- a/src/python/common/app_process.py
+++ b/src/python/common/app_process.py
@@ -113,6 +113,15 @@ class AppProcess(Process):
 
         super().terminate()
 
+    def close_queues(self):
+        """Close multiprocessing queues to prevent file descriptor leaks.
+
+        Must be called after the process has been joined. Subclasses should
+        override to close their own queues and call super().
+        """
+        self.__exception_queue.close()
+        self.__exception_queue.join_thread()
+
     def propagate_exception(self):
         """
         Raises any exception that was caught by the process

--- a/src/python/common/multiprocessing_logger.py
+++ b/src/python/common/multiprocessing_logger.py
@@ -44,6 +44,8 @@ class MultiprocessingLogger:
     def stop(self):
         self.__listener_shutdown.set()
         self.__listener.join()
+        self.__queue.close()
+        self.__queue.join_thread()
 
     def propagate_exception(self):
         """

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -432,12 +432,37 @@ class Controller:
                 pc.local_scan_process.terminate()
                 pc.remote_scan_process.terminate()
             self.__extract_process.terminate()
+            for cp in self.__active_command_processes:
+                cp.process.terminate()
+            for mp in self.__active_move_processes:
+                mp.terminate()
             for pc in self.__pair_contexts:
                 pc.active_scan_process.join()
                 pc.local_scan_process.join()
                 pc.remote_scan_process.join()
             self.__extract_process.join()
+            for cp in self.__active_command_processes:
+                cp.process.join()
+            for mp in self.__active_move_processes:
+                mp.join()
             self.__mp_logger.stop()
+
+            # Close multiprocessing queues to release file descriptors.
+            # Without this, each restart cycle leaks FDs until the OS limit
+            # is exhausted (OSError: [Errno 24] No file descriptors available).
+            for pc in self.__pair_contexts:
+                pc.active_scan_process.close_queues()
+                pc.local_scan_process.close_queues()
+                pc.remote_scan_process.close_queues()
+                pc.active_scanner.close()
+            self.__extract_process.close_queues()
+            for cp in self.__active_command_processes:
+                cp.process.close_queues()
+            for mp in self.__active_move_processes:
+                mp.close_queues()
+            self.__active_command_processes.clear()
+            self.__active_move_processes.clear()
+
             self.__started = False
             self.logger.info("Exited controller")
 

--- a/src/python/controller/extract/extract_process.py
+++ b/src/python/controller/extract/extract_process.py
@@ -120,6 +120,18 @@ class ExtractProcess(AppProcess):
 
         time.sleep(ExtractProcess.__DEFAULT_SLEEP_INTERVAL_IN_SECS)
 
+    @overrides(AppProcess)
+    def close_queues(self):
+        self.__command_queue.close()
+        self.__command_queue.join_thread()
+        self.__status_result_queue.close()
+        self.__status_result_queue.join_thread()
+        self.__completed_result_queue.close()
+        self.__completed_result_queue.join_thread()
+        self.__failed_result_queue.close()
+        self.__failed_result_queue.join_thread()
+        super().close_queues()
+
     def extract(self, req: ExtractRequest):
         """
         Process-safe method to queue an extraction

--- a/src/python/controller/scan/active_scanner.py
+++ b/src/python/controller/scan/active_scanner.py
@@ -35,6 +35,11 @@ class ActiveScanner(IScanner):
         """
         self.__active_files_queue.put(file_names)
 
+    def close(self):
+        """Close multiprocessing resources."""
+        self.__active_files_queue.close()
+        self.__active_files_queue.join_thread()
+
     @overrides(IScanner)
     def scan(self) -> List[SystemFile]:
         # Grab the latest list of active files, if any

--- a/src/python/controller/scan/scanner_process.py
+++ b/src/python/controller/scan/scanner_process.py
@@ -125,6 +125,12 @@ class ScannerProcess(AppProcess):
             pass
         return latest_scan
 
+    @overrides(AppProcess)
+    def close_queues(self):
+        self.__queue.close()
+        self.__queue.join_thread()
+        super().close_queues()
+
     def force_scan(self):
         """Force process to wake and do an immediate scan"""
         self.__wake_event.set()

--- a/src/python/tests/unittests/test_controller/test_extract/test_extract_process.py
+++ b/src/python/tests/unittests/test_controller/test_extract/test_extract_process.py
@@ -177,3 +177,9 @@ class TestExtractProcess(unittest.TestCase):
         self.assertEqual("c", call_2.model_file.name)
         self.assertEqual(False, call_2.model_file.is_dir)
         self.assertEqual(1234, call_2.model_file.local_size)
+
+    def test_close_queues_releases_resources(self):
+        self.process.run_init()
+        self.process.run_loop()
+        # close_queues() should not raise
+        self.process.close_queues()

--- a/src/python/tests/unittests/test_controller/test_scan/test_scanner_process.py
+++ b/src/python/tests/unittests/test_controller/test_scan/test_scanner_process.py
@@ -226,3 +226,30 @@ class TestScannerProcessSpawned(unittest.TestCase):
         with self.assertRaises(ScannerError) as ctx:
             process.propagate_exception()
         self.assertEqual("fatal-from-child", str(ctx.exception))
+
+    def test_close_queues_releases_resources(self):
+        """Verify close_queues() can be called after join without error."""
+        files = [SystemFile("test.txt", 10, False)]
+        scanner = PicklableScanner(files=files)
+        process = ScannerProcess(scanner=scanner, interval_in_ms=50)
+
+        log_queue = multiprocessing.Queue()
+        process.set_mp_log_queue(log_queue, logging.DEBUG)
+
+        process.start()
+
+        # Wait for at least one result
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if process.pop_latest_result() is not None:
+                break
+            time.sleep(0.05)
+
+        process.terminate()
+        process.join(timeout=5)
+        self.assertFalse(process.is_alive())
+
+        # close_queues() should not raise
+        process.close_queues()
+        log_queue.close()
+        log_queue.join_thread()


### PR DESCRIPTION
## Summary

- **Root cause**: `multiprocessing.Queue` objects (pipes + semaphores) were never explicitly closed during controller shutdown. With the spawn migration (#232), each restart cycle leaked ~60 file descriptors until the container's OS limit was exhausted.
- **Symptom**: Second restart attempt crashes with `OSError: [Errno 24] No file descriptors available`, killing the process. The container auto-restarts but the UI shows stale data until manual page refresh.
- **Fix**: Add `close_queues()` method to `AppProcess`, `ScannerProcess`, and `ExtractProcess`. Close `ActiveScanner`'s queue and `MultiprocessingLogger`'s queue during shutdown. Also terminate/join/close any in-flight command and move processes.

### Files changed

| File | Change |
|------|--------|
| `common/app_process.py` | Add `close_queues()` base method |
| `controller/scan/scanner_process.py` | Override `close_queues()` to close result queue |
| `controller/extract/extract_process.py` | Override `close_queues()` to close 4 queues |
| `controller/scan/active_scanner.py` | Add `close()` for active files queue |
| `common/multiprocessing_logger.py` | Close queue in `stop()` |
| `controller/controller.py` | Call `close_queues()` after joining all processes; also terminate/join/close command and move processes |
| Test files | Add `test_close_queues_releases_resources` for scanner and extract processes |

## Test plan

- [x] All 22 affected unit tests pass (scanner, extract, multiprocessing logger, app process)
- [x] Full test suite: 489 passed (failures are pre-existing SSH/LFTP infra tests)
- [ ] Deploy to Docker and verify restart button works repeatedly
- [ ] Verify SSE stream reconnects and UI updates after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced resource cleanup procedures to prevent file descriptor leaks during process termination and system restarts, improving overall stability.

* **Tests**
  * Added tests validating proper resource cleanup behavior across multiprocessing components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->