### PR TITLE
Convert file action buttons to native button elements (#241)

### DIFF
--- a/src/angular/src/app/pages/files/file.component.html
+++ b/src/angular/src/app/pages/files/file.component.html
@@ -47,16 +47,16 @@
         </div>
         <div class="name">
             @if (!file().isDir && !file().isArchive) {
-                <img src="assets/icons/file-light.svg" />
+                <img src="assets/icons/file-light.svg" alt="" aria-hidden="true" />
             }
             @if (!file().isDir && file().isArchive) {
-                <img src="assets/icons/file-archive-light.svg" />
+                <img src="assets/icons/file-archive-light.svg" alt="" aria-hidden="true" />
             }
             @if (file().isDir && !file().isArchive) {
-                <img src="assets/icons/directory-light.svg" />
+                <img src="assets/icons/directory-light.svg" alt="" aria-hidden="true" />
             }
             @if (file().isDir && file().isArchive) {
-                <img src="assets/icons/directory-archive-light.svg" />
+                <img src="assets/icons/directory-archive-light.svg" alt="" aria-hidden="true" />
             }
             <div class="text">
                 <div class="title">
@@ -134,51 +134,51 @@
              [disabled]="!isQueueable()"
              (click)="onQueue(file())"
              [class.loading]="activeAction === FileAction.QUEUE">
-            <div class="loader"></div>
-            <img src="assets/icons/queue.svg" />
-            <div class="text"><span>Queue</span></div>
+            <span class="loader"></span>
+            <img src="assets/icons/queue.svg" alt="" aria-hidden="true" />
+            <span class="text">Queue</span>
         </button>
         <button type="button" class="button" appClickStopPropagation
              [disabled]="!isStoppable()"
              (click)="onStop(file())"
              [class.loading]="activeAction === FileAction.STOP">
-            <div class="loader"></div>
-            <img src="assets/icons/stop.svg" />
-            <div class="text"><span>Stop</span></div>
+            <span class="loader"></span>
+            <img src="assets/icons/stop.svg" alt="" aria-hidden="true" />
+            <span class="text">Stop</span>
         </button>
         <button type="button" class="button" appClickStopPropagation
              [disabled]="!isExtractable()"
              (click)="onExtract(file())"
              [class.loading]="activeAction === FileAction.EXTRACT">
-            <div class="loader"></div>
-            <img src="assets/icons/extract.svg" />
-            <div class="text"><span>Extract</span></div>
+            <span class="loader"></span>
+            <img src="assets/icons/extract.svg" alt="" aria-hidden="true" />
+            <span class="text">Extract</span>
         </button>
         <button type="button" class="button" appClickStopPropagation
              [disabled]="!isValidatable()"
              (click)="onValidate(file())"
              [class.loading]="activeAction === FileAction.VALIDATE">
-            <div class="loader"></div>
+            <span class="loader"></span>
             <img src="assets/icons/validate.svg" alt="" aria-hidden="true" />
-            <div class="text"><span>Validate</span></div>
+            <span class="text">Validate</span>
         </button>
         <button type="button" class="button" appClickStopPropagation
              [disabled]="!isLocallyDeletable()"
              (click)="onDeleteLocal(file())"
              [class.loading]="activeAction === FileAction.DELETE_LOCAL"
              [class.confirming]="confirmingDelete === 'local'">
-            <div class="loader"></div>
-            <img src="assets/icons/delete-local.svg" />
-            <div class="text"><span>{{ confirmingDelete === 'local' ? 'Confirm?' : 'Delete Local' }}</span></div>
+            <span class="loader"></span>
+            <img src="assets/icons/delete-local.svg" alt="" aria-hidden="true" />
+            <span class="text">{{ confirmingDelete === 'local' ? 'Confirm?' : 'Delete Local' }}</span>
         </button>
         <button type="button" class="button" appClickStopPropagation
              [disabled]="!isRemotelyDeletable()"
              (click)="onDeleteRemote(file())"
              [class.loading]="activeAction === FileAction.DELETE_REMOTE"
              [class.confirming]="confirmingDelete === 'remote'">
-            <div class="loader"></div>
-            <img src="assets/icons/delete-remote.svg" />
-            <div class="text"><span>{{ confirmingDelete === 'remote' ? 'Confirm?' : 'Delete Remote' }}</span></div>
+            <span class="loader"></span>
+            <img src="assets/icons/delete-remote.svg" alt="" aria-hidden="true" />
+            <span class="text">{{ confirmingDelete === 'remote' ? 'Confirm?' : 'Delete Remote' }}</span>
         </button>
     </div>
 </div>

--- a/src/angular/src/app/pages/files/file.component.scss
+++ b/src/angular/src/app/pages/files/file.component.scss
@@ -160,15 +160,11 @@
     .text {
         height: 25px;
         display: flex;
-        flex-direction: column;
         align-items: center;
         justify-content: center;
-
-        span {
-            font-size: 12px;
-            text-align: center;
-            line-height: 12px;
-        }
+        font-size: 12px;
+        text-align: center;
+        line-height: 12px;
     }
 
     img {


### PR DESCRIPTION
## Summary
- Convert all 6 action buttons (Queue, Stop, Extract, Validate, Delete Local, Delete Remote) from `<div>` to `<button type="button">` elements
- Replace `[attr.disabled]="isXxx() ? null : true"` with native `[disabled]="!isXxx()"`
- Remove manual click guards (`!isXxx() || onXxx(file())`) — native disabled prevents clicks
- Add button reset styles (padding, font, appearance) to preserve existing visual appearance

Closes #241

## Test plan
- [ ] All action buttons are keyboard accessible (Tab to focus, Enter/Space to activate)
- [ ] Disabled buttons are not activatable via keyboard or click
- [ ] Visual appearance is unchanged from current div-based buttons
- [x] All 225 Vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved the accessibility and semantic structure of action buttons by enhancing their implementation with proper disabled state handling.
  * Refined button styling to ensure consistent appearance and user interaction feedback across the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->