### PR TITLE
Fix CI: add missing xfer_verify to test config helper

### DIFF
--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -65,6 +65,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
       enabled: false,
       algorithm: "md5",
       auto_validate: false,
+      xfer_verify: false,
     },
     ...overrides,
   };


### PR DESCRIPTION
## Summary

- The `makeConfig()` helper in `config.service.spec.ts` was missing the `xfer_verify` field that was added to the `Validate` interface when the xfer-verify feature was merged
- This caused a `TS2741` build error in CI on every push to `develop`

## Test plan

- [x] All 278 Angular unit tests pass locally
- [x] CI should go green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)