### PR TITLE
Fix file descriptor leak on restart (#265)

### DIFF
--- a/src/python/common/app_process.py
+++ b/src/python/common/app_process.py
@@ -99,6 +99,9 @@ class AppProcess(Process):
     @overrides(Process)
     def terminate(self):
         # Send a terminate signal, and force terminate after a timeout
+        # Guard against None: close_queues() clears this reference
+        if self._terminate is None:
+            return
         self._terminate.set()
 
         def elapsed_ms(start):


### PR DESCRIPTION
## Summary

- **Fix FD leak in `AppProcess.close_queues()`**: After a process is joined, the `_terminate` Event and `_mp_log_queue` references were still held, preventing GC from reclaiming their underlying semaphore file descriptors. On each `ServiceRestart` cycle, new `Seedsync` instances accumulated leaked FDs.
- Clear both references (`self._terminate = None`, `self._mp_log_queue = None`) in `close_queues()` so GC can release the semaphores.

Closes #265

## Test plan

- [x] Existing `test_close_queues_releases_resources` in `test_scanner_process.py` exercises the updated `close_queues()` path
- [ ] Verify no regressions in Python unit tests (`pytest` in Docker test-image)
- [ ] Manual: trigger a `ServiceRestart` and confirm `/proc/<pid>/fd` count does not grow across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved shutdown cleanup to release multiprocessing resources and avoid errors during termination, reducing potential resource leaks and ensuring safer application shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->