### PR TITLE
Expose verbose logging setting in web UI (#266)

### DIFF
--- a/src/angular/src/app/models/config.ts
+++ b/src/angular/src/app/models/config.ts
@@ -5,6 +5,7 @@
 
 export interface General {
   debug: boolean | null;
+  verbose: boolean | null;
   exclude_patterns: string | null;
 }
 
@@ -87,6 +88,7 @@ export interface Config {
 
 export const DEFAULT_GENERAL: General = {
   debug: null,
+  verbose: null,
   exclude_patterns: null,
 };
 

--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -308,6 +308,12 @@ export const OPTIONS_CONTEXT_LOGGING: IOptionsContext = {
       description: 'Enables debug logging',
     },
     {
+      type: OptionType.Checkbox,
+      label: 'Verbose LFTP Logging',
+      valuePath: ['general', 'verbose'],
+      description: 'Log all LFTP command output. Requires debug mode enabled.',
+    },
+    {
       type: OptionType.Select,
       label: 'Log Format',
       valuePath: ['logging', 'log_format'],

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -12,7 +12,7 @@ import { Config } from "../../models/config";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
-    general: { debug: false, exclude_patterns: "" },
+    general: { debug: false, verbose: false, exclude_patterns: "" },
     lftp: {
       remote_address: "host",
       remote_username: "user",


### PR DESCRIPTION
## Summary
- Add `verbose` checkbox to the Logging settings section in the web UI, placed after the existing Debug checkbox
- Add `verbose: boolean | null` to the `General` TypeScript interface and its default constant
- Update `makeConfig()` test helper to include `verbose` field

Closes #266

## Test plan
- [x] All 278 Vitest unit tests pass
- [ ] Verify the Verbose LFTP Logging checkbox appears in Settings > Logging in the browser
- [ ] Toggle the checkbox and confirm the setting persists after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Verbose LFTP Logging" option in settings to enable detailed logging of all LFTP command output when debug mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->