### PR TITLE
Fix pending_completion stuck for stopped downloads deleted locally

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -731,7 +731,13 @@ class Controller:
                         diff.new_file.name in pc.pending_completion:
                     use_staging = self.__context.config.controller.use_staging and \
                                   self.__context.config.controller.staging_path
-                    if use_staging:
+                    # A file with no local presence and DEFAULT state means
+                    # it was deleted locally (e.g. stopped download whose files
+                    # were removed). Nothing left to track.
+                    if diff.new_file.state == ModelFile.State.DEFAULT and \
+                            diff.new_file.local_size is None:
+                        pc.pending_completion.discard(diff.new_file.name)
+                    elif use_staging:
                         move_key = _persist_key(diff.new_file.pair_id, diff.new_file.name)
                         if move_key in self.__moved_file_keys:
                             pc.pending_completion.discard(diff.new_file.name)


### PR DESCRIPTION
## Summary

- Fix `pending_completion` never clearing when a stopped download's local files are deleted with `auto_delete_remote` enabled
- Adds early exit: when file is `DEFAULT` with `local_size=None`, clear from `pending_completion` since there's nothing left to track
- Stops ActiveScanner from polling non-existent paths indefinitely

## Root Cause

When an LFTP job disappears (stop or completion), the file enters `pending_completion`. Exit conditions only check for terminal states (`DOWNLOADED`, `DELETED`, etc.). But with `auto_delete_remote=True` and remote still present, the model builder skips persist authority, leaving the file in `DEFAULT` — which wasn't an exit condition. Result: ActiveScanner polls forever.

## Test plan

- [ ] Stop a downloading file, then delete its local files — verify spinner clears and ActiveScanner stops polling
- [ ] Verify normal download completion still works (file transitions through DOWNLOADED → EXTRACTED etc.)
- [ ] Verify with both staging enabled and disabled

Fixes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of locally-deleted files by adding validation checks to prevent errors when the system attempts to process or move files that have been deleted locally but remain in the tracking system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->