### PR TITLE
Fix model builder cache not invalidating when active files clear

### DIFF
--- a/src/python/controller/model_builder.py
+++ b/src/python/controller/model_builder.py
@@ -44,9 +44,12 @@ class ModelBuilder:
         self.logger = base_logger.getChild("ModelBuilder")
 
     def set_active_files(self, active_files: List[SystemFile]):
+        prev_active_files = self.__active_files
         self.__active_files = {file.name: file for file in active_files}
         # Always invalidate when active files present (sizes change rapidly)
-        if len(active_files) > 0:
+        # Also invalidate when active files change (e.g. files removed after
+        # a stopped download is deleted locally)
+        if len(active_files) > 0 or self.__active_files != prev_active_files:
             self.__cached_model = None
 
     def set_local_files(self, local_files: List[SystemFile]):

--- a/src/python/tests/unittests/test_controller/test_model_builder.py
+++ b/src/python/tests/unittests/test_controller/test_model_builder.py
@@ -557,9 +557,8 @@ class TestModelBuilder(unittest.TestCase):
         model = self.model_builder.build_model()
         self.assertEqual(99, model.get_file("a").local_size)
 
-    def test_build_downloading_state_is_retained(self):
-        # downloading files latest info should be retained even after
-        # they have stopped downloading
+    def test_build_downloading_falls_back_to_local_when_active_clears(self):
+        # When active files are present, they override local sizes
         self.model_builder.set_local_files([SystemFile("a", 42, False)])
         self.model_builder.set_active_files([SystemFile("a", 99, False)])
         s = LftpJobStatus(0, LftpJobStatus.Type.PGET, LftpJobStatus.State.RUNNING, "a", "")
@@ -568,13 +567,13 @@ class TestModelBuilder(unittest.TestCase):
         model = self.model_builder.build_model()
         self.assertEqual(99, model.get_file("a").local_size)
 
-        # set active files to empty
+        # When active files clear, model falls back to local scan data
         self.model_builder.set_active_files([])
         s = LftpJobStatus(0, LftpJobStatus.Type.PGET, LftpJobStatus.State.RUNNING, "a", "")
         s.total_transfer_state = LftpJobStatus.TransferState(12345, 1000, 0.25, None, None)
         self.model_builder.set_lftp_statuses([s])
         model = self.model_builder.build_model()
-        self.assertEqual(99, model.get_file("a").local_size)
+        self.assertEqual(42, model.get_file("a").local_size)
 
     def test_build_downloading_speed(self):
         s = LftpJobStatus(0, LftpJobStatus.Type.PGET, LftpJobStatus.State.RUNNING, "a", "")
@@ -1549,7 +1548,13 @@ class TestModelBuilder(unittest.TestCase):
         self.assertTrue(self.model_builder.has_changes())
         self.model_builder.build_model()
 
-        # Does not invalidate on empty active files
+        # Invalidates when active files go from non-empty to empty
+        # (e.g. stopped download deleted locally — active scan returns nothing)
+        self.model_builder.set_active_files([])
+        self.assertTrue(self.model_builder.has_changes())
+        self.model_builder.build_model()
+
+        # Does not invalidate on repeated empty active files
         self.model_builder.set_active_files([])
         self.assertFalse(self.model_builder.has_changes())
 


### PR DESCRIPTION
## Summary

- Fix `set_active_files` in `ModelBuilder` to invalidate cache when active files change (not just when non-empty)
- This was the missing piece preventing PR #272's `pending_completion` fix from working

## Root Cause

PR #272 added code to clear `pending_completion` when a file is `DEFAULT` with `local_size=None`. But that check only runs when a model diff fires. The diff never fired because `set_active_files([])` (empty result from ActiveScanner scanning a deleted path) did NOT invalidate the model builder cache. The model stayed cached with stale `local_size > 0` from the previous active scan, so no diff was generated.

## Fix

Change `set_active_files` to also invalidate when the active files dict changes (goes from non-empty to empty), matching the pattern used by `set_local_files`, `set_remote_files`, etc.

## Test plan

- [x] Updated `test_rebuild_on_active_files` — cache invalidates when active files go non-empty → empty
- [x] Added check: repeated empty calls do NOT invalidate (no unnecessary rebuilds)  
- [x] Updated `test_build_downloading_falls_back_to_local_when_active_clears` — model correctly falls back to local scan size when active files clear
- [x] All 66 model builder tests pass
- [ ] Deploy and verify: stop a download, delete local files — spinner clears, ActiveScanner stops

Fixes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cache consistency by properly invalidating cached data when active files are added, removed, or reordered.
  * Fixed fallback mechanism to use local file scan data when active file transfers are cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->