### PR TITLE
Improve integrity check settings clarity and validate button UX

### DIFF
--- a/src/angular/src/app/models/view-file.ts
+++ b/src/angular/src/app/models/view-file.ts
@@ -23,6 +23,7 @@ export interface ViewFile {
   isLocallyDeletable: boolean;
   isRemotelyDeletable: boolean;
   isValidatable: boolean;
+  validateTooltip: string | null;
   localCreatedTimestamp: Date | null;
   localModifiedTimestamp: Date | null;
   remoteCreatedTimestamp: Date | null;

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -53,6 +53,7 @@ function makeViewFile(overrides: Partial<ViewFile> = {}): ViewFile {
     isLocallyDeletable: false,
     isRemotelyDeletable: true,
     isValidatable: false,
+    validateTooltip: null,
     localCreatedTimestamp: null,
     localModifiedTimestamp: null,
     remoteCreatedTimestamp: null,

--- a/src/angular/src/app/pages/files/file.component.html
+++ b/src/angular/src/app/pages/files/file.component.html
@@ -156,6 +156,7 @@
         </button>
         <button type="button" class="button" appClickStopPropagation
              [disabled]="!isValidatable()"
+             [title]="file().validateTooltip ?? ''"
              (click)="onValidate(file())"
              [class.loading]="activeAction === FileAction.VALIDATE">
             <span class="loader"></span>

--- a/src/angular/src/app/pages/files/file.component.spec.ts
+++ b/src/angular/src/app/pages/files/file.component.spec.ts
@@ -27,6 +27,7 @@ function makeViewFile(overrides: Partial<ViewFile> = {}): ViewFile {
     isLocallyDeletable: true,
     isRemotelyDeletable: true,
     isValidatable: false,
+    validateTooltip: null,
     localCreatedTimestamp: null,
     localModifiedTimestamp: null,
     remoteCreatedTimestamp: null,

--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -366,31 +366,32 @@ export const OPTIONS_CONTEXT_VALIDATE: IOptionsContext = {
   options: [
     {
       type: OptionType.Checkbox,
-      label: 'Enable integrity checking',
+      label: 'Verify transfers inline (recommended)',
+      valuePath: ['validate', 'xfer_verify'],
+      description:
+        'Have LFTP verify checksums during transfer. Works independently of the settings below.\n' +
+        '(xfer:verify)',
+    },
+    {
+      type: OptionType.Checkbox,
+      label: 'Enable post-download validation',
       valuePath: ['validate', 'enabled'],
-      description: 'Verify file checksums after download by comparing local and remote hashes',
+      description:
+        'Allow manual and automatic validation of downloaded files by comparing local and remote checksums via SSH. ' +
+        'Not available when auto-remote delete is enabled.',
     },
     {
       type: OptionType.Checkbox,
       label: 'Auto-validate after download',
       valuePath: ['validate', 'auto_validate'],
-      description: 'Automatically validate files when download completes',
+      description: 'Automatically validate files when download completes. Requires post-download validation above.',
     },
     {
       type: OptionType.Select,
       label: 'Hash Algorithm',
       valuePath: ['validate', 'algorithm'],
-      description: 'Checksum algorithm used for integrity verification',
+      description: 'Checksum algorithm used for post-download validation',
       choices: ['md5', 'sha1', 'sha256'],
-    },
-    {
-      type: OptionType.Checkbox,
-      label: 'Verify transfers inline (recommended)',
-      valuePath: ['validate', 'xfer_verify'],
-      description:
-        'Verify file checksums during transfer using lftp xfer:verify. ' +
-        'Uses the selected hash algorithm above.\n' +
-        '(xfer:verify)',
     },
   ],
 };

--- a/src/angular/src/app/pages/settings/settings-page.component.html
+++ b/src/angular/src/app/pages/settings/settings-page.component.html
@@ -22,7 +22,7 @@
       </ng-container>
 
       <ng-container
-        *ngTemplateOutlet="optionsList; context: OPTIONS_CONTEXT_VALIDATE">
+        *ngTemplateOutlet="optionsList; context: validateContext">
       </ng-container>
 
       <ng-container

--- a/src/angular/src/app/pages/settings/settings-page.component.ts
+++ b/src/angular/src/app/pages/settings/settings-page.component.ts
@@ -41,12 +41,12 @@ import {
 export class SettingsPageComponent implements OnInit {
   serverContext: IOptionsContext = OPTIONS_CONTEXT_SERVER;
   autoqueueContext: IOptionsContext = OPTIONS_CONTEXT_AUTOQUEUE;
+  validateContext: IOptionsContext = OPTIONS_CONTEXT_VALIDATE;
   readonly OPTIONS_CONTEXT_DISCOVERY = OPTIONS_CONTEXT_DISCOVERY;
   readonly OPTIONS_CONTEXT_CONNECTIONS = OPTIONS_CONTEXT_CONNECTIONS;
   readonly OPTIONS_CONTEXT_OTHER = OPTIONS_CONTEXT_OTHER;
   readonly OPTIONS_CONTEXT_STAGING = OPTIONS_CONTEXT_STAGING;
   readonly OPTIONS_CONTEXT_EXTRACT = OPTIONS_CONTEXT_EXTRACT;
-  readonly OPTIONS_CONTEXT_VALIDATE = OPTIONS_CONTEXT_VALIDATE;
   readonly OPTIONS_CONTEXT_ADVANCED_LFTP = OPTIONS_CONTEXT_ADVANCED_LFTP;
   readonly OPTIONS_CONTEXT_LOGGING = OPTIONS_CONTEXT_LOGGING;
   readonly OPTIONS_CONTEXT_NOTIFICATIONS = OPTIONS_CONTEXT_NOTIFICATIONS;
@@ -96,6 +96,15 @@ export class SettingsPageComponent implements OnInit {
       this.autoqueueContext = SettingsPageComponent.buildAutoqueueContext(hasEnabledPairs);
       this.cdr.markForCheck();
     });
+
+    this.configService.config$.pipe(
+      map((config) => config?.validate?.enabled ?? false),
+      distinctUntilChanged(),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((validateEnabled) => {
+      this.validateContext = SettingsPageComponent.buildValidateContext(validateEnabled);
+      this.cdr.markForCheck();
+    });
   }
 
   private static buildServerContext(hasEnabledPairs: boolean): IOptionsContext {
@@ -116,6 +125,18 @@ export class SettingsPageComponent implements OnInit {
       options: OPTIONS_CONTEXT_AUTOQUEUE.options.map((option) => {
         if (hasEnabledPairs && option.valuePath[1] === 'enabled') {
           return { ...option, description: SettingsPageComponent.OVERRIDE_NOTE, disabled: true };
+        }
+        return option;
+      }),
+    };
+  }
+
+  private static buildValidateContext(validateEnabled: boolean): IOptionsContext {
+    return {
+      ...OPTIONS_CONTEXT_VALIDATE,
+      options: OPTIONS_CONTEXT_VALIDATE.options.map((option) => {
+        if (!validateEnabled && (option.valuePath[1] === 'auto_validate' || option.valuePath[1] === 'algorithm')) {
+          return { ...option, disabled: true };
         }
         return option;
       }),

--- a/src/angular/src/app/services/files/view-file.service.ts
+++ b/src/angular/src/app/services/files/view-file.service.ts
@@ -453,14 +453,20 @@ function createViewFile(modelFile: ModelFile, pairNameMap: Map<string, string>, 
       ViewFileStatus.CORRUPT,
       ViewFileStatus.DELETED,
     ].includes(status) && remoteSize > 0;
+  const validatableStatuses = [
+    ViewFileStatus.DOWNLOADED,
+    ViewFileStatus.EXTRACTED,
+    ViewFileStatus.EXTRACT_FAILED,
+    ViewFileStatus.VALIDATED,
+    ViewFileStatus.CORRUPT,
+  ];
   const isValidatable =
-    [
-      ViewFileStatus.DOWNLOADED,
-      ViewFileStatus.EXTRACTED,
-      ViewFileStatus.EXTRACT_FAILED,
-      ViewFileStatus.VALIDATED,
-      ViewFileStatus.CORRUPT,
-    ].includes(status) && modelFile.local_size != null && modelFile.remote_size != null;
+    validatableStatuses.includes(status) && modelFile.local_size != null && modelFile.remote_size != null;
+
+  let validateTooltip: string | null = null;
+  if (!isValidatable && validatableStatuses.includes(status) && modelFile.remote_size == null) {
+    validateTooltip = 'Remote file not available for checksum comparison';
+  }
 
   return {
     name: modelFile.name,
@@ -483,6 +489,7 @@ function createViewFile(modelFile: ModelFile, pairNameMap: Map<string, string>, 
     isLocallyDeletable,
     isRemotelyDeletable,
     isValidatable,
+    validateTooltip,
     localCreatedTimestamp: modelFile.local_created_timestamp,
     localModifiedTimestamp: modelFile.local_modified_timestamp,
     remoteCreatedTimestamp: modelFile.remote_created_timestamp,


### PR DESCRIPTION
## Summary

- **Reorder settings**: Move "Verify transfers inline" to top of Integrity Check section with description clarifying it works independently of post-download validation
- **Rename and clarify**: Rename "Enable integrity checking" to "Enable post-download validation" with note about auto-remote delete incompatibility
- **Dynamic disable**: Grey out "Auto-validate after download" and "Hash Algorithm" when post-download validation is disabled
- **Validate button tooltip**: Show "Remote file not available for checksum comparison" on hover when the remote file has been deleted

## Test plan

- [x] All 278 Angular Vitest tests pass
- [ ] Verify settings page: toggle "Enable post-download validation" off and confirm auto-validate and algorithm are greyed out
- [ ] Verify settings page: "Verify transfers inline" appears first and is always enabled regardless of post-download validation toggle
- [ ] Verify file list: hover over disabled Validate button on a file with deleted remote and confirm tooltip appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added verbose LFTP logging option to settings
  * Added validation status tooltips in file interface

* **Bug Fixes**
  * Fixed file descriptor leakage on restart
  * Improved post-download validation handling and status detection

* **Infrastructure**
  * Docker image now Alpine-only; Debian variant removed

* **Documentation**
  * Version 0.14.0 released with updated installation guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->