### PR TITLE
Fix parser crash on chunk line-wrap from long filenames

### DIFF
--- a/src/python/lftp/job_status_parser.py
+++ b/src/python/lftp/job_status_parser.py
@@ -244,6 +244,23 @@ class LftpJobStatusParser:
         ).format(eta=LftpJobStatusParser.__TIME_UNITS_REGEX)
         partial_progress_m = re.compile(partial_progress_pattern)
 
+        # Chunk line-wrap fragments: long filenames cause lftp chunk progress
+        # lines to wrap, producing a tail fragment like:
+        #   "tmos.7.1.DV.HDR.H.265-TheFarm.mkv' at 22283455338 (0%) 427.6K/s eta:28m [Receiving data]"
+        # These are the tail of a `filename' at <pos> (<pct>%) ... line where
+        # the leading backtick and start of the filename are on the previous line.
+        chunk_wrap_pattern = (
+            r"^(?:[^`\\].*)?'\s+at\s+\d+\s+"
+            r"(?:\(\d+%\)\s+)?"
+            r"(?:(?:\d+\.?\d*\s?({sz}))\/s\s+)?"
+            r"(?:eta:({eta})\s+)?"
+            r"\s*\[.*\]$"
+        ).format(
+            sz=LftpJobStatusParser.__SIZE_UNITS_REGEX,
+            eta=LftpJobStatusParser.__TIME_UNITS_REGEX,
+        )
+        chunk_wrap_m = re.compile(chunk_wrap_pattern)
+
         prev_job = None
         while lines:
             line = lines.pop(0)
@@ -254,7 +271,7 @@ class LftpJobStatusParser:
             if not (
                 prev_job or pget_header_m.match(line) or mirror_header_m.match(line) or mirror_fl_header_m.match(line)
             ):
-                if orphan_progress_m.match(line) or partial_progress_m.match(line):
+                if orphan_progress_m.match(line) or partial_progress_m.match(line) or chunk_wrap_m.match(line):
                     self.logger.warning("Skipping orphan lftp progress line: '%s'", line)
                     continue
                 raise ValueError("First line is not a matching header '{}'".format(line))
@@ -502,7 +519,7 @@ class LftpJobStatusParser:
                 continue
 
             # If we got here, check if it's a known orphan progress line
-            if orphan_progress_m.match(line) or partial_progress_m.match(line):
+            if orphan_progress_m.match(line) or partial_progress_m.match(line) or chunk_wrap_m.match(line):
                 self.logger.warning("Skipping orphan lftp progress line: '%s'", line)
                 continue
 

--- a/src/python/tests/unittests/test_lftp/test_job_status_parser.py
+++ b/src/python/tests/unittests/test_lftp/test_job_status_parser.py
@@ -1546,6 +1546,46 @@ class TestLftpJobStatusParser(unittest.TestCase):
             statuses = parser.parse(output)
             self.assertEqual(1, len(statuses), f"Failed on fragment: {fragment}")
 
+    def test_chunk_line_wrap_fragment_skipped_after_job(self):
+        """Regression test: long filenames cause chunk progress lines to wrap,
+        producing a tail fragment like:
+            tmos.7.1.DV.HDR.H.265-TheFarm.mkv' at 22283455338 (0%) 427.6K/s eta:28m [Receiving data]
+        The parser should skip these instead of crashing."""
+        output = (
+            "[0] mirror -c /remote/path/show /local/path/ -- 500M/1G (50%) 10M/s\n"
+            "tmos.7.1.DV.HDR.H.265-TheFarm.mkv' at 22283455338 (0%) 427.6K/s eta:28m [Receiving data]"
+        )
+        parser = LftpJobStatusParser()
+        statuses = parser.parse(output)
+        self.assertEqual(1, len(statuses))
+
+    def test_bare_chunk_line_wrap_fragment_skipped(self):
+        """A bare chunk line-wrap fragment with no valid jobs should be skipped."""
+        output = "tmos.7.1.DV.HDR.H.265-TheFarm.mkv' at 22283455338 (0%) 427.6K/s eta:28m [Receiving data]"
+        parser = LftpJobStatusParser()
+        statuses = parser.parse(output)
+        self.assertEqual(0, len(statuses))
+
+    def test_chunk_line_wrap_fragment_connecting(self):
+        """Chunk line-wrap fragment with [Connecting...] status should also be skipped."""
+        output = (
+            "[0] mirror -c /remote/path/show /local/path/ -- 500M/1G (50%) 10M/s\n"
+            "Some.Long.Name.mkv' at 2760950243 (0%) [Connecting...]"
+        )
+        parser = LftpJobStatusParser()
+        statuses = parser.parse(output)
+        self.assertEqual(1, len(statuses))
+
+    def test_chunk_line_wrap_at_quote_boundary(self):
+        """Edge case: wrap lands exactly at the closing quote."""
+        output = (
+            "[0] mirror -c /remote/path/show /local/path/ -- 500M/1G (50%) 10M/s\n"
+            "' at 12345 (0%) 100K/s eta:5m [Receiving data]"
+        )
+        parser = LftpJobStatusParser()
+        statuses = parser.parse(output)
+        self.assertEqual(1, len(statuses))
+
     def test_truly_unrecognized_line_raises(self):
         """A truly unrecognized line (not an orphan progress line) should still raise."""
         output = "[0] mirror -c /remote/path/show /local/path/ -- 500M/1G (50%) 10M/s\ncompletely unexpected garbage"


### PR DESCRIPTION
## Summary

Fix lftp parser crash when long filenames cause chunk progress lines to wrap across PTY boundaries.

## Problem

Files with very long names (e.g. `1923 (2022) S01E04 (1080p SKST WEB-DL DDP5.1 H264)-Vialle.mkv`) produce chunk progress lines that exceed the PTY width. The line wraps, and the parser sees a tail fragment like:

```
tmos.7.1.DV.HDR.H.265-TheFarm.mkv' at 22283455338 (0%) 427.6K/s eta:28m [Receiving data]
```

This fragment is missing the leading backtick (`` ` ``) and start of the filename, so the `chunk_at` pattern can't match it. The parser raises `ValueError`, which crashes the controller and restarts the app.

This is the same class of bug as #253 and #260 (Unraid PTY wrapping), but for a different fragment type.

## Fix

Add a `chunk_wrap_m` pattern that matches these tail fragments: lines that end with `' at <pos> (<pct>%) [<speed>] [eta:<time>] [<status>]` but don't start with a backtick or backslash. These are safely skipped alongside existing orphan/partial progress line handling.

## Test plan

- [x] 3 new regression tests: fragment after job, bare fragment, fragment with [Connecting...] status
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing robustness to correctly ignore wrapped progress fragments in job status output, preventing false-positive parse results and crashes.

* **Tests**
  * Added regression tests covering wrapped progress fragments and edge-wrap scenarios to ensure consistent, reliable status parsing across varied output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->