### PR TITLE
Add Pyright type checking foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Ruff
-        run: pip install ruff
+      - name: Install tools
+        run: pip install ruff pyright
 
       - name: Ruff check
         working-directory: src/python
@@ -63,6 +63,11 @@ jobs:
       - name: Ruff format check
         working-directory: src/python
         run: ruff format --check
+
+      - name: Pyright type check (informational)
+        working-directory: src/python
+        continue-on-error: true
+        run: pyright
 
   python-test:
     name: Python Unit Tests

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -20,7 +20,7 @@ test = [
 ]
 dev = [
     "ruff>=0.11",
-    # Future: pyright
+    "pyright>=1.1",
 ]
 
 [tool.ruff]

--- a/src/python/pyrightconfig.json
+++ b/src/python/pyrightconfig.json
@@ -1,0 +1,10 @@
+{
+    "typeCheckingMode": "basic",
+    "pythonVersion": "3.12",
+    "include": [
+        "."
+    ],
+    "exclude": [
+        "tests"
+    ]
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Pyright rollout plan (see #249 comment). Sets up the foundation for incremental type safety adoption.

### Changes

- **`pyrightconfig.json`** — basic mode, Python 3.12, tests excluded
- **`pyproject.toml`** — added `pyright>=1.1` to dev dependency group
- **CI** — Pyright step added as informational (`continue-on-error: true`), runs alongside Ruff in the `python-lint` job

### Why informational?

Current baseline is 240 production errors. Making Pyright blocking now would prevent all PRs. Instead, the CI step reports the error count on every PR so we can track progress as errors are fixed in subsequent phases:

- Phase 2: Low-hanging fruit (~46 errors in small modules)
- Phase 3: Security-critical paths (~95 errors in SSH, LFTP, extraction)
- Phase 4: Complex modules (~109 errors in controller.py, config.py)
- Phase 5: Tests (565 errors, excluded for now)

Once production errors reach 0, the `continue-on-error` flag will be removed to make Pyright required.

### Follow-up

- #291 — Upgrade from basic to strict mode (after basic reaches 0 errors)

## Test plan

- [ ] CI python-lint job runs Pyright and reports errors without failing
- [ ] Ruff checks still pass
- [ ] No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline with Python static type checking using pyright
  * Created and configured Python type-checking setup targeting Python 3.12
  * Added pyright as a development dependency and integrated type-checking step in continuous integration workflow
  * Type-checking results included as informational feedback to catch potential issues during development

<!-- end of auto-generated comment: release notes by coderabbit.ai -->