### PR TITLE
Fix false download completion on parser error

### DIFF
--- a/src/python/lftp/lftp.py
+++ b/src/python/lftp/lftp.py
@@ -465,9 +465,12 @@ class Lftp:
     def xfer_verify_command(self, command: str):
         self.__set(Lftp.__SET_XFER_VERIFY_COMMAND, command)
 
-    def status(self) -> list[LftpJobStatus]:
+    def status(self) -> list[LftpJobStatus] | None:
         """
-        Return a status list of queued and running jobs
+        Return a status list of queued and running jobs.
+        Returns None when the status output could not be parsed, so callers
+        can distinguish "no jobs" from "parse failed" and avoid false
+        completion signals.
         :return:
         """
         out = self.__run_command("jobs -v")
@@ -478,7 +481,7 @@ class Lftp:
             self.__consecutive_status_errors += 1
             if self.__consecutive_status_errors < MAX_CONSECUTIVE_STATUS_ERRORS:
                 self.logger.warning(f"Ignoring status error (count={self.__consecutive_status_errors})")
-                statuses = []
+                return None
             else:
                 raise
         return statuses


### PR DESCRIPTION
## Summary

Fix a critical bug where parser errors cause downloads to be falsely marked as completed, permanently stalling the staging-to-final move pipeline.

## Problem

When `lftp.status()` fails to parse the `jobs -v` output (due to PTY line wrapping, connection errors, etc.), it returned an empty list `[]`. The controller then saw all previously-downloading files disappear from the status and marked them as "just completed":

```python
current_downloading = set(s.name for s in lftp_statuses)  # empty set
just_completed = prev_downloading_file_names - current_downloading  # ALL files!
```

This added partially-downloaded files to `persist.downloaded_file_names`, but since the actual files in staging were incomplete (e.g. 78%), the move process never ran (size verification fails), and the files were permanently stuck.

Observed in production: `1923 (2022) S01` was falsely completed 3 times in a row when SSH connections were reset, leaving it stuck at 78% in staging.

## Fix

Return `None` from `status()` on parse error instead of `[]`. The controller already checks `if lftp_statuses is not None:` before the completion detection block, so `None` correctly skips the entire cycle. The next successful parse sees the files still running.

One-line change in `lftp.py`.

## Test plan

- [ ] CI passes
- [ ] Verify with long-filename downloads that trigger parser warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)