### PR TITLE
Fix progress tracking for downloads with .lftp temp naming

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -338,7 +338,10 @@ class Controller:
         self._configure_lftp(lftp)
 
         # Scanners
-        active_scanner = ActiveScanner(effective_local_path)
+        active_scanner = ActiveScanner(
+            effective_local_path,
+            lftp_temp_suffix=Constants.LFTP_TEMP_FILE_SUFFIX if self.__context.config.lftp.use_temp_file else None,
+        )
         local_scanner = LocalScanner(local_path=local_path, use_temp_file=self.__context.config.lftp.use_temp_file)
         remote_scanner = RemoteScanner(
             remote_address=self.__context.config.lftp.remote_address,

--- a/src/python/controller/scan/active_scanner.py
+++ b/src/python/controller/scan/active_scanner.py
@@ -18,8 +18,10 @@ class ActiveScanner(IScanner):
     methods are called by different processes.
     """
 
-    def __init__(self, local_path: str):
+    def __init__(self, local_path: str, lftp_temp_suffix: str | None = None):
         self.__scanner = SystemScanner(local_path)
+        if lftp_temp_suffix:
+            self.__scanner.set_lftp_temp_suffix(lftp_temp_suffix)
         self.__active_files_queue = multiprocessing.Queue()
         self.__active_files = []  # latest state
         self.logger = logging.getLogger(self.__class__.__name__)


### PR DESCRIPTION
## Summary

Fix 0% progress display for single-file downloads when the `.lftp` temp file rename setting is enabled with staging.

## Problem

The ActiveScanner looks for downloading files by name in the staging directory. With temp naming enabled, lftp writes to `filename.lftp` instead of `filename`. The scanner couldn't find the file and reported "Path does not exist" every cycle, resulting in 0% progress until the download completed and lftp renamed the file.

## Fix

Pass the `.lftp` temp suffix to ActiveScanner's `SystemScanner`, which already has built-in fallback logic in `scan_single()` — it checks for both `filename` and `filename.lftp` and returns the result under the original name.

Two files changed, 5 lines added.

Closes #297

## Test plan

- [ ] CI passes
- [ ] Queue a single-file download with temp naming enabled — progress should update during transfer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced temporary file handling for scanning operations. The scanner now properly respects global temporary file settings when processing files during scan operations, improving compatibility with LFTP-based scanning workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->