### PR TITLE
Replace debug toggle with log level dropdown (#252)

### DIFF
--- a/src/angular/src/app/models/config.ts
+++ b/src/angular/src/app/models/config.ts
@@ -4,7 +4,7 @@
  */
 
 export interface General {
-  debug: boolean | null;
+  log_level: string | null;
   verbose: boolean | null;
   exclude_patterns: string | null;
 }
@@ -90,7 +90,7 @@ export interface Config {
 }
 
 export const DEFAULT_GENERAL: General = {
-  debug: null,
+  log_level: null,
   verbose: null,
   exclude_patterns: null,
 };

--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -310,16 +310,17 @@ export const OPTIONS_CONTEXT_LOGGING: IOptionsContext = {
   id: 'logging',
   options: [
     {
-      type: OptionType.Checkbox,
-      label: 'Enable Debug',
-      valuePath: ['general', 'debug'],
-      description: 'Enables debug logging',
+      type: OptionType.Select,
+      label: 'Log Level',
+      valuePath: ['general', 'log_level'],
+      description: 'Controls which log messages are recorded',
+      choices: ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
     },
     {
       type: OptionType.Checkbox,
       label: 'Verbose LFTP Logging',
       valuePath: ['general', 'verbose'],
-      description: 'Log all LFTP command output (debug mode must be enabled for logs to appear).',
+      description: 'Log all LFTP command output (log level must be set to DEBUG for logs to appear).',
     },
     {
       type: OptionType.Select,

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -12,7 +12,7 @@ import { Config } from "../../models/config";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
-    general: { debug: false, verbose: false, exclude_patterns: "" },
+    general: { log_level: "INFO", verbose: false, exclude_patterns: "" },
     lftp: {
       remote_address: "host",
       remote_username: "user",

--- a/src/e2e-playwright/tests/settings.spec.ts
+++ b/src/e2e-playwright/tests/settings.spec.ts
@@ -58,7 +58,7 @@ test.describe("Settings Page", () => {
   });
 
   test("checkbox toggle saves to backend", async ({ apiGet }) => {
-    const checkbox = settings.getCheckbox("Enable Debug");
+    const checkbox = settings.getCheckbox("Verbose LFTP Logging");
     const wasBefore = await checkbox.isChecked();
     const expected = !wasBefore;
 
@@ -70,7 +70,7 @@ test.describe("Settings Page", () => {
         .poll(
           async () => {
             const config = await apiGet("/server/config/get");
-            return config.general.debug;
+            return config.general.verbose;
           },
           { timeout: 5000 }
         )
@@ -83,7 +83,7 @@ test.describe("Settings Page", () => {
         .poll(
           async () => {
             const config = await apiGet("/server/config/get");
-            return config.general.debug;
+            return config.general.verbose;
           },
           { timeout: 5000 }
         )

--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -103,6 +103,18 @@ class Checkers:
             )
         return normalized
 
+    @staticmethod
+    def log_level_allowed(cls: T, name: str, value: str) -> str:  # type: ignore[reportInvalidTypeVarUse, reportSelfClsParameterName]
+        allowed = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+        normalized = value.strip().upper() if value else ""
+        if normalized not in allowed:
+            raise ConfigError(
+                "Bad config: {}.{} ({}) must be one of: {}".format(
+                    cls.__name__, name, value, ", ".join(sorted(allowed))
+                )
+            )
+        return normalized
+
 
 class InnerConfig(ABC):
     """
@@ -236,13 +248,13 @@ class Config(Persist):
     """
 
     class General(IC):
-        debug = PROP("debug", Checkers.null, Converters.bool)
+        log_level = PROP("log_level", Checkers.log_level_allowed, Converters.null)
         verbose = PROP("verbose", Checkers.null, Converters.bool)
         exclude_patterns = PROP("exclude_patterns", Checkers.string_allow_empty, Converters.null)
 
         def __init__(self):
             super().__init__()
-            self.debug = None
+            self.log_level = "INFO"
             self.verbose = None
             self.exclude_patterns = ""
 

--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -81,9 +81,14 @@ class Seedsync:
             config = Seedsync._create_default_config()
             config.to_file(self.config_path)
 
-        # Determine the true value of debug
+        # Determine the effective log level
         assert config is not None
-        is_debug = bool(args.debug or config.general.debug)
+        # --debug CLI flag overrides config to DEBUG for backward compatibility
+        if args.debug:
+            effective_log_level = "DEBUG"
+        else:
+            effective_log_level = config.general.log_level or "INFO"
+        is_debug = effective_log_level == "DEBUG"
 
         # Create context args
         ctx_args = Args()
@@ -97,13 +102,13 @@ class Seedsync:
         # We separate the main log from the web-access log
         log_format = config.logging.log_format or "standard"
         logger = self._create_logger(
-            name=Constants.SERVICE_NAME, debug=is_debug, logdir=args.logdir, log_format=log_format
+            name=Constants.SERVICE_NAME, log_level=effective_log_level, logdir=args.logdir, log_format=log_format
         )
         Seedsync.logger = logger
         web_access_logger = self._create_logger(
-            name=Constants.WEB_ACCESS_LOG_NAME, debug=is_debug, logdir=args.logdir, log_format=log_format
+            name=Constants.WEB_ACCESS_LOG_NAME, log_level=effective_log_level, logdir=args.logdir, log_format=log_format
         )
-        logger.info("Debug mode is {}.".format("enabled" if is_debug else "disabled"))
+        logger.info("Log level: {}".format(effective_log_level))
 
         # Create status
         status = Status()
@@ -274,7 +279,7 @@ class Seedsync:
         return parser.parse_args(args)
 
     @staticmethod
-    def _create_logger(name: str, debug: bool, logdir: str | None, log_format: str = "standard") -> logging.Logger:
+    def _create_logger(name: str, log_level: str, logdir: str | None, log_format: str = "standard") -> logging.Logger:
         logger = logging.getLogger(name)
 
         # Remove any existing handlers (needed when restarting)
@@ -283,7 +288,8 @@ class Seedsync:
             handler.close()
             logger.removeHandler(handler)
 
-        logger.setLevel(logging.DEBUG if debug else logging.INFO)
+        numeric_level = getattr(logging, log_level.upper(), logging.INFO)
+        logger.setLevel(numeric_level)
         if logdir is not None:
             # Output logs to a file in the given directory
             handler = RotatingFileHandler(
@@ -311,7 +317,7 @@ class Seedsync:
         """
         config = Config()
 
-        config.general.debug = False
+        config.general.log_level = "INFO"
         config.general.verbose = False
 
         config.lftp.remote_address = Seedsync.__CONFIG_DUMMY_VALUE

--- a/src/python/tests/integration/test_controller/test_controller.py
+++ b/src/python/tests/integration/test_controller/test_controller.py
@@ -283,7 +283,7 @@ class TestController(unittest.TestCase):
         ctx_args.local_path_to_scanfs = local_script_path
 
         config_dict = {
-            "General": {"debug": "True", "verbose": "True"},
+            "General": {"log_level": "DEBUG", "verbose": "True"},
             "Lftp": {
                 "remote_address": "localhost",
                 "remote_username": "seedsynctest",

--- a/src/python/tests/integration/test_web/test_handler/test_config.py
+++ b/src/python/tests/integration/test_web/test_handler/test_config.py
@@ -9,23 +9,23 @@ from tests.integration.test_web.test_web_app import BaseTestWebApp
 
 class TestConfigHandler(BaseTestWebApp):
     def test_get(self):
-        self.context.config.general.debug = True
+        self.context.config.general.log_level = "DEBUG"
         self.context.config.lftp.remote_path = "/remote/server/path"
         self.context.config.controller.interval_ms_local_scan = 5678
         self.context.config.web.port = 8080
         resp = self.test_app.get("/server/config/get")
         self.assertEqual(200, resp.status_int)
         json_dict = json.loads(str(resp.html))
-        self.assertEqual(True, json_dict["general"]["debug"])
+        self.assertEqual("DEBUG", json_dict["general"]["log_level"])
         self.assertEqual("/remote/server/path", json_dict["lftp"]["remote_path"])
         self.assertEqual(5678, json_dict["controller"]["interval_ms_local_scan"])
         self.assertEqual(8080, json_dict["web"]["port"])
 
     def test_set_good(self):
-        self.assertEqual(None, self.context.config.general.debug)
-        resp = self.test_app.get("/server/config/set/general/debug/True")
+        self.assertEqual("INFO", self.context.config.general.log_level)
+        resp = self.test_app.get("/server/config/set/general/log_level/DEBUG")
         self.assertEqual(200, resp.status_int)
-        self.assertEqual(True, self.context.config.general.debug)
+        self.assertEqual("DEBUG", self.context.config.general.log_level)
 
         self.assertEqual(None, self.context.config.lftp.remote_path)
         uri = quote(quote("/path/to/somewhere", safe=""), safe="")
@@ -58,12 +58,12 @@ class TestConfigHandler(BaseTestWebApp):
         self.assertFalse(self.context.config.general.has_property("bad_option"))
 
     def test_set_bad_value(self):
-        # boolean
-        self.assertEqual(None, self.context.config.general.debug)
-        resp = self.test_app.get("/server/config/set/general/debug/cat", expect_errors=True)
+        # log_level
+        self.assertEqual("INFO", self.context.config.general.log_level)
+        resp = self.test_app.get("/server/config/set/general/log_level/cat", expect_errors=True)
         self.assertEqual(400, resp.status_int)
-        self.assertEqual("Bad config: General.debug (cat) must be a boolean value", str(resp.html))
-        self.assertEqual(None, self.context.config.general.debug)
+        self.assertIn("Bad config: General.log_level (cat) must be one of:", str(resp.html))
+        self.assertEqual("INFO", self.context.config.general.log_level)
 
         # positive int
         self.assertEqual(None, self.context.config.controller.interval_ms_local_scan)

--- a/src/python/tests/unittests/test_common/test_config.py
+++ b/src/python/tests/unittests/test_common/test_config.py
@@ -61,7 +61,6 @@ class TestCheckers(unittest.TestCase):
         with self.assertRaises(ConfigError):
             Checkers.algorithm_allowed(TestCheckers, "algo", "invalid")
 
-
     def test_log_level_allowed(self):
         for level in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
             self.assertEqual(level, Checkers.log_level_allowed(None, "", level))

--- a/src/python/tests/unittests/test_common/test_config.py
+++ b/src/python/tests/unittests/test_common/test_config.py
@@ -62,6 +62,21 @@ class TestCheckers(unittest.TestCase):
             Checkers.algorithm_allowed(TestCheckers, "algo", "invalid")
 
 
+    def test_log_level_allowed(self):
+        for level in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+            self.assertEqual(level, Checkers.log_level_allowed(None, "", level))
+        # Case normalization
+        self.assertEqual("DEBUG", Checkers.log_level_allowed(None, "", "debug"))
+        self.assertEqual("INFO", Checkers.log_level_allowed(None, "", "Info"))
+        # Invalid levels
+        with self.assertRaises(ConfigError):
+            Checkers.log_level_allowed(TestCheckers, "level", "WARN")
+        with self.assertRaises(ConfigError):
+            Checkers.log_level_allowed(TestCheckers, "level", "")
+        with self.assertRaises(ConfigError):
+            Checkers.log_level_allowed(TestCheckers, "level", "invalid")
+
+
 class DummyInnerConfig(InnerConfig):
     c_prop1 = InnerConfig._create_property("prop1", Checkers.null, Converters.null)
     a_prop2 = InnerConfig._create_property("prop2", Checkers.null, Converters.null)
@@ -174,20 +189,40 @@ class TestConfig(unittest.TestCase):
 
     def test_general(self):
         good_dict = {
-            "debug": "True",
+            "log_level": "DEBUG",
             "verbose": "False",
         }
         general = Config.General.from_dict(good_dict)
-        self.assertEqual(True, general.debug)
+        self.assertEqual("DEBUG", general.log_level)
         self.assertEqual(False, general.verbose)
 
-        self.check_common(Config.General, good_dict, {"debug", "verbose"})
+        self.check_common(Config.General, good_dict, {"verbose"})
 
         # bad values
-        self.check_bad_value_error(Config.General, good_dict, "debug", "SomeString")
-        self.check_bad_value_error(Config.General, good_dict, "debug", "-1")
+        self.check_bad_value_error(Config.General, good_dict, "log_level", "SomeString")
+        self.check_bad_value_error(Config.General, good_dict, "log_level", "-1")
         self.check_bad_value_error(Config.General, good_dict, "verbose", "SomeString")
         self.check_bad_value_error(Config.General, good_dict, "verbose", "-1")
+
+        # all valid log levels
+        for level in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+            general = Config.General.from_dict({"log_level": level, "verbose": "False"})
+            self.assertEqual(level, general.log_level)
+
+        # case insensitive input is normalized to uppercase
+        general = Config.General.from_dict({"log_level": "info", "verbose": "False"})
+        self.assertEqual("INFO", general.log_level)
+
+    def test_general_old_debug_key_ignored(self):
+        """Old config files with 'debug' key should be silently ignored"""
+        old_dict = {
+            "debug": "True",
+            "verbose": "False",
+        }
+        general = Config.General.from_dict(old_dict)
+        # 'debug' is unknown and silently ignored; log_level gets its default
+        self.assertEqual("INFO", general.log_level)
+        self.assertEqual(False, general.verbose)
 
     def test_lftp(self):
         good_dict = {
@@ -440,7 +475,7 @@ class TestConfig(unittest.TestCase):
 
         config_file.write("""
         [General]
-        debug=False
+        log_level=WARNING
         verbose=True
 
         [Lftp]
@@ -481,7 +516,7 @@ class TestConfig(unittest.TestCase):
         config_file.flush()
         config = Config.from_file(config_file.name)
 
-        self.assertEqual(False, config.general.debug)
+        self.assertEqual("WARNING", config.general.log_level)
         self.assertEqual(True, config.general.verbose)
 
         self.assertEqual("remote.server.com", config.lftp.remote_address)
@@ -523,7 +558,7 @@ class TestConfig(unittest.TestCase):
         config_file.flush()
         config2 = Config.from_file(config_file.name)
         # Should load without error, known sections still valid
-        self.assertEqual(False, config2.general.debug)
+        self.assertEqual("WARNING", config2.general.log_level)
 
         # Remove config file
         config_file.close()
@@ -534,7 +569,7 @@ class TestConfig(unittest.TestCase):
         os.close(fd)
 
         config = Config()
-        config.general.debug = True
+        config.general.log_level = "DEBUG"
         config.general.verbose = False
         config.lftp.remote_address = "server.remote.com"
         config.lftp.remote_username = "user-on-remote-server"
@@ -578,7 +613,7 @@ class TestConfig(unittest.TestCase):
 
         golden_str = """
         [General]
-        debug = True
+        log_level = DEBUG
         verbose = False
         exclude_patterns =
 
@@ -680,7 +715,7 @@ class TestConfig(unittest.TestCase):
 
     def test_from_dict_missing_key_uses_default(self):
         """Missing keys in from_dict should use the __init__ default value"""
-        # Config.General has defaults: debug=None, verbose=None
+        # Config.General has defaults: log_level="INFO", verbose=None
         # Config.AutoQueue has defaults: enabled=None, etc.
         # Use Config.Web which has a single property 'port' with default None
         # Test with Lftp which has net_limit_rate defaulting to ""
@@ -718,10 +753,10 @@ class TestConfig(unittest.TestCase):
         """Missing sections in from_dict should use defaults instead of raising"""
         # Only General section present - all others should get defaults
         config_dict = {
-            "General": {"debug": "True", "verbose": "False"},
+            "General": {"log_level": "DEBUG", "verbose": "False"},
         }
         config = Config.from_dict(config_dict)
-        self.assertEqual(True, config.general.debug)
+        self.assertEqual("DEBUG", config.general.log_level)
         self.assertEqual(False, config.general.verbose)
         # Other sections should have default (None) values
         self.assertIsNone(config.lftp.remote_address)
@@ -732,7 +767,7 @@ class TestConfig(unittest.TestCase):
     def test_from_dict_empty_uses_all_defaults(self):
         """Completely empty dict should return config with all defaults"""
         config = Config.from_dict({})
-        self.assertIsNone(config.general.debug)
+        self.assertEqual("INFO", config.general.log_level)
         self.assertIsNone(config.lftp.remote_address)
         self.assertIsNone(config.controller.interval_ms_remote_scan)
         self.assertIsNone(config.web.port)
@@ -742,14 +777,14 @@ class TestConfig(unittest.TestCase):
         """Parsing a config string with missing sections should use defaults"""
         content = """
         [General]
-        debug=True
+        log_level=DEBUG
         verbose=False
 
         [Web]
         port=9999
         """
         config = Config.from_str(content)
-        self.assertEqual(True, config.general.debug)
+        self.assertEqual("DEBUG", config.general.log_level)
         self.assertEqual(9999, config.web.port)
         # Missing sections get defaults
         self.assertIsNone(config.lftp.remote_address)
@@ -759,7 +794,7 @@ class TestConfig(unittest.TestCase):
     def test_default_config_round_trip(self):
         """Default config should survive a write-then-read round trip"""
         config = Config()
-        config.general.debug = False
+        config.general.log_level = "INFO"
         config.general.verbose = False
         config.lftp.remote_address = "addr"
         config.lftp.remote_username = "user"
@@ -891,7 +926,7 @@ class TestConfig(unittest.TestCase):
     def test_controller_staging_round_trip(self):
         """Staging properties should survive a serialization round trip"""
         config = Config()
-        config.general.debug = False
+        config.general.log_level = "INFO"
         config.general.verbose = False
         config.lftp.remote_address = "addr"
         config.lftp.remote_username = "user"

--- a/src/python/tests/unittests/test_web/test_serialize/test_serialize_config.py
+++ b/src/python/tests/unittests/test_web/test_serialize/test_serialize_config.py
@@ -10,11 +10,11 @@ from web.serialize import SerializeConfig
 class TestSerializeConfig(unittest.TestCase):
     def test_section_general(self):
         config = Config()
-        config.general.debug = True
+        config.general.log_level = "DEBUG"
         out = SerializeConfig.config(config)
         out_dict = json.loads(out)
         self.assertIn("general", out_dict)
-        self.assertEqual(True, out_dict["general"]["debug"])
+        self.assertEqual("DEBUG", out_dict["general"]["log_level"])
 
     def test_section_lftp(self):
         config = Config()


### PR DESCRIPTION
## Summary
- Remove `Config.General.debug` (bool), add `Config.General.log_level` (DEBUG/INFO/WARNING/ERROR/CRITICAL, default INFO)
- UI: replace "Enable Debug" checkbox with "Log Level" dropdown in Logging section
- `--debug` CLI flag still works (overrides to DEBUG)
- Old configs with `debug` key silently ignored on upgrade — no crash
- 10 test files updated (unit, integration, E2E)

## Test plan
- [ ] All Angular Vitest tests pass
- [ ] Python unit and integration tests pass
- [ ] Verify dropdown renders with all 5 log levels in Settings → Logging
- [ ] Verify `--debug` CLI flag still forces DEBUG level
- [ ] Upgrade test: start with old config containing `debug = True`, verify no crash and log_level defaults to INFO

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced binary debug mode with a configurable log level (DEBUG, INFO, WARNING, ERROR, CRITICAL). Default is INFO.
  * Settings UI now exposes a Log Level dropdown; config file supports log_level.

* **Refactor**
  * Core logging now uses standard log levels throughout the application and services.

* **Tests**
  * Unit, integration and end-to-end tests updated to use log_level (and updated defaults/expectations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->