### PR TITLE
Add size sorting to file list (#254)

### DIFF
--- a/src/angular/src/app/models/view-file-options.ts
+++ b/src/angular/src/app/models/view-file-options.ts
@@ -15,4 +15,6 @@ export enum SortMethod {
   STATUS,
   NAME_ASC,
   NAME_DESC,
+  SIZE_ASC,
+  SIZE_DESC,
 }

--- a/src/angular/src/app/pages/files/file-options.component.html
+++ b/src/angular/src/app/pages/files/file-options.component.html
@@ -132,25 +132,25 @@
                 }
                 @if ((options | async)?.sortMethod === SortMethod.NAME_ASC) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" /></div>
+                        <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" alt="Sort ascending" /></div>
                         <span class="text">Name A&#8594;Z</span>
                     </div>
                 }
                 @if ((options | async)?.sortMethod === SortMethod.NAME_DESC) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" /></div>
+                        <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" alt="Sort descending" /></div>
                         <span class="text">Name Z&#8594;A</span>
                     </div>
                 }
                 @if ((options | async)?.sortMethod === SortMethod.SIZE_ASC) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" /></div>
+                        <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" alt="Sort ascending" /></div>
                         <span class="text">Size S&#8594;L</span>
                     </div>
                 }
                 @if ((options | async)?.sortMethod === SortMethod.SIZE_DESC) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" /></div>
+                        <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" alt="Sort descending" /></div>
                         <span class="text">Size L&#8594;S</span>
                     </div>
                 }
@@ -166,25 +166,25 @@
             <div class="dropdown-item"
                  [class.active]="(options | async)?.sortMethod === SortMethod.NAME_ASC"
                  (click)="onSort(SortMethod.NAME_ASC)">
-                <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" /></div>
+                <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" alt="Sort ascending" /></div>
                 <span class="text">Name A&#8594;Z</span>
             </div>
             <div class="dropdown-item"
                  [class.active]="(options | async)?.sortMethod === SortMethod.NAME_DESC"
                  (click)="onSort(SortMethod.NAME_DESC)">
-                <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" /></div>
+                <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" alt="Sort descending" /></div>
                 <span class="text">Name Z&#8594;A</span>
             </div>
             <div class="dropdown-item"
                  [class.active]="(options | async)?.sortMethod === SortMethod.SIZE_ASC"
                  (click)="onSort(SortMethod.SIZE_ASC)">
-                <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" /></div>
+                <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" alt="Sort ascending" /></div>
                 <span class="text">Size S&#8594;L</span>
             </div>
             <div class="dropdown-item"
                  [class.active]="(options | async)?.sortMethod === SortMethod.SIZE_DESC"
                  (click)="onSort(SortMethod.SIZE_DESC)">
-                <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" /></div>
+                <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" alt="Sort descending" /></div>
                 <span class="text">Size L&#8594;S</span>
             </div>
         </div>

--- a/src/angular/src/app/pages/files/file-options.component.html
+++ b/src/angular/src/app/pages/files/file-options.component.html
@@ -142,6 +142,18 @@
                         <span class="text">Name Z&#8594;A</span>
                     </div>
                 }
+                @if ((options | async)?.sortMethod === SortMethod.SIZE_ASC) {
+                    <div class="sel-item">
+                        <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" /></div>
+                        <span class="text">Size S&#8594;L</span>
+                    </div>
+                }
+                @if ((options | async)?.sortMethod === SortMethod.SIZE_DESC) {
+                    <div class="sel-item">
+                        <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" /></div>
+                        <span class="text">Size L&#8594;S</span>
+                    </div>
+                }
             </div>
         </button>
         <div class="dropdown-menu">
@@ -162,6 +174,18 @@
                  (click)="onSort(SortMethod.NAME_DESC)">
                 <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" /></div>
                 <span class="text">Name Z&#8594;A</span>
+            </div>
+            <div class="dropdown-item"
+                 [class.active]="(options | async)?.sortMethod === SortMethod.SIZE_ASC"
+                 (click)="onSort(SortMethod.SIZE_ASC)">
+                <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" /></div>
+                <span class="text">Size S&#8594;L</span>
+            </div>
+            <div class="dropdown-item"
+                 [class.active]="(options | async)?.sortMethod === SortMethod.SIZE_DESC"
+                 (click)="onSort(SortMethod.SIZE_DESC)">
+                <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" /></div>
+                <span class="text">Size L&#8594;S</span>
             </div>
         </div>
     </div>

--- a/src/angular/src/app/services/files/view-file-sort.service.spec.ts
+++ b/src/angular/src/app/services/files/view-file-sort.service.spec.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TestBed } from "@angular/core/testing";
+import { BehaviorSubject } from "rxjs";
+import { ViewFileSortService } from "./view-file-sort.service";
+import { ViewFileOptionsService } from "./view-file-options.service";
+import { ViewFileService, ViewFileComparator } from "./view-file.service";
+import { LoggerService } from "../utils/logger.service";
+import { ViewFileOptions, SortMethod } from "../../models/view-file-options";
+import { ViewFile, ViewFileStatus } from "../../models/view-file";
+
+function makeViewFile(
+  overrides: Partial<ViewFile> & { name: string },
+): ViewFile {
+  return {
+    pairId: null,
+    pairName: null,
+    isDir: false,
+    localSize: 0,
+    remoteSize: 0,
+    percentDownloaded: 0,
+    status: ViewFileStatus.DEFAULT,
+    downloadingSpeed: 0,
+    eta: 0,
+    fullPath: "/path/" + overrides.name,
+    isArchive: false,
+    isSelected: false,
+    isChecked: false,
+    isQueueable: false,
+    isStoppable: false,
+    isExtractable: false,
+    isLocallyDeletable: false,
+    isRemotelyDeletable: false,
+    isValidatable: false,
+    validateTooltip: null,
+    localCreatedTimestamp: null,
+    localModifiedTimestamp: null,
+    remoteCreatedTimestamp: null,
+    remoteModifiedTimestamp: null,
+    ...overrides,
+  };
+}
+
+function defaultOptions(): ViewFileOptions {
+  return {
+    showDetails: false,
+    sortMethod: SortMethod.STATUS,
+    selectedStatusFilter: null,
+    nameFilter: "",
+    pinFilter: false,
+  };
+}
+
+describe("ViewFileSortService", () => {
+  let optionsSubject: BehaviorSubject<ViewFileOptions>;
+  let capturedComparator: ViewFileComparator | null;
+  let mockViewFileService: { setComparator: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    optionsSubject = new BehaviorSubject<ViewFileOptions>(defaultOptions());
+    capturedComparator = null;
+    mockViewFileService = {
+      setComparator: vi.fn((c: ViewFileComparator | null) => {
+        capturedComparator = c;
+      }),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        ViewFileSortService,
+        {
+          provide: ViewFileOptionsService,
+          useValue: { options$: optionsSubject.asObservable() },
+        },
+        {
+          provide: ViewFileService,
+          useValue: mockViewFileService,
+        },
+        {
+          provide: LoggerService,
+          useValue: {
+            debug: vi.fn(),
+            error: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+          },
+        },
+      ],
+    });
+
+    // Instantiate the service so the constructor subscription fires
+    TestBed.inject(ViewFileSortService);
+  });
+
+  function setSort(method: SortMethod): void {
+    optionsSubject.next({ ...defaultOptions(), sortMethod: method });
+  }
+
+  function sortFiles(files: ViewFile[]): ViewFile[] {
+    return [...files].sort(capturedComparator!);
+  }
+
+  // --- Comparator selection ---
+
+  it("should set Status comparator on init", () => {
+    expect(mockViewFileService.setComparator).toHaveBeenCalled();
+    expect(capturedComparator).not.toBeNull();
+  });
+
+  it("should set Size Asc comparator when SIZE_ASC selected", () => {
+    setSort(SortMethod.SIZE_ASC);
+    expect(capturedComparator).not.toBeNull();
+  });
+
+  it("should set Size Desc comparator when SIZE_DESC selected", () => {
+    setSort(SortMethod.SIZE_DESC);
+    expect(capturedComparator).not.toBeNull();
+  });
+
+  // --- Size Ascending ---
+
+  describe("Size Ascending", () => {
+    beforeEach(() => setSort(SortMethod.SIZE_ASC));
+
+    it("should sort smaller files first", () => {
+      const files = [
+        makeViewFile({ name: "big", remoteSize: 1000 }),
+        makeViewFile({ name: "small", remoteSize: 100 }),
+        makeViewFile({ name: "medium", remoteSize: 500 }),
+      ];
+      const sorted = sortFiles(files);
+      expect(sorted.map((f) => f.name)).toEqual(["small", "medium", "big"]);
+    });
+
+    it("should fall back to localSize when remoteSize is 0", () => {
+      const files = [
+        makeViewFile({ name: "remote", remoteSize: 200 }),
+        makeViewFile({ name: "local-only", remoteSize: 0, localSize: 100 }),
+      ];
+      const sorted = sortFiles(files);
+      expect(sorted.map((f) => f.name)).toEqual(["local-only", "remote"]);
+    });
+
+    it("should sort null sizes (both 0) last", () => {
+      const files = [
+        makeViewFile({ name: "no-size", remoteSize: 0, localSize: 0 }),
+        makeViewFile({ name: "has-size", remoteSize: 50 }),
+      ];
+      const sorted = sortFiles(files);
+      expect(sorted.map((f) => f.name)).toEqual(["has-size", "no-size"]);
+    });
+
+    it("should sort by name when sizes are equal", () => {
+      const files = [
+        makeViewFile({ name: "beta", remoteSize: 100 }),
+        makeViewFile({ name: "alpha", remoteSize: 100 }),
+      ];
+      const sorted = sortFiles(files);
+      expect(sorted.map((f) => f.name)).toEqual(["alpha", "beta"]);
+    });
+
+    it("should sort multiple null-size files by name", () => {
+      const files = [
+        makeViewFile({ name: "zebra", remoteSize: 0, localSize: 0 }),
+        makeViewFile({ name: "apple", remoteSize: 0, localSize: 0 }),
+      ];
+      const sorted = sortFiles(files);
+      expect(sorted.map((f) => f.name)).toEqual(["apple", "zebra"]);
+    });
+  });
+
+  // --- Size Descending ---
+
+  describe("Size Descending", () => {
+    beforeEach(() => setSort(SortMethod.SIZE_DESC));
+
+    it("should sort larger files first", () => {
+      const files = [
+        makeViewFile({ name: "small", remoteSize: 100 }),
+        makeViewFile({ name: "big", remoteSize: 1000 }),
+        makeViewFile({ name: "medium", remoteSize: 500 }),
+      ];
+      const sorted = sortFiles(files);
+      expect(sorted.map((f) => f.name)).toEqual(["big", "medium", "small"]);
+    });
+
+    it("should fall back to localSize when remoteSize is 0", () => {
+      const files = [
+        makeViewFile({ name: "local-only", remoteSize: 0, localSize: 300 }),
+        makeViewFile({ name: "remote", remoteSize: 200 }),
+      ];
+      const sorted = sortFiles(files);
+      expect(sorted.map((f) => f.name)).toEqual(["local-only", "remote"]);
+    });
+
+    it("should sort null sizes (both 0) last", () => {
+      const files = [
+        makeViewFile({ name: "no-size", remoteSize: 0, localSize: 0 }),
+        makeViewFile({ name: "has-size", remoteSize: 50 }),
+      ];
+      const sorted = sortFiles(files);
+      expect(sorted.map((f) => f.name)).toEqual(["has-size", "no-size"]);
+    });
+
+    it("should sort by name when sizes are equal", () => {
+      const files = [
+        makeViewFile({ name: "beta", remoteSize: 100 }),
+        makeViewFile({ name: "alpha", remoteSize: 100 }),
+      ];
+      const sorted = sortFiles(files);
+      expect(sorted.map((f) => f.name)).toEqual(["alpha", "beta"]);
+    });
+  });
+});

--- a/src/angular/src/app/services/files/view-file-sort.service.ts
+++ b/src/angular/src/app/services/files/view-file-sort.service.ts
@@ -43,6 +43,38 @@ const NameDescendingComparator: ViewFileComparator = (a: ViewFile, b: ViewFile):
   return b.name.localeCompare(a.name);
 };
 
+/**
+ * Get the effective size for sorting: use remoteSize, fall back to localSize.
+ * Returns null if both are zero/unavailable.
+ */
+function getEffectiveSize(file: ViewFile): number | null {
+  if (file.remoteSize > 0) return file.remoteSize;
+  if (file.localSize > 0) return file.localSize;
+  return null;
+}
+
+const SizeAscendingComparator: ViewFileComparator = (a: ViewFile, b: ViewFile): number => {
+  const aSize = getEffectiveSize(a);
+  const bSize = getEffectiveSize(b);
+  // Null sizes sort last
+  if (aSize === null && bSize === null) return a.name.localeCompare(b.name);
+  if (aSize === null) return 1;
+  if (bSize === null) return -1;
+  if (aSize !== bSize) return aSize - bSize;
+  return a.name.localeCompare(b.name);
+};
+
+const SizeDescendingComparator: ViewFileComparator = (a: ViewFile, b: ViewFile): number => {
+  const aSize = getEffectiveSize(a);
+  const bSize = getEffectiveSize(b);
+  // Null sizes sort last
+  if (aSize === null && bSize === null) return a.name.localeCompare(b.name);
+  if (aSize === null) return 1;
+  if (bSize === null) return -1;
+  if (aSize !== bSize) return bSize - aSize;
+  return a.name.localeCompare(b.name);
+};
+
 @Injectable({ providedIn: 'root' })
 export class ViewFileSortService {
   private readonly logger = inject(LoggerService);
@@ -64,6 +96,12 @@ export class ViewFileSortService {
         } else if (this.sortMethod === SortMethod.NAME_ASC) {
           this.viewFileService.setComparator(NameAscendingComparator);
           this.logger.debug('Comparator set to: Name Asc');
+        } else if (this.sortMethod === SortMethod.SIZE_ASC) {
+          this.viewFileService.setComparator(SizeAscendingComparator);
+          this.logger.debug('Comparator set to: Size Asc');
+        } else if (this.sortMethod === SortMethod.SIZE_DESC) {
+          this.viewFileService.setComparator(SizeDescendingComparator);
+          this.logger.debug('Comparator set to: Size Desc');
         } else {
           this.viewFileService.setComparator(null);
           this.logger.debug('Comparator set to: null');


### PR DESCRIPTION
## Summary
- Add `SIZE_ASC` and `SIZE_DESC` to `SortMethod` enum
- Comparators use `remoteSize`, fall back to `localSize`, nulls sort last, ties break by name
- UI shows "Size S→L" and "Size L→S" in sort dropdown

## Test plan
- [ ] All 303 Vitest tests pass (12 new sort tests added)
- [ ] Verify size sort in UI with mixed file sizes
- [ ] Verify null-size files sort to bottom
- [ ] Verify sort persists across page reloads

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two size-based sort options to the Sort menu (Size S→L, Size L→S); sorts use available size data and place items without size at the end, tie-broken alphabetically.
* **Accessibility**
  * Improved alt text for sort icons in the UI.
* **Tests**
  * Added unit tests validating size-based sorting behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->