### PR TITLE
Add virtual scrolling for large file lists (#256)

### DIFF
--- a/src/angular/package-lock.json
+++ b/src/angular/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "seedsync",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seedsync",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "dependencies": {
+        "@angular/cdk": "^21.2.5",
         "@angular/common": "^21.2.6",
         "@angular/compiler": "^21.2.6",
         "@angular/core": "^21.2.6",
@@ -416,6 +417,22 @@
         "vitest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "21.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.5.tgz",
+      "integrity": "sha512-F1sVqMAGYoiJNYYaR2cerqTo7IqpxQ3ZtMDxR3rtB0rSSd5UPOIQoqpsfSd6uH8FVnuzKaBII8Mg6YrjClFsng==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^8.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^21.0.0 || ^22.0.0",
+        "@angular/core": "^21.0.0 || ^22.0.0",
+        "@angular/platform-browser": "^21.0.0 || ^22.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -6863,7 +6880,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -6917,7 +6933,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"

--- a/src/angular/package.json
+++ b/src/angular/package.json
@@ -23,6 +23,7 @@
   "private": true,
   "packageManager": "npm@10.9.2",
   "dependencies": {
+    "@angular/cdk": "^21.2.5",
     "@angular/common": "^21.2.6",
     "@angular/compiler": "^21.2.6",
     "@angular/core": "^21.2.6",

--- a/src/angular/src/app/pages/files/file-list.component.html
+++ b/src/angular/src/app/pages/files/file-list.component.html
@@ -23,7 +23,7 @@
       }
     }
     <cdk-virtual-scroll-viewport itemSize="50" class="file-viewport">
-        <div *cdkVirtualFor="let file of files; trackBy: identify" class="file-row">
+        <div *cdkVirtualFor="let file of files; trackBy: identify; let isEven = even" class="file-row" [class.even]="isEven">
             <app-file
                 [file]="file"
                 [options]="options"

--- a/src/angular/src/app/pages/files/file-list.component.html
+++ b/src/angular/src/app/pages/files/file-list.component.html
@@ -22,8 +22,8 @@
         </app-bulk-action-bar>
       }
     }
-    @for (file of files | async; track identify($index, file)) {
-        <div>
+    <cdk-virtual-scroll-viewport itemSize="50" class="file-viewport">
+        <div *cdkVirtualFor="let file of files; trackBy: identify" class="file-row">
             <app-file
                 [file]="file"
                 [options]="options"
@@ -37,5 +37,5 @@
                 (deleteRemoteEvent)="onDeleteRemote($event)">
             </app-file>
         </div>
-    }
+    </cdk-virtual-scroll-viewport>
 </div>

--- a/src/angular/src/app/pages/files/file-list.component.scss
+++ b/src/angular/src/app/pages/files/file-list.component.scss
@@ -4,14 +4,20 @@
     display: none;
 }
 
+/* Virtual scroll viewport */
+.file-viewport {
+    height: calc(100vh - 160px);
+    min-height: 200px;
+}
+
 /* striped rows */
-#file-list > div:nth-child(even){
+.file-row:nth-child(even){
     background-color: var(--ss-primary-lighter);
 }
 
 /* list separator */
-#file-list > div {border-bottom: 1px solid var(--ss-border);}
-#file-list > div:last-child{border-bottom: none;}
+.file-row {border-bottom: 1px solid var(--ss-border);}
+.file-row:last-child{border-bottom: none;}
 
 
 /* Medium and large screens */
@@ -49,16 +55,16 @@
 
 // ── Dark mode refinements ──
 :host-context([data-bs-theme="dark"]) {
-    #file-list > div:nth-child(even) {
+    .file-row:nth-child(even) {
         background-color: rgba(255, 255, 255, 0.02);
     }
 
-    #file-list > div {
+    .file-row {
         border-bottom-color: rgba(255, 255, 255, 0.04);
         transition: background 120ms ease;
     }
 
-    #file-list > div:last-child {
+    .file-row:last-child {
         border-bottom: none;
     }
 

--- a/src/angular/src/app/pages/files/file-list.component.scss
+++ b/src/angular/src/app/pages/files/file-list.component.scss
@@ -4,20 +4,22 @@
     display: none;
 }
 
-/* Virtual scroll viewport */
+/* Virtual scroll viewport — 160px accounts for navbar (56px) + header row (40px) + file-options bar (48px) + padding (16px) */
+$file-list-chrome-height: 160px;
 .file-viewport {
-    height: calc(100vh - 160px);
+    height: calc(100vh - $file-list-chrome-height);
     min-height: 200px;
 }
 
-/* striped rows */
-.file-row:nth-child(even){
+/* striped rows — use template-driven .even class instead of :nth-child
+   because virtual scroll recycles DOM nodes */
+.file-row.even {
     background-color: var(--ss-primary-lighter);
 }
 
-/* list separator */
-.file-row {border-bottom: 1px solid var(--ss-border);}
-.file-row:last-child{border-bottom: none;}
+/* list separator — use top-border so recycled rows always show a separator
+   regardless of DOM position (no :last-child needed) */
+.file-row + .file-row {border-top: 1px solid var(--ss-border);}
 
 
 /* Medium and large screens */
@@ -55,17 +57,16 @@
 
 // ── Dark mode refinements ──
 :host-context([data-bs-theme="dark"]) {
-    .file-row:nth-child(even) {
+    .file-row.even {
         background-color: rgba(255, 255, 255, 0.02);
     }
 
-    .file-row {
-        border-bottom-color: rgba(255, 255, 255, 0.04);
-        transition: background 120ms ease;
+    .file-row + .file-row {
+        border-top-color: rgba(255, 255, 255, 0.04);
     }
 
-    .file-row:last-child {
-        border-bottom: none;
+    .file-row {
+        transition: background 120ms ease;
     }
 
     #header div {

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -114,6 +114,8 @@ describe('FileListComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(FileListComponent);
+    // Give the virtual scroll viewport a stable height so it renders items
+    (fixture.nativeElement as HTMLElement).style.height = '400px';
     fixture.detectChanges();
     component = fixture.componentInstance;
   });

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { BehaviorSubject, Observable, of, EMPTY } from 'rxjs';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 import { FileListComponent } from './file-list.component';
 import { ViewFileService } from '../../services/files/view-file.service';
@@ -104,7 +105,7 @@ describe('FileListComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [FileListComponent],
+      imports: [FileListComponent, ScrollingModule],
       providers: [
         { provide: ViewFileService, useValue: mockViewFileService },
         { provide: ViewFileOptionsService, useValue: { options$: optionsSubject.asObservable() } },

--- a/src/angular/src/app/pages/files/file-list.component.ts
+++ b/src/angular/src/app/pages/files/file-list.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, DestroyRef, inject } from '@angular
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AsyncPipe } from '@angular/common';
 import { Observable } from 'rxjs';
+import { CdkVirtualScrollViewport, CdkFixedSizeVirtualScroll, CdkVirtualForOf } from '@angular/cdk/scrolling';
 
 import { ViewFileService } from '../../services/files/view-file.service';
 import { WebReaction } from '../../services/utils/rest.service';
@@ -16,7 +17,7 @@ import { BulkActionBarComponent } from './bulk-action-bar.component';
 @Component({
   selector: 'app-file-list',
   standalone: true,
-  imports: [AsyncPipe, FileComponent, BulkActionBarComponent],
+  imports: [AsyncPipe, FileComponent, BulkActionBarComponent, CdkVirtualScrollViewport, CdkFixedSizeVirtualScroll, CdkVirtualForOf],
   templateUrl: './file-list.component.html',
   styleUrls: ['./file-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush


### PR DESCRIPTION
## Summary
- Install `@angular/cdk` and use `CdkVirtualScrollViewport` with fixed-size strategy (`itemSize=50`) for windowed file list rendering
- Replace `@for` loop with `*cdkVirtualFor` — only visible rows are rendered in the DOM
- Viewport fills available height via `calc(100vh - 160px)`
- Header and bulk action bar remain outside the scrolling area
- Striped row and border CSS selectors updated for `.file-row` class

## Test plan
- [ ] All 303 Vitest tests pass
- [ ] Angular build succeeds
- [ ] Verify smooth scrolling with 10+ files in UI
- [ ] Verify selection, filtering, and bulk actions work correctly within virtual scroll
- [ ] Verify striped rows render correctly in both light and dark mode
- [ ] Verify no visual jumps when scrolling

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File list now uses virtual scrolling for better performance with large file sets.

* **Style**
  * Updated file-list layout and row/separator styling to work with virtual scrolling and recycled DOM nodes.

* **Tests**
  * Test adjustments to provide a stable viewport and include scrolling support.

* **Chores**
  * Added Angular CDK as a dependency to enable virtual scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->