### PR TITLE
Promote recommended workflow to front-and-center in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,20 @@ You can limit download speed in Settings under the **Connections** section. The 
 - Values with suffixes: `K` for KB/s, `M` for MB/s (e.g., `500K`, `2M`)
 - `0` or empty for unlimited
 
+## Recommended Workflow
+
+The best way to use SeedSync is with **hard links** and a dedicated completion directory:
+
+1. **Configure your torrent client** (qBittorrent, ruTorrent, etc.) to hard link completed downloads into a separate folder (e.g., `/downloads/complete`). Hard links don't use extra disk space — your originals stay intact for seeding.
+2. **Point SeedSync** at the completion directory.
+3. **Enable Auto-Queue** and turn on **"Delete remote file after syncing"** in Settings.
+
+This way, each file is downloaded exactly once. After SeedSync syncs it, the hard link is removed from the completion directory, so it's never re-downloaded — even after a container restart. Your originals remain untouched for seeding.
+
+> **Note**: Both directories must be on the same filesystem for hard links to work.
+
+See the [full setup guide](https://nitrobass24.github.io/seedsync/usage#recommended-setup) in the docs for directory layout examples and torrent client configuration.
+
 ## Building from Source
 
 ```bash
@@ -235,12 +249,6 @@ Fix:
 1. Change **Server Script Path** to a location outside your sync tree (`~` or `~/.local`)
 2. Remove the conflicting directory from the remote server: `rm -rf /your/sync/path/scanfs`
 3. Restart the container
-
-### Recommended Setup with Hard Links
-
-The preferred way to use SeedSync is with a dedicated completion directory using **hard links**. Configure your torrent client to hard link completed downloads to a separate folder (e.g., `/downloads/complete`), point SeedSync at that folder, and enable auto-delete of remote files after syncing. Hard links don't use extra disk space, and your originals remain intact for seeding. Note: both directories must be on the same filesystem for hard links to work.
-
-See the [FAQ](https://nitrobass24.github.io/seedsync/faq#what-is-the-recommended-way-to-set-up-seedsync-with-my-torrent-client) for a detailed setup guide and [qbit-hardlinker](https://github.com/gravelfreeman/qbit-hardlinker) for qBittorrent integration.
 
 ## Report an Issue
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -89,37 +89,7 @@ Leave it empty to use the system default `python3`.
 
 ## What is the recommended way to set up SeedSync with my torrent client?
 
-The best approach is to use **hard links** with a dedicated completion directory. This keeps SeedSync's sync directory clean, avoids downloading files you don't want, and lets your torrents continue seeding without interference.
-
-### How it works
-
-1. **Configure your torrent client** (ruTorrent, qBittorrent, etc.) to hard link completed downloads into a dedicated directory. For example, if your client downloads to `/downloads/tv`, have it hard link completed files to `/downloads/complete`.
-2. **Point SeedSync** at the completion directory (`/downloads/complete`).
-3. **Enable Auto-Queue** and turn on **"Delete remote file after syncing"** in SeedSync settings.
-
-:::note
-Hard links only work when both directories are on the **same filesystem**. If your download and completion directories are on different mounts, use a bind mount to place them on the same filesystem, or use a copy-on-complete script instead (at the cost of extra disk space).
-:::
-
-Hard links don't consume extra disk space on the seedbox — they create another reference to the same data on disk. When SeedSync finishes syncing and deletes from `/downloads/complete`, only the hard link is removed. The original file stays intact for seeding.
-
-### Setting up hard links
-
-- **qBittorrent**: Use [qbit-hardlinker](https://github.com/gravelfreeman/qbit-hardlinker) to automatically hard link completed downloads to your SeedSync directory.
-- **ruTorrent**: Use a post-completion script that creates hard links. Note that the Autotools "Move to" option performs a *move*, not a hard link — this would break seeding since the original file is relocated.
-
-### Example directory layout
-
-```text
-/downloads/
-├── tv/              ← Sonarr downloads here, torrents continue seeding
-├── movies/          ← Radarr downloads here
-└── complete/        ← Hard links go here, SeedSync watches this directory
-```
-
-:::tip
-This setup also solves the common problem of setting up SeedSync on a seedbox that already has many existing files. Since only newly completed downloads get hard linked into the completion directory, SeedSync won't try to sync your entire library.
-:::
+Use hard links with a dedicated completion directory and enable "Delete remote file after syncing." See the [Recommended Setup](./usage.md#recommended-setup) guide for full details.
 
 ## Where are settings stored?
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -28,6 +28,7 @@ This is the modernized fork of `ipsingh06/seedsync`, with updated dependencies a
 1. Follow the [Installation](./installation.md) guide to run the container.
 2. Open the web UI at `http://localhost:8800`.
 3. Go to Settings and configure your remote server and local paths.
+4. Set up the [recommended workflow](./usage.md#recommended-setup) with hard links and auto-delete for a sync-once, never-re-download setup.
 
 ## Docs
 

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -2,6 +2,40 @@
 title: Usage
 ---
 
+## Recommended Setup
+
+The best way to use SeedSync is with **hard links** and a dedicated completion directory. This ensures each file is downloaded exactly once and is never re-downloaded — even after a container restart.
+
+### How it works
+
+1. **Configure your torrent client** (qBittorrent, ruTorrent, etc.) to hard link completed downloads into a dedicated directory. For example, if your client downloads to `/downloads/tv`, have it hard link completed files to `/downloads/complete`.
+2. **Point SeedSync** at the completion directory (`/downloads/complete`).
+3. **Enable Auto-Queue** and turn on **"Delete remote file after syncing"** in Settings.
+
+Hard links don't consume extra disk space on the seedbox — they create another reference to the same data on disk. When SeedSync finishes syncing and deletes from `/downloads/complete`, only the hard link is removed. The original file stays intact for seeding.
+
+:::note
+Hard links only work when both directories are on the **same filesystem**. If your download and completion directories are on different mounts, use a bind mount to place them on the same filesystem, or use a copy-on-complete script instead (at the cost of extra disk space).
+:::
+
+### Setting up hard links
+
+- **qBittorrent**: Use [qbit-hardlinker](https://github.com/gravelfreeman/qbit-hardlinker) to automatically hard link completed downloads to your SeedSync directory.
+- **ruTorrent**: Use a post-completion script that creates hard links. Note that the Autotools "Move to" option performs a *move*, not a hard link — this would break seeding since the original file is relocated.
+
+### Example directory layout
+
+```text
+/downloads/
+├── tv/              ← Sonarr downloads here, torrents continue seeding
+├── movies/          ← Radarr downloads here
+└── complete/        ← Hard links go here, SeedSync watches this directory
+```
+
+:::tip
+This setup also solves the common problem of setting up SeedSync on a seedbox that already has many existing files. Since only newly completed downloads get hard linked into the completion directory, SeedSync won't try to sync your entire library.
+:::
+
 ## Dashboard
 
 The Dashboard lists files and folders on the remote server and the local machine. From here you can:

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -33,7 +33,7 @@ Hard links only work when both directories are on the **same filesystem**. If yo
 ```
 
 :::tip
-This setup also solves the common problem of setting up SeedSync on a seedbox that already has many existing files. Since only newly completed downloads get hard linked into the completion directory, SeedSync won't try to sync your entire library.
+This setup also solves the common problem of setting up SeedSync on a seedbox that already has many existing files. Since only newly completed downloads get hard-linked into the completion directory, SeedSync won't try to sync your entire library.
 :::
 
 ## Dashboard


### PR DESCRIPTION
## Summary
- Moved the hard links + delete-remote setup guide from FAQ/Troubleshooting to the **top of the Usage page** and a new **Recommended Workflow** section in the README
- Added step 4 to the docs site quick start pointing to the recommended workflow
- Replaced the detailed FAQ entry with a cross-reference to avoid duplication

Motivated by [#339](https://github.com/nitrobass24/seedsync/issues/339) — users weren't finding the recommended workflow because it was buried.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Build docs site locally (`cd website && npm run build`) and confirm usage page anchor `#recommended-setup` works
- [ ] Confirm FAQ cross-reference link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Recommended Workflow" describing a hard-link-based setup (use a dedicated completion directory, enable Auto-Queue and “Delete remote file after syncing”) to ensure files download once and avoid re-downloading after restarts.
  * Consolidated and simplified hard-link guidance across docs and FAQ, with links to the full setup guide and alternative options for same-filesystem constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->