### PR TITLE
Fix bulk delete crash from unbounded process spawning

### DIFF
--- a/src/angular/src/app/services/files/view-file.service.ts
+++ b/src/angular/src/app/services/files/view-file.service.ts
@@ -199,23 +199,24 @@ export class ViewFileService {
   }
 
   bulkDeleteLocal(): Observable<WebReaction[]> {
-    return this.bulkAction(f => f.isLocallyDeletable, f => this.deleteLocal(f));
+    return this.bulkAction(f => f.isLocallyDeletable, f => this.deleteLocal(f), 4);
   }
 
   bulkDeleteRemote(): Observable<WebReaction[]> {
-    return this.bulkAction(f => f.isRemotelyDeletable, f => this.deleteRemote(f));
+    return this.bulkAction(f => f.isRemotelyDeletable, f => this.deleteRemote(f), 4);
   }
 
   private bulkAction(
     filter: (f: ViewFile) => boolean,
-    action: (f: ViewFile) => Observable<WebReaction>
+    action: (f: ViewFile) => Observable<WebReaction>,
+    concurrency: number = Infinity
   ): Observable<WebReaction[]> {
     const checked = this.files.filter(f => this.checkedSet.has(viewFileKey(f)) && filter(f));
     if (checked.length === 0) {
       return of([]);
     }
     return from(checked).pipe(
-      mergeMap(f => action(f), 4),
+      mergeMap(f => action(f), concurrency),
       toArray()
     );
   }

--- a/src/angular/src/app/services/files/view-file.service.ts
+++ b/src/angular/src/app/services/files/view-file.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
-import { BehaviorSubject, Observable, of, forkJoin } from 'rxjs';
+import { BehaviorSubject, Observable, of, from } from 'rxjs';
+import { mergeMap, toArray } from 'rxjs/operators';
 
 import { LoggerService } from '../utils/logger.service';
 import { ModelFileService } from './model-file.service';
@@ -213,7 +214,10 @@ export class ViewFileService {
     if (checked.length === 0) {
       return of([]);
     }
-    return forkJoin(checked.map(f => action(f)));
+    return from(checked).pipe(
+      mergeMap(f => action(f), 4),
+      toArray()
+    );
   }
 
   setFilterCriteria(criteria: ViewFileFilterCriteria | null): void {

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -1194,6 +1194,8 @@ class Controller:
 
             elif command.action == Controller.Command.Action.DELETE_LOCAL:
                 if len(self.__active_command_processes) >= Controller._MAX_CONCURRENT_COMMAND_PROCESSES:
+                    self.logger.debug("Deferring %s for '%s': %d active processes at cap",
+                                     command.action, command.filename, len(self.__active_command_processes))
                     deferred.append(command)
                     continue
                 if file.state not in (
@@ -1237,6 +1239,8 @@ class Controller:
 
             elif command.action == Controller.Command.Action.DELETE_REMOTE:
                 if len(self.__active_command_processes) >= Controller._MAX_CONCURRENT_COMMAND_PROCESSES:
+                    self.logger.debug("Deferring %s for '%s': %d active processes at cap",
+                                     command.action, command.filename, len(self.__active_command_processes))
                     deferred.append(command)
                     continue
                 if file.state not in (

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -1194,8 +1194,12 @@ class Controller:
 
             elif command.action == Controller.Command.Action.DELETE_LOCAL:
                 if len(self.__active_command_processes) >= Controller._MAX_CONCURRENT_COMMAND_PROCESSES:
-                    self.logger.debug("Deferring %s for '%s': %d active processes at cap",
-                                     command.action, command.filename, len(self.__active_command_processes))
+                    self.logger.debug(
+                        "Deferring %s for '%s': %d active processes at cap",
+                        command.action,
+                        command.filename,
+                        len(self.__active_command_processes),
+                    )
                     deferred.append(command)
                     continue
                 if file.state not in (
@@ -1239,8 +1243,12 @@ class Controller:
 
             elif command.action == Controller.Command.Action.DELETE_REMOTE:
                 if len(self.__active_command_processes) >= Controller._MAX_CONCURRENT_COMMAND_PROCESSES:
-                    self.logger.debug("Deferring %s for '%s': %d active processes at cap",
-                                     command.action, command.filename, len(self.__active_command_processes))
+                    self.logger.debug(
+                        "Deferring %s for '%s': %d active processes at cap",
+                        command.action,
+                        command.filename,
+                        len(self.__active_command_processes),
+                    )
                     deferred.append(command)
                     continue
                 if file.state not in (

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -1390,7 +1390,7 @@ class Controller:
             return
 
         self.__moved_file_keys.add(move_key)
-        process = MoveProcess(source_path=staging_source, dest_path=dest_path, file_name=file_name)
+        process = MoveProcess(source_path=staging_source, dest_path=dest_path, file_name=file_name, pair_id=pair_id)
         process.set_mp_log_queue(self.__mp_logger.queue, self.__mp_logger.log_level)
         self.__active_move_processes.append(process)
         process.start()
@@ -1422,6 +1422,8 @@ class Controller:
                     move_process.propagate_exception()
                 except Exception:
                     self.logger.warning("Move process failed: %s", move_process.name, exc_info=True)
+                    move_key = _persist_key(move_process.pair_id, move_process.file_name)
+                    self.__moved_file_keys.discard(move_key)
                 for pc in self.__pair_contexts:
                     pc.local_scan_process.force_scan()
         self.__active_move_processes = still_active_moves

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -235,6 +235,8 @@ class Controller:
             self.process = process
             self.post_callback = post_callback
 
+    _MAX_CONCURRENT_COMMAND_PROCESSES = 8
+
     def __init__(self, context: Context, persist: ControllerPersist):
         self.__context = context
         self.__persist = persist
@@ -1189,6 +1191,9 @@ class Controller:
                     self.__extract_process.extract(req)
 
             elif command.action == Controller.Command.Action.DELETE_LOCAL:
+                if len(self.__active_command_processes) >= Controller._MAX_CONCURRENT_COMMAND_PROCESSES:
+                    self.__command_queue.put(command)
+                    continue
                 if file.state not in (
                     ModelFile.State.DEFAULT,
                     ModelFile.State.DOWNLOADED,
@@ -1229,6 +1234,9 @@ class Controller:
                     command_wrapper.process.start()
 
             elif command.action == Controller.Command.Action.DELETE_REMOTE:
+                if len(self.__active_command_processes) >= Controller._MAX_CONCURRENT_COMMAND_PROCESSES:
+                    self.__command_queue.put(command)
+                    continue
                 if file.state not in (
                     ModelFile.State.DEFAULT,
                     ModelFile.State.DOWNLOADED,
@@ -1393,7 +1401,10 @@ class Controller:
             if move_process.is_alive():
                 still_active_moves.append(move_process)
             else:
-                move_process.propagate_exception()
+                try:
+                    move_process.propagate_exception()
+                except Exception:
+                    self.logger.warning("Move process failed: %s", move_process.name, exc_info=True)
                 for pc in self.__pair_contexts:
                     pc.local_scan_process.force_scan()
         self.__active_move_processes = still_active_moves

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -1131,6 +1131,8 @@ class Controller:
             for _callback in _command.callbacks:
                 _callback.on_failure(_msg)
 
+        deferred: list[Controller.Command] = []
+
         while not self.__command_queue.empty():
             command = self.__command_queue.get()
             self.logger.info("Received command {} for file {}".format(str(command.action), command.filename))
@@ -1192,7 +1194,7 @@ class Controller:
 
             elif command.action == Controller.Command.Action.DELETE_LOCAL:
                 if len(self.__active_command_processes) >= Controller._MAX_CONCURRENT_COMMAND_PROCESSES:
-                    self.__command_queue.put(command)
+                    deferred.append(command)
                     continue
                 if file.state not in (
                     ModelFile.State.DEFAULT,
@@ -1235,7 +1237,7 @@ class Controller:
 
             elif command.action == Controller.Command.Action.DELETE_REMOTE:
                 if len(self.__active_command_processes) >= Controller._MAX_CONCURRENT_COMMAND_PROCESSES:
-                    self.__command_queue.put(command)
+                    deferred.append(command)
                     continue
                 if file.state not in (
                     ModelFile.State.DEFAULT,
@@ -1313,6 +1315,9 @@ class Controller:
 
             for callback in command.callbacks:
                 callback.on_success()
+
+        for cmd in deferred:
+            self.__command_queue.put(cmd)
 
     def __propagate_exceptions(self):
         """

--- a/src/python/controller/move/move_process.py
+++ b/src/python/controller/move/move_process.py
@@ -15,11 +15,20 @@ class MoveProcess(AppOneShotProcess):
     for cross-device moves.
     """
 
-    def __init__(self, source_path: str, dest_path: str, file_name: str):
+    def __init__(self, source_path: str, dest_path: str, file_name: str, pair_id: str | None = None):
         super().__init__(name=self.__class__.__name__)
         self.__source_path = source_path
         self.__dest_path = dest_path
         self.__file_name = file_name
+        self._pair_id = pair_id
+
+    @property
+    def file_name(self) -> str:
+        return self.__file_name
+
+    @property
+    def pair_id(self) -> str | None:
+        return self._pair_id
 
     @staticmethod
     def _get_total_size(path: str) -> int:


### PR DESCRIPTION
## Summary
- **Backend**: Cap concurrent delete/command subprocesses at 8 in the controller. Excess commands are re-queued and processed on the next tick (500ms). Prevents exhausting file descriptors, process limits, and semaphores in Docker containers.
- **Backend**: Guard `MoveProcess.propagate_exception()` with try/except so a failed staging move no longer crashes the controller.
- **Frontend**: Replace `forkJoin` (all N requests simultaneously) with `mergeMap` capped at 4 concurrent HTTP requests as defense-in-depth.

Closes #338

## Test plan
- [ ] Angular unit tests pass (303 tests)
- [ ] Select 50+ files and bulk delete local — verify no crash, files deleted in batches
- [ ] Verify single file delete still works normally
- [ ] Verify bulk queue/stop (non-process commands) are unaffected by the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bulk file operations now run with controlled parallelism to avoid saturating resources.
  * Delete operations are automatically queued and deferred under high load to maintain responsiveness.
  * Overall process capacity management added to limit concurrent work and prevent overload.
  * Cleanup and error handling improved to increase reliability during move/delete workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->