### PR TITLE
Add Sonarr/Radarr integration (#328)

### DIFF
--- a/src/angular/src/app/models/config.ts
+++ b/src/angular/src/app/models/config.ts
@@ -68,6 +68,15 @@ export interface Notifications {
   notify_on_delete_complete: boolean | null;
 }
 
+export interface Integrations {
+  sonarr_url: string | null;
+  sonarr_api_key: string | null;
+  sonarr_enabled: boolean | null;
+  radarr_url: string | null;
+  radarr_api_key: string | null;
+  radarr_enabled: boolean | null;
+}
+
 export interface Validate {
   enabled: boolean | null;
   algorithm: string | null;
@@ -86,6 +95,7 @@ export interface Config {
   autoqueue: AutoQueue;
   logging: Logging;
   notifications: Notifications;
+  integrations: Integrations;
   validate: Validate;
 }
 
@@ -154,6 +164,15 @@ export const DEFAULT_NOTIFICATIONS: Notifications = {
   notify_on_delete_complete: null,
 };
 
+export const DEFAULT_INTEGRATIONS: Integrations = {
+  sonarr_url: null,
+  sonarr_api_key: null,
+  sonarr_enabled: null,
+  radarr_url: null,
+  radarr_api_key: null,
+  radarr_enabled: null,
+};
+
 export const DEFAULT_VALIDATE: Validate = {
   enabled: null,
   algorithm: null,
@@ -169,5 +188,6 @@ export const DEFAULT_CONFIG: Config = {
   autoqueue: { ...DEFAULT_AUTOQUEUE },
   logging: { ...DEFAULT_LOGGING },
   notifications: { ...DEFAULT_NOTIFICATIONS },
+  integrations: { ...DEFAULT_INTEGRATIONS },
   validate: { ...DEFAULT_VALIDATE },
 };

--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -406,6 +406,56 @@ export const OPTIONS_CONTEXT_VALIDATE: IOptionsContext = {
   ],
 };
 
+export const OPTIONS_CONTEXT_INTEGRATIONS_SONARR: IOptionsContext = {
+  header: 'Sonarr',
+  id: 'integrations-sonarr',
+  options: [
+    {
+      type: OptionType.Checkbox,
+      label: 'Enable Sonarr integration',
+      valuePath: ['integrations', 'sonarr_enabled'],
+      description: 'Trigger Sonarr to scan for downloaded episodes when a download completes',
+    },
+    {
+      type: OptionType.Text,
+      label: 'Sonarr URL',
+      valuePath: ['integrations', 'sonarr_url'],
+      description: 'Base URL for Sonarr (e.g. http://localhost:8989)',
+    },
+    {
+      type: OptionType.Password,
+      label: 'Sonarr API Key',
+      valuePath: ['integrations', 'sonarr_api_key'],
+      description: 'Found in Sonarr under Settings > General > API Key',
+    },
+  ],
+};
+
+export const OPTIONS_CONTEXT_INTEGRATIONS_RADARR: IOptionsContext = {
+  header: 'Radarr',
+  id: 'integrations-radarr',
+  options: [
+    {
+      type: OptionType.Checkbox,
+      label: 'Enable Radarr integration',
+      valuePath: ['integrations', 'radarr_enabled'],
+      description: 'Trigger Radarr to scan for downloaded movies when a download completes',
+    },
+    {
+      type: OptionType.Text,
+      label: 'Radarr URL',
+      valuePath: ['integrations', 'radarr_url'],
+      description: 'Base URL for Radarr (e.g. http://localhost:7878)',
+    },
+    {
+      type: OptionType.Password,
+      label: 'Radarr API Key',
+      valuePath: ['integrations', 'radarr_api_key'],
+      description: 'Found in Radarr under Settings > General > API Key',
+    },
+  ],
+};
+
 export const OPTIONS_CONTEXT_EXTRACT: IOptionsContext = {
   header: 'Archive Extraction',
   id: 'extraction',

--- a/src/angular/src/app/pages/settings/settings-page.component.html
+++ b/src/angular/src/app/pages/settings/settings-page.component.html
@@ -68,6 +68,61 @@
       <ng-container
         *ngTemplateOutlet="optionsList; context: OPTIONS_CONTEXT_NOTIFICATIONS">
       </ng-container>
+
+      <div class="card">
+        <h3 class="card-header">Integrations</h3>
+        <div class="card-body">
+          <h5>Sonarr</h5>
+          @for (option of OPTIONS_CONTEXT_INTEGRATIONS_SONARR.options; track option.label) {
+            <div>
+              <app-option
+                [type]="option.type"
+                [label]="option.label"
+                [description]="option.description"
+                [choices]="option.choices || []"
+                [value]="getOptionValue(config$ | async, option.valuePath)"
+                (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event)">
+              </app-option>
+            </div>
+          }
+          <div class="test-connection">
+            <button class="btn btn-sm btn-outline-secondary" [disabled]="sonarrTesting" (click)="onTestSonarr()">
+              {{ sonarrTesting ? 'Testing...' : 'Test Connection' }}
+            </button>
+            @if (sonarrTestResult) {
+              <span class="test-result" [class.text-success]="sonarrTestResult.success" [class.text-danger]="!sonarrTestResult.success">
+                {{ sonarrTestResult.message }}
+              </span>
+            }
+          </div>
+
+          <hr />
+
+          <h5>Radarr</h5>
+          @for (option of OPTIONS_CONTEXT_INTEGRATIONS_RADARR.options; track option.label) {
+            <div>
+              <app-option
+                [type]="option.type"
+                [label]="option.label"
+                [description]="option.description"
+                [choices]="option.choices || []"
+                [value]="getOptionValue(config$ | async, option.valuePath)"
+                (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event)">
+              </app-option>
+            </div>
+          }
+          <div class="test-connection">
+            <button class="btn btn-sm btn-outline-secondary" [disabled]="radarrTesting" (click)="onTestRadarr()">
+              {{ radarrTesting ? 'Testing...' : 'Test Connection' }}
+            </button>
+            @if (radarrTestResult) {
+              <span class="test-result" [class.text-success]="radarrTestResult.success" [class.text-danger]="!radarrTestResult.success">
+                {{ radarrTestResult.message }}
+              </span>
+            }
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/src/angular/src/app/pages/settings/settings-page.component.html
+++ b/src/angular/src/app/pages/settings/settings-page.component.html
@@ -79,6 +79,7 @@
                 [type]="option.type"
                 [label]="option.label"
                 [description]="option.description"
+                [disabled]="!!option.disabled"
                 [choices]="option.choices || []"
                 [value]="getOptionValue(config$ | async, option.valuePath)"
                 (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event)">
@@ -105,6 +106,7 @@
                 [type]="option.type"
                 [label]="option.label"
                 [description]="option.description"
+                [disabled]="!!option.disabled"
                 [choices]="option.choices || []"
                 [value]="getOptionValue(config$ | async, option.valuePath)"
                 (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event)">

--- a/src/angular/src/app/pages/settings/settings-page.component.html
+++ b/src/angular/src/app/pages/settings/settings-page.component.html
@@ -86,7 +86,7 @@
             </div>
           }
           <div class="test-connection">
-            <button class="btn btn-sm btn-outline-secondary" [disabled]="sonarrTesting" (click)="onTestSonarr()">
+            <button type="button" class="btn btn-sm btn-outline-secondary" [disabled]="sonarrTesting" (click)="onTestSonarr()">
               {{ sonarrTesting ? 'Testing...' : 'Test Connection' }}
             </button>
             @if (sonarrTestResult) {
@@ -112,7 +112,7 @@
             </div>
           }
           <div class="test-connection">
-            <button class="btn btn-sm btn-outline-secondary" [disabled]="radarrTesting" (click)="onTestRadarr()">
+            <button type="button" class="btn btn-sm btn-outline-secondary" [disabled]="radarrTesting" (click)="onTestRadarr()">
               {{ radarrTesting ? 'Testing...' : 'Test Connection' }}
             </button>
             @if (radarrTestResult) {

--- a/src/angular/src/app/pages/settings/settings-page.component.html
+++ b/src/angular/src/app/pages/settings/settings-page.component.html
@@ -91,7 +91,7 @@
               {{ sonarrTesting ? 'Testing...' : 'Test Connection' }}
             </button>
             @if (sonarrTestResult) {
-              <span class="test-result" [class.text-success]="sonarrTestResult.success" [class.text-danger]="!sonarrTestResult.success">
+              <span class="test-result" aria-live="polite" aria-atomic="true" [class.text-success]="sonarrTestResult.success" [class.text-danger]="!sonarrTestResult.success">
                 {{ sonarrTestResult.message }}
               </span>
             }
@@ -118,7 +118,7 @@
               {{ radarrTesting ? 'Testing...' : 'Test Connection' }}
             </button>
             @if (radarrTestResult) {
-              <span class="test-result" [class.text-success]="radarrTestResult.success" [class.text-danger]="!radarrTestResult.success">
+              <span class="test-result" aria-live="polite" aria-atomic="true" [class.text-success]="radarrTestResult.success" [class.text-danger]="!radarrTestResult.success">
                 {{ radarrTestResult.message }}
               </span>
             }

--- a/src/angular/src/app/pages/settings/settings-page.component.scss
+++ b/src/angular/src/app/pages/settings/settings-page.component.scss
@@ -83,6 +83,17 @@
 }
 
 
+.test-connection {
+    padding: 8px 15px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+
+    .test-result {
+        font-size: 85%;
+    }
+}
+
 /* Medium and large screens */
 @media only screen and (min-width: $medium-min-width) {
     #settings {

--- a/src/angular/src/app/pages/settings/settings-page.component.spec.ts
+++ b/src/angular/src/app/pages/settings/settings-page.component.spec.ts
@@ -1,7 +1,17 @@
 import '@angular/compiler';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { BehaviorSubject, of } from 'rxjs';
 import { SettingsPageComponent } from './settings-page.component';
 import { OptionType } from './option.component';
+import { LoggerService } from '../../services/utils/logger.service';
+import { ConfigService } from '../../services/settings/config.service';
+import { IntegrationsService, TestConnectionResult } from '../../services/settings/integrations.service';
+import { NotificationService } from '../../services/utils/notification.service';
+import { ServerCommandService } from '../../services/server/server-command.service';
+import { ConnectedService } from '../../services/utils/connected.service';
+import { PathPairsService } from '../../services/settings/path-pairs.service';
+import { Config, DEFAULT_CONFIG } from '../../models/config';
 import {
   IOptionsContext,
   OPTIONS_CONTEXT_INTEGRATIONS_SONARR,
@@ -114,5 +124,107 @@ describe('Integrations options contexts', () => {
     for (const opt of OPTIONS_CONTEXT_INTEGRATIONS_RADARR.options) {
       expect(opt.valuePath[0]).toBe('integrations');
     }
+  });
+});
+
+describe('SettingsPageComponent integration tests', () => {
+  let fixture: ComponentFixture<SettingsPageComponent>;
+  let component: SettingsPageComponent;
+  let configSubject: BehaviorSubject<Config | null>;
+  let connectedSubject: BehaviorSubject<boolean>;
+  let pairsSubject: BehaviorSubject<any[]>;
+  let mockIntegrationsService: { testSonarr: ReturnType<typeof vi.fn>; testRadarr: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    configSubject = new BehaviorSubject<Config | null>({ ...DEFAULT_CONFIG });
+    connectedSubject = new BehaviorSubject<boolean>(true);
+    pairsSubject = new BehaviorSubject<any[]>([]);
+    mockIntegrationsService = {
+      testSonarr: vi.fn(),
+      testRadarr: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [SettingsPageComponent],
+      providers: [
+        { provide: LoggerService, useValue: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() } },
+        { provide: ConfigService, useValue: { config$: configSubject.asObservable(), set: vi.fn(() => of({ success: true, data: 'ok', errorMessage: null })) } },
+        { provide: IntegrationsService, useValue: mockIntegrationsService },
+        { provide: NotificationService, useValue: { show: vi.fn(), hide: vi.fn() } },
+        { provide: ServerCommandService, useValue: { restart: vi.fn() } },
+        { provide: ConnectedService, useValue: { connected$: connectedSubject.asObservable() } },
+        { provide: PathPairsService, useValue: { pairs$: pairsSubject.asObservable() } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SettingsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should render Integrations card with Sonarr and Radarr headings', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const headings = Array.from(el.querySelectorAll('h5')).map((h) => h.textContent?.trim());
+    expect(headings).toContain('Sonarr');
+    expect(headings).toContain('Radarr');
+  });
+
+  it('should render test connection buttons with type="button"', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const buttons = Array.from(el.querySelectorAll('.test-connection button'));
+    expect(buttons.length).toBe(2);
+    for (const btn of buttons) {
+      expect(btn.getAttribute('type')).toBe('button');
+    }
+  });
+
+  it('should call integrationsService.testSonarr on Sonarr test button click', () => {
+    const successResult: TestConnectionResult = { success: true, message: 'Sonarr connected (v4.0.0)' };
+    mockIntegrationsService.testSonarr.mockReturnValue(of(successResult));
+
+    component.onTestSonarr();
+    fixture.detectChanges();
+
+    expect(mockIntegrationsService.testSonarr).toHaveBeenCalledOnce();
+    expect(component.sonarrTestResult).toEqual(successResult);
+    expect(component.sonarrTesting).toBe(false);
+  });
+
+  it('should call integrationsService.testRadarr on Radarr test button click', () => {
+    const successResult: TestConnectionResult = { success: true, message: 'Radarr connected (v5.2.0)' };
+    mockIntegrationsService.testRadarr.mockReturnValue(of(successResult));
+
+    component.onTestRadarr();
+    fixture.detectChanges();
+
+    expect(mockIntegrationsService.testRadarr).toHaveBeenCalledOnce();
+    expect(component.radarrTestResult).toEqual(successResult);
+    expect(component.radarrTesting).toBe(false);
+  });
+
+  it('should display failure result in the DOM after failed test', () => {
+    const failResult: TestConnectionResult = { success: false, message: 'Connection failed: refused' };
+    mockIntegrationsService.testSonarr.mockReturnValue(of(failResult));
+
+    component.onTestSonarr();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const resultSpan = el.querySelector('.test-connection .test-result.text-danger');
+    expect(resultSpan).not.toBeNull();
+    expect(resultSpan!.textContent?.trim()).toContain('Connection failed');
+  });
+
+  it('should display success result in the DOM after successful test', () => {
+    const successResult: TestConnectionResult = { success: true, message: 'Sonarr connected (v4.0.0)' };
+    mockIntegrationsService.testSonarr.mockReturnValue(of(successResult));
+
+    component.onTestSonarr();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const resultSpan = el.querySelector('.test-connection .test-result.text-success');
+    expect(resultSpan).not.toBeNull();
+    expect(resultSpan!.textContent?.trim()).toContain('Sonarr connected');
   });
 });

--- a/src/angular/src/app/pages/settings/settings-page.component.spec.ts
+++ b/src/angular/src/app/pages/settings/settings-page.component.spec.ts
@@ -1,7 +1,12 @@
 import '@angular/compiler';
 import { describe, it, expect } from 'vitest';
 import { SettingsPageComponent } from './settings-page.component';
-import { IOptionsContext } from './options-list';
+import { OptionType } from './option.component';
+import {
+  IOptionsContext,
+  OPTIONS_CONTEXT_INTEGRATIONS_SONARR,
+  OPTIONS_CONTEXT_INTEGRATIONS_RADARR,
+} from './options-list';
 
 // Access private static methods for unit testing
 const buildServerContext = (hasEnabledPairs: boolean): IOptionsContext =>
@@ -65,6 +70,49 @@ describe('SettingsPageComponent.buildAutoqueueContext', () => {
 
     for (const option of others) {
       expect(option.disabled).toBeFalsy();
+    }
+  });
+});
+
+describe('Integrations options contexts', () => {
+  it('Sonarr context should have correct options', () => {
+    expect(OPTIONS_CONTEXT_INTEGRATIONS_SONARR.header).toBe('Sonarr');
+    expect(OPTIONS_CONTEXT_INTEGRATIONS_SONARR.id).toBe('integrations-sonarr');
+    const optionKeys = OPTIONS_CONTEXT_INTEGRATIONS_SONARR.options.map((o) => o.valuePath[1]);
+    expect(optionKeys).toContain('sonarr_enabled');
+    expect(optionKeys).toContain('sonarr_url');
+    expect(optionKeys).toContain('sonarr_api_key');
+  });
+
+  it('Sonarr API key should be a Password field', () => {
+    const apiKeyOption = OPTIONS_CONTEXT_INTEGRATIONS_SONARR.options.find(
+      (o) => o.valuePath[1] === 'sonarr_api_key',
+    )!;
+    expect(apiKeyOption.type).toBe(OptionType.Password);
+  });
+
+  it('Radarr context should have correct options', () => {
+    expect(OPTIONS_CONTEXT_INTEGRATIONS_RADARR.header).toBe('Radarr');
+    expect(OPTIONS_CONTEXT_INTEGRATIONS_RADARR.id).toBe('integrations-radarr');
+    const optionKeys = OPTIONS_CONTEXT_INTEGRATIONS_RADARR.options.map((o) => o.valuePath[1]);
+    expect(optionKeys).toContain('radarr_enabled');
+    expect(optionKeys).toContain('radarr_url');
+    expect(optionKeys).toContain('radarr_api_key');
+  });
+
+  it('Radarr API key should be a Password field', () => {
+    const apiKeyOption = OPTIONS_CONTEXT_INTEGRATIONS_RADARR.options.find(
+      (o) => o.valuePath[1] === 'radarr_api_key',
+    )!;
+    expect(apiKeyOption.type).toBe(OptionType.Password);
+  });
+
+  it('all integrations options should reference the integrations section', () => {
+    for (const opt of OPTIONS_CONTEXT_INTEGRATIONS_SONARR.options) {
+      expect(opt.valuePath[0]).toBe('integrations');
+    }
+    for (const opt of OPTIONS_CONTEXT_INTEGRATIONS_RADARR.options) {
+      expect(opt.valuePath[0]).toBe('integrations');
     }
   });
 });

--- a/src/angular/src/app/pages/settings/settings-page.component.ts
+++ b/src/angular/src/app/pages/settings/settings-page.component.ts
@@ -5,6 +5,7 @@ import { distinctUntilChanged, map } from 'rxjs';
 
 import { LoggerService } from '../../services/utils/logger.service';
 import { ConfigService } from '../../services/settings/config.service';
+import { IntegrationsService } from '../../services/settings/integrations.service';
 import { NotificationService } from '../../services/utils/notification.service';
 import { ServerCommandService } from '../../services/server/server-command.service';
 import { ConnectedService } from '../../services/utils/connected.service';
@@ -28,6 +29,8 @@ import {
   OPTIONS_CONTEXT_ADVANCED_LFTP,
   OPTIONS_CONTEXT_LOGGING,
   OPTIONS_CONTEXT_NOTIFICATIONS,
+  OPTIONS_CONTEXT_INTEGRATIONS_SONARR,
+  OPTIONS_CONTEXT_INTEGRATIONS_RADARR,
 } from './options-list';
 
 @Component({
@@ -50,8 +53,14 @@ export class SettingsPageComponent implements OnInit {
   readonly OPTIONS_CONTEXT_ADVANCED_LFTP = OPTIONS_CONTEXT_ADVANCED_LFTP;
   readonly OPTIONS_CONTEXT_LOGGING = OPTIONS_CONTEXT_LOGGING;
   readonly OPTIONS_CONTEXT_NOTIFICATIONS = OPTIONS_CONTEXT_NOTIFICATIONS;
+  readonly OPTIONS_CONTEXT_INTEGRATIONS_SONARR = OPTIONS_CONTEXT_INTEGRATIONS_SONARR;
+  readonly OPTIONS_CONTEXT_INTEGRATIONS_RADARR = OPTIONS_CONTEXT_INTEGRATIONS_RADARR;
 
   advancedLftpCollapsed = true;
+  sonarrTestResult: { success: boolean; message: string } | null = null;
+  radarrTestResult: { success: boolean; message: string } | null = null;
+  sonarrTesting = false;
+  radarrTesting = false;
 
   private readonly logger = inject(LoggerService);
   private readonly configService = inject(ConfigService);
@@ -59,6 +68,7 @@ export class SettingsPageComponent implements OnInit {
   private readonly commandService = inject(ServerCommandService);
   private readonly connectedService = inject(ConnectedService);
   private readonly pathPairsService = inject(PathPairsService);
+  private readonly integrationsService = inject(IntegrationsService);
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -183,6 +193,30 @@ export class SettingsPageComponent implements OnInit {
 
   toggleAdvancedLftp(): void {
     this.advancedLftpCollapsed = !this.advancedLftpCollapsed;
+  }
+
+  onTestSonarr(): void {
+    this.sonarrTesting = true;
+    this.sonarrTestResult = null;
+    this.integrationsService.testSonarr().subscribe({
+      next: (result) => {
+        this.sonarrTestResult = result;
+        this.sonarrTesting = false;
+        this.cdr.markForCheck();
+      },
+    });
+  }
+
+  onTestRadarr(): void {
+    this.radarrTesting = true;
+    this.radarrTestResult = null;
+    this.integrationsService.testRadarr().subscribe({
+      next: (result) => {
+        this.radarrTestResult = result;
+        this.radarrTesting = false;
+        this.cdr.markForCheck();
+      },
+    });
   }
 
   onCommandRestart(): void {

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -61,6 +61,14 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
       notify_on_extraction_failed: false,
       notify_on_delete_complete: false,
     },
+    integrations: {
+      sonarr_url: null,
+      sonarr_api_key: null,
+      sonarr_enabled: false,
+      radarr_url: null,
+      radarr_api_key: null,
+      radarr_enabled: false,
+    },
     validate: {
       enabled: false,
       algorithm: "md5",

--- a/src/angular/src/app/services/settings/integrations.service.spec.ts
+++ b/src/angular/src/app/services/settings/integrations.service.spec.ts
@@ -1,0 +1,76 @@
+import '@angular/compiler';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { IntegrationsService } from './integrations.service';
+
+describe('IntegrationsService', () => {
+  let service: IntegrationsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting(), IntegrationsService],
+    });
+    service = TestBed.inject(IntegrationsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  it('should return success on Sonarr test', () => {
+    let result: any;
+    service.testSonarr().subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne('/server/integrations/test/sonarr');
+    expect(req.request.method).toBe('GET');
+    req.flush({ success: true, version: '4.0.0.1' });
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('4.0.0.1');
+  });
+
+  it('should return failure on Sonarr error', () => {
+    let result: any;
+    service.testSonarr().subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne('/server/integrations/test/sonarr');
+    req.flush({ error: 'Connection failed: refused' }, { status: 502, statusText: 'Bad Gateway' });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Connection failed');
+  });
+
+  it('should return success on Radarr test', () => {
+    let result: any;
+    service.testRadarr().subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne('/server/integrations/test/radarr');
+    req.flush({ success: true, version: '5.2.0.1' });
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('5.2.0.1');
+  });
+
+  it('should return failure on Radarr error', () => {
+    let result: any;
+    service.testRadarr().subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne('/server/integrations/test/radarr');
+    req.flush({ error: 'API key is not configured' }, { status: 400, statusText: 'Bad Request' });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('API key is not configured');
+  });
+
+  it('should handle non-JSON error gracefully', () => {
+    let result: any;
+    service.testSonarr().subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne('/server/integrations/test/sonarr');
+    req.error(new ProgressEvent('error'));
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Sonarr connection failed');
+  });
+});

--- a/src/angular/src/app/services/settings/integrations.service.spec.ts
+++ b/src/angular/src/app/services/settings/integrations.service.spec.ts
@@ -2,7 +2,7 @@ import '@angular/compiler';
 import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { IntegrationsService } from './integrations.service';
 
@@ -16,6 +16,10 @@ describe('IntegrationsService', () => {
     });
     service = TestBed.inject(IntegrationsService);
     httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should return success on Sonarr test', () => {

--- a/src/angular/src/app/services/settings/integrations.service.ts
+++ b/src/angular/src/app/services/settings/integrations.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+
+export interface TestConnectionResult {
+  readonly success: boolean;
+  readonly message: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class IntegrationsService {
+  private readonly http = inject(HttpClient);
+
+  testSonarr(): Observable<TestConnectionResult> {
+    return this._testConnection('/server/integrations/test/sonarr', 'Sonarr');
+  }
+
+  testRadarr(): Observable<TestConnectionResult> {
+    return this._testConnection('/server/integrations/test/radarr', 'Radarr');
+  }
+
+  private _testConnection(url: string, service: string): Observable<TestConnectionResult> {
+    return this.http.get<{ success?: boolean; version?: string; error?: string }>(url).pipe(
+      map((data) => ({
+        success: true,
+        message: `${service} connected (v${data.version})`,
+      })),
+      catchError((err: HttpErrorResponse) => {
+        let message: string;
+        try {
+          const body = typeof err.error === 'string' ? JSON.parse(err.error) : err.error;
+          message = body?.error || `${service} connection failed`;
+        } catch {
+          message = `${service} connection failed`;
+        }
+        return of({ success: false, message });
+      }),
+    );
+  }
+}

--- a/src/e2e-playwright/tests/settings.spec.ts
+++ b/src/e2e-playwright/tests/settings.spec.ts
@@ -21,6 +21,7 @@ test.describe("Settings Page", () => {
       "Logging",
       "Other Settings",
       "Notifications",
+      "Integrations",
     ]) {
       await expect(settings.getSection(section)).toBeVisible();
     }

--- a/src/e2e-playwright/tests/settings.spec.ts
+++ b/src/e2e-playwright/tests/settings.spec.ts
@@ -220,7 +220,10 @@ test.describe("Settings Page", () => {
   });
 
   test("API Key field is a password field", async () => {
-    const field = settings.getTextInput("API Key");
+    const otherSettings = settings.getSection("Other Settings");
+    const field = otherSettings
+      .locator("app-option", { hasText: "API Key" })
+      .locator("input[type='text'], input[type='password']");
     await expect(field).toHaveAttribute("type", "password");
   });
 });

--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -380,6 +380,23 @@ class Config(Persist):
             self.notify_on_extraction_failed = True
             self.notify_on_delete_complete = True
 
+    class Integrations(IC):
+        sonarr_url = PROP("sonarr_url", Checkers.string_allow_empty, Converters.null)
+        sonarr_api_key = PROP("sonarr_api_key", Checkers.string_allow_empty, Converters.null)
+        sonarr_enabled = PROP("sonarr_enabled", Checkers.null, Converters.bool)
+        radarr_url = PROP("radarr_url", Checkers.string_allow_empty, Converters.null)
+        radarr_api_key = PROP("radarr_api_key", Checkers.string_allow_empty, Converters.null)
+        radarr_enabled = PROP("radarr_enabled", Checkers.null, Converters.bool)
+
+        def __init__(self):
+            super().__init__()
+            self.sonarr_url = ""
+            self.sonarr_api_key = ""
+            self.sonarr_enabled = False
+            self.radarr_url = ""
+            self.radarr_api_key = ""
+            self.radarr_enabled = False
+
     class Validate(IC):
         enabled = PROP("enabled", Checkers.null, Converters.bool)
         algorithm = PROP("algorithm", Checkers.algorithm_allowed, Converters.null)
@@ -401,6 +418,7 @@ class Config(Persist):
         self.autoqueue = Config.AutoQueue()
         self.logging = Config.Logging()
         self.notifications = Config.Notifications()
+        self.integrations = Config.Integrations()
         self.validate = Config.Validate()
 
     @staticmethod
@@ -457,6 +475,7 @@ class Config(Persist):
         config.autoqueue = Config.AutoQueue.from_dict(config_dict.pop("AutoQueue", {}))
         config.logging = Config.Logging.from_dict(config_dict.pop("Logging", {}))
         config.notifications = Config.Notifications.from_dict(config_dict.pop("Notifications", {}))
+        config.integrations = Config.Integrations.from_dict(config_dict.pop("Integrations", {}))
         config.validate = Config.Validate.from_dict(config_dict.pop("Validate", {}))
 
         Config._check_empty_outer_dict(config_dict)
@@ -473,6 +492,7 @@ class Config(Persist):
         config_dict["AutoQueue"] = self.autoqueue.as_dict()
         config_dict["Logging"] = self.logging.as_dict()
         config_dict["Notifications"] = self.notifications.as_dict()
+        config_dict["Integrations"] = self.integrations.as_dict()
         config_dict["Validate"] = self.validate.as_dict()
         return config_dict
 
@@ -489,6 +509,7 @@ class Config(Persist):
         return {
             "Lftp": {"remote_password"},
             "Web": {"api_key"},
+            "Integrations": {"sonarr_api_key", "radarr_api_key"},
         }
 
     @staticmethod

--- a/src/python/controller/arr_notifier.py
+++ b/src/python/controller/arr_notifier.py
@@ -1,18 +1,20 @@
 import json
 import logging
+import os
 import threading
 import time
 import urllib.request
 
-from common import Config
+from common import Config, PathPairsConfig
 from model import IModelListener, ModelFile
 
 
 class ArrNotifier(IModelListener):
     """Notifies Sonarr/Radarr on download completion so they can trigger import scans."""
 
-    def __init__(self, config: Config, logger: logging.Logger):
+    def __init__(self, config: Config, path_pairs_config: PathPairsConfig, logger: logging.Logger):
         self._config = config
+        self._path_pairs_config = path_pairs_config
         self._logger = logger.getChild("ArrNotifier")
         self._shutdown_flag = False
         self._active_threads: set[threading.Thread] = set()
@@ -31,7 +33,7 @@ class ArrNotifier(IModelListener):
         if new_file.state != ModelFile.State.DOWNLOADED:
             return
 
-        local_path = new_file.full_path
+        local_path = self._resolve_local_path(new_file)
         cfg = self._config.integrations
 
         if cfg.sonarr_enabled and cfg.sonarr_url and cfg.sonarr_api_key:
@@ -79,6 +81,17 @@ class ArrNotifier(IModelListener):
             )
         else:
             self._logger.info("Arr notifier shutdown: all threads completed")
+
+    def _resolve_local_path(self, file: ModelFile) -> str:
+        """Resolve the absolute local filesystem path for a downloaded file."""
+        base = ""
+        if file.pair_id:
+            pair = self._path_pairs_config.get_pair(file.pair_id)
+            if pair:
+                base = pair.local_path
+        if not base:
+            base = self._config.lftp.local_path or ""
+        return os.path.join(base, file.full_path) if base else file.full_path
 
     def _fire_scan(self, service: str, base_url: str, api_key: str, command_name: str, path: str):
         """Fire-and-forget POST in a daemon thread."""

--- a/src/python/controller/arr_notifier.py
+++ b/src/python/controller/arr_notifier.py
@@ -93,8 +93,8 @@ class ArrNotifier(IModelListener):
             if self._shutdown_flag:
                 self._logger.debug("%s scan suppressed during shutdown: %s", service, path)
                 return
+            thread.start()
             self._active_threads.add(thread)
-        thread.start()
 
     def _thread_wrapper(self, service: str, url: str, api_key: str, payload: dict[str, str]) -> None:
         try:

--- a/src/python/controller/arr_notifier.py
+++ b/src/python/controller/arr_notifier.py
@@ -96,14 +96,14 @@ class ArrNotifier(IModelListener):
             self._active_threads.add(thread)
         thread.start()
 
-    def _thread_wrapper(self, service: str, url: str, api_key: str, payload: dict) -> None:
+    def _thread_wrapper(self, service: str, url: str, api_key: str, payload: dict[str, str]) -> None:
         try:
             self._send_post(service, url, api_key, payload)
         finally:
             with self._lock:
                 self._active_threads.discard(threading.current_thread())
 
-    def _send_post(self, service: str, url: str, api_key: str, payload: dict) -> None:
+    def _send_post(self, service: str, url: str, api_key: str, payload: dict[str, str]) -> None:
         if not url.startswith(("http://", "https://")):
             self._logger.warning("%s URL rejected: scheme is not http/https", service)
             return

--- a/src/python/controller/arr_notifier.py
+++ b/src/python/controller/arr_notifier.py
@@ -1,0 +1,125 @@
+import json
+import logging
+import threading
+import time
+import urllib.request
+
+from common import Config
+from model import IModelListener, ModelFile
+
+
+class ArrNotifier(IModelListener):
+    """Notifies Sonarr/Radarr on download completion so they can trigger import scans."""
+
+    def __init__(self, config: Config, logger: logging.Logger):
+        self._config = config
+        self._logger = logger.getChild("ArrNotifier")
+        self._shutdown_flag = False
+        self._active_threads: set[threading.Thread] = set()
+        self._lock = threading.Lock()
+
+    def file_added(self, file: ModelFile):
+        pass
+
+    def file_removed(self, file: ModelFile):
+        pass
+
+    def file_updated(self, old_file: ModelFile, new_file: ModelFile):
+        if old_file.state == new_file.state:
+            return
+
+        if new_file.state != ModelFile.State.DOWNLOADED:
+            return
+
+        local_path = new_file.full_path
+        cfg = self._config.integrations
+
+        if cfg.sonarr_enabled and cfg.sonarr_url and cfg.sonarr_api_key:
+            self._fire_scan(
+                service="Sonarr",
+                base_url=cfg.sonarr_url,
+                api_key=cfg.sonarr_api_key,
+                command_name="DownloadedEpisodesScan",
+                path=local_path,
+            )
+
+        if cfg.radarr_enabled and cfg.radarr_url and cfg.radarr_api_key:
+            self._fire_scan(
+                service="Radarr",
+                base_url=cfg.radarr_url,
+                api_key=cfg.radarr_api_key,
+                command_name="DownloadedMoviesScan",
+                path=local_path,
+            )
+
+    def shutdown(self, timeout: float = 5):
+        """Drain in-flight threads and prevent new ones."""
+        with self._lock:
+            self._shutdown_flag = True
+            threads = list(self._active_threads)
+
+        if not threads:
+            self._logger.debug("Arr notifier shutdown: no in-flight threads")
+            return
+
+        self._logger.info("Arr notifier shutting down, waiting for %d in-flight thread(s)", len(threads))
+        deadline = time.monotonic() + timeout
+        for thread in threads:
+            remaining = max(0, deadline - time.monotonic())
+            thread.join(timeout=remaining)
+
+        with self._lock:
+            still_alive = [t for t in self._active_threads if t.is_alive()]
+
+        if still_alive:
+            self._logger.warning(
+                "Arr notifier shutdown: %d thread(s) did not complete within %.1fs timeout",
+                len(still_alive),
+                timeout,
+            )
+        else:
+            self._logger.info("Arr notifier shutdown: all threads completed")
+
+    def _fire_scan(self, service: str, base_url: str, api_key: str, command_name: str, path: str):
+        """Fire-and-forget POST in a daemon thread."""
+        url = base_url.rstrip("/") + "/api/v3/command"
+        payload = {"name": command_name, "path": path}
+        thread = threading.Thread(
+            target=self._thread_wrapper,
+            args=(service, url, api_key, payload),
+            daemon=True,
+        )
+        with self._lock:
+            if self._shutdown_flag:
+                self._logger.debug("%s scan suppressed during shutdown: %s", service, path)
+                return
+            self._active_threads.add(thread)
+        thread.start()
+
+    def _thread_wrapper(self, service: str, url: str, api_key: str, payload: dict) -> None:
+        try:
+            self._send_post(service, url, api_key, payload)
+        finally:
+            with self._lock:
+                self._active_threads.discard(threading.current_thread())
+
+    def _send_post(self, service: str, url: str, api_key: str, payload: dict) -> None:
+        if not url.startswith(("http://", "https://")):
+            self._logger.warning("%s URL rejected: scheme is not http/https", service)
+            return
+        try:
+            data = json.dumps(payload).encode("utf-8")
+            req = urllib.request.Request(
+                url,
+                data=data,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Api-Key": api_key,
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10):
+                pass
+            self._logger.debug("%s scan triggered: %s", service, payload.get("path", ""))
+        except Exception as e:
+            self._logger.warning("%s scan failed: %s", service, str(e))

--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -154,7 +154,7 @@ class Seedsync:
         controller.add_model_listener(webhook_notifier)
 
         # Create arr notifier (Sonarr/Radarr integration)
-        arr_notifier = ArrNotifier(self.context.config, self.context.logger)
+        arr_notifier = ArrNotifier(self.context.config, self.context.path_pairs_config, self.context.logger)
         controller.add_model_listener(arr_notifier)
 
         # Create auto queue
@@ -400,6 +400,7 @@ class Seedsync:
             "logging",
             "notifications",
             "integrations",
+            "validate",
         ]:
             section = getattr(config, section_attr)
             default_section = getattr(defaults, section_attr)

--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -391,7 +391,16 @@ class Seedsync:
         """
         defaults = Seedsync._create_default_config()
         changed = False
-        for section_attr in ["general", "lftp", "controller", "web", "autoqueue", "logging", "notifications", "integrations"]:
+        for section_attr in [
+            "general",
+            "lftp",
+            "controller",
+            "web",
+            "autoqueue",
+            "logging",
+            "notifications",
+            "integrations",
+        ]:
             section = getattr(config, section_attr)
             default_section = getattr(defaults, section_attr)
             for key in section.as_dict():

--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -35,6 +35,7 @@ from common import (
 )
 from common.json_formatter import JsonFormatter
 from controller import AutoQueue, AutoQueuePersist, Controller, ControllerJob, ControllerPersist
+from controller.arr_notifier import ArrNotifier
 from controller.notifier import WebhookNotifier
 from web import WebAppBuilder, WebAppJob
 
@@ -152,6 +153,10 @@ class Seedsync:
         webhook_notifier = WebhookNotifier(self.context.config, self.context.logger)
         controller.add_model_listener(webhook_notifier)
 
+        # Create arr notifier (Sonarr/Radarr integration)
+        arr_notifier = ArrNotifier(self.context.config, self.context.logger)
+        controller.add_model_listener(arr_notifier)
+
         # Create auto queue
         auto_queue = AutoQueue(self.context, self.auto_queue_persist, controller)
 
@@ -226,8 +231,9 @@ class Seedsync:
                 controller_job.join()
             webapp_job.join()
 
-            # Drain in-flight webhook notifications
+            # Drain in-flight notifications
             webhook_notifier.shutdown()
+            arr_notifier.shutdown()
 
             # Last persist
             self.persist()
@@ -358,6 +364,13 @@ class Seedsync:
         config.notifications.notify_on_extraction_failed = True
         config.notifications.notify_on_delete_complete = True
 
+        config.integrations.sonarr_url = ""
+        config.integrations.sonarr_api_key = ""
+        config.integrations.sonarr_enabled = False
+        config.integrations.radarr_url = ""
+        config.integrations.radarr_api_key = ""
+        config.integrations.radarr_enabled = False
+
         config.lftp.net_limit_rate = ""
         config.lftp.net_socket_buffer = "8M"
         config.lftp.pget_min_chunk_size = "100M"
@@ -378,7 +391,7 @@ class Seedsync:
         """
         defaults = Seedsync._create_default_config()
         changed = False
-        for section_attr in ["general", "lftp", "controller", "web", "autoqueue", "logging", "notifications"]:
+        for section_attr in ["general", "lftp", "controller", "web", "autoqueue", "logging", "notifications", "integrations"]:
             section = getattr(config, section_attr)
             default_section = getattr(defaults, section_attr)
             for key in section.as_dict():

--- a/src/python/tests/integration/test_web/test_handler/test_integrations.py
+++ b/src/python/tests/integration/test_web/test_handler/test_integrations.py
@@ -1,0 +1,83 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tests.integration.test_web.test_web_app import BaseTestWebApp
+
+
+class TestIntegrationsHandler(BaseTestWebApp):
+    def test_test_sonarr_missing_url(self):
+        self.context.config.integrations.sonarr_url = ""
+        self.context.config.integrations.sonarr_api_key = "some-key"
+        resp = self.test_app.get("/server/integrations/test/sonarr", expect_errors=True)
+        self.assertEqual(400, resp.status_int)
+        body = json.loads(str(resp.html))
+        self.assertIn("URL is not configured", body["error"])
+
+    def test_test_sonarr_missing_api_key(self):
+        self.context.config.integrations.sonarr_url = "http://localhost:8989"
+        self.context.config.integrations.sonarr_api_key = ""
+        resp = self.test_app.get("/server/integrations/test/sonarr", expect_errors=True)
+        self.assertEqual(400, resp.status_int)
+        body = json.loads(str(resp.html))
+        self.assertIn("API key is not configured", body["error"])
+
+    def test_test_sonarr_bad_scheme(self):
+        self.context.config.integrations.sonarr_url = "ftp://localhost:8989"
+        self.context.config.integrations.sonarr_api_key = "some-key"
+        resp = self.test_app.get("/server/integrations/test/sonarr", expect_errors=True)
+        self.assertEqual(400, resp.status_int)
+        body = json.loads(str(resp.html))
+        self.assertIn("http://", body["error"])
+
+    @patch("web.handler.integrations.urllib.request.urlopen")
+    def test_test_sonarr_success(self, mock_urlopen):
+        self.context.config.integrations.sonarr_url = "http://localhost:8989"
+        self.context.config.integrations.sonarr_api_key = "test-key"
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"version": "4.0.0.1"}).encode("utf-8")
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        resp = self.test_app.get("/server/integrations/test/sonarr")
+        self.assertEqual(200, resp.status_int)
+        body = json.loads(str(resp.html))
+        self.assertTrue(body["success"])
+        self.assertEqual("4.0.0.1", body["version"])
+
+    @patch("web.handler.integrations.urllib.request.urlopen")
+    def test_test_sonarr_connection_failure(self, mock_urlopen):
+        self.context.config.integrations.sonarr_url = "http://localhost:8989"
+        self.context.config.integrations.sonarr_api_key = "test-key"
+        mock_urlopen.side_effect = ConnectionRefusedError("Connection refused")
+        resp = self.test_app.get("/server/integrations/test/sonarr", expect_errors=True)
+        self.assertEqual(502, resp.status_int)
+        body = json.loads(str(resp.html))
+        self.assertIn("Connection failed", body["error"])
+
+    @patch("web.handler.integrations.urllib.request.urlopen")
+    def test_test_radarr_success(self, mock_urlopen):
+        self.context.config.integrations.radarr_url = "http://localhost:7878"
+        self.context.config.integrations.radarr_api_key = "test-key"
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"version": "5.2.0.1"}).encode("utf-8")
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        resp = self.test_app.get("/server/integrations/test/radarr")
+        self.assertEqual(200, resp.status_int)
+        body = json.loads(str(resp.html))
+        self.assertTrue(body["success"])
+        self.assertEqual("5.2.0.1", body["version"])
+
+    def test_test_radarr_missing_url(self):
+        self.context.config.integrations.radarr_url = ""
+        self.context.config.integrations.radarr_api_key = "some-key"
+        resp = self.test_app.get("/server/integrations/test/radarr", expect_errors=True)
+        self.assertEqual(400, resp.status_int)
+        body = json.loads(str(resp.html))
+        self.assertIn("URL is not configured", body["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/python/tests/unittests/test_common/test_config.py
+++ b/src/python/tests/unittests/test_common/test_config.py
@@ -670,6 +670,14 @@ class TestConfig(unittest.TestCase):
         notify_on_extraction_failed = True
         notify_on_delete_complete = True
 
+        [Integrations]
+        sonarr_url =
+        sonarr_api_key =
+        sonarr_enabled = False
+        radarr_url =
+        radarr_api_key =
+        radarr_enabled = False
+
         [Validate]
         enabled = False
         algorithm = md5

--- a/src/python/tests/unittests/test_controller/test_arr_notifier.py
+++ b/src/python/tests/unittests/test_controller/test_arr_notifier.py
@@ -1,6 +1,5 @@
 import logging
 import threading
-import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -47,8 +46,7 @@ class TestArrNotifier(unittest.TestCase):
 
         with patch.object(notifier, "_send_post") as mock_send:
             notifier.file_updated(old_file, new_file)
-            # Give threads a moment (there shouldn't be any)
-            time.sleep(0.1)
+            notifier.shutdown(timeout=2)
             mock_send.assert_not_called()
 
     def test_sonarr_fires_on_download_complete(self):
@@ -102,7 +100,7 @@ class TestArrNotifier(unittest.TestCase):
 
         with patch.object(notifier, "_send_post") as mock_send:
             notifier.file_updated(old_file, new_file)
-            time.sleep(0.1)
+            notifier.shutdown(timeout=2)
             mock_send.assert_not_called()
 
     def test_no_fire_when_state_unchanged(self):
@@ -113,7 +111,7 @@ class TestArrNotifier(unittest.TestCase):
 
         with patch.object(notifier, "_send_post") as mock_send:
             notifier.file_updated(old_file, new_file)
-            time.sleep(0.1)
+            notifier.shutdown(timeout=2)
             mock_send.assert_not_called()
 
     def test_no_fire_when_url_empty(self):
@@ -124,7 +122,7 @@ class TestArrNotifier(unittest.TestCase):
 
         with patch.object(notifier, "_send_post") as mock_send:
             notifier.file_updated(old_file, new_file)
-            time.sleep(0.1)
+            notifier.shutdown(timeout=2)
             mock_send.assert_not_called()
 
     def test_no_fire_when_api_key_empty(self):
@@ -135,7 +133,7 @@ class TestArrNotifier(unittest.TestCase):
 
         with patch.object(notifier, "_send_post") as mock_send:
             notifier.file_updated(old_file, new_file)
-            time.sleep(0.1)
+            notifier.shutdown(timeout=2)
             mock_send.assert_not_called()
 
     def test_shutdown_prevents_new_scans(self):
@@ -183,11 +181,12 @@ class TestArrNotifier(unittest.TestCase):
             started.set()
             raise RuntimeError("connection refused")
 
-        with patch.object(notifier, "_send_post", side_effect=failing_send):
+        with patch.object(notifier, "_send_post", side_effect=failing_send) as mock_send:
             old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
             new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
             notifier.file_updated(old_file, new_file)
-            started.wait(timeout=5)
+            self.assertTrue(started.wait(timeout=5), "failing_send was never invoked")
+            mock_send.assert_called_once()
             notifier.shutdown(timeout=2)
 
             with notifier._lock:

--- a/src/python/tests/unittests/test_controller/test_arr_notifier.py
+++ b/src/python/tests/unittests/test_controller/test_arr_notifier.py
@@ -18,6 +18,7 @@ class TestArrNotifier(unittest.TestCase):
         radarr_enabled=False,
         radarr_url="http://localhost:7878",
         radarr_api_key="test-radarr-key",
+        local_path="/downloads",
     ):
         config = MagicMock()
         config.integrations.sonarr_enabled = sonarr_enabled
@@ -26,12 +27,15 @@ class TestArrNotifier(unittest.TestCase):
         config.integrations.radarr_enabled = radarr_enabled
         config.integrations.radarr_url = radarr_url
         config.integrations.radarr_api_key = radarr_api_key
+        config.lftp.local_path = local_path
         return config
 
     def _make_notifier(self, **kwargs):
         config = self._make_config(**kwargs)
+        path_pairs_config = MagicMock()
+        path_pairs_config.get_pair.return_value = None
         logger = logging.getLogger("test_arr_notifier")
-        return ArrNotifier(config, logger)
+        return ArrNotifier(config, path_pairs_config, logger)
 
     def _make_model_file(self, name="test.mkv", state=ModelFile.State.DEFAULT):
         f = ModelFile(name, False)
@@ -203,6 +207,39 @@ class TestArrNotifier(unittest.TestCase):
             notifier.shutdown(timeout=2)
             url_arg = mock_send.call_args[0][1]
             self.assertEqual(url_arg, "http://localhost:8989/api/v3/command")
+
+    def test_payload_path_is_absolute(self):
+        """Payload path should be the absolute local filesystem path."""
+        notifier = self._make_notifier(sonarr_enabled=True, local_path="/downloads")
+        old_file = self._make_model_file(name="Show.S01E01.mkv", state=ModelFile.State.DOWNLOADING)
+        new_file = self._make_model_file(name="Show.S01E01.mkv", state=ModelFile.State.DOWNLOADED)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            notifier.shutdown(timeout=2)
+            payload = mock_send.call_args[0][3]
+            self.assertEqual(payload["path"], "/downloads/Show.S01E01.mkv")
+
+    def test_payload_path_uses_pair_local_path(self):
+        """When file has a pair_id, use the pair's local_path."""
+        config = self._make_config(sonarr_enabled=True, local_path="/fallback")
+        path_pairs_config = MagicMock()
+        pair = MagicMock()
+        pair.local_path = "/media/tv"
+        path_pairs_config.get_pair.return_value = pair
+        logger = logging.getLogger("test_arr_notifier")
+        notifier = ArrNotifier(config, path_pairs_config, logger)
+
+        old_file = self._make_model_file(name="Show.S01E01.mkv", state=ModelFile.State.DOWNLOADING)
+        new_file = self._make_model_file(name="Show.S01E01.mkv", state=ModelFile.State.DOWNLOADED)
+        new_file.pair_id = "pair-1"
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            notifier.shutdown(timeout=2)
+            payload = mock_send.call_args[0][3]
+            self.assertEqual(payload["path"], "/media/tv/Show.S01E01.mkv")
+            path_pairs_config.get_pair.assert_called_with("pair-1")
 
 
 if __name__ == "__main__":

--- a/src/python/tests/unittests/test_controller/test_arr_notifier.py
+++ b/src/python/tests/unittests/test_controller/test_arr_notifier.py
@@ -1,0 +1,210 @@
+import logging
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from controller.arr_notifier import ArrNotifier
+from model.file import ModelFile
+
+
+class TestArrNotifier(unittest.TestCase):
+    """Tests for ArrNotifier Sonarr/Radarr integration."""
+
+    def _make_config(
+        self,
+        sonarr_enabled=False,
+        sonarr_url="http://localhost:8989",
+        sonarr_api_key="test-sonarr-key",
+        radarr_enabled=False,
+        radarr_url="http://localhost:7878",
+        radarr_api_key="test-radarr-key",
+    ):
+        config = MagicMock()
+        config.integrations.sonarr_enabled = sonarr_enabled
+        config.integrations.sonarr_url = sonarr_url
+        config.integrations.sonarr_api_key = sonarr_api_key
+        config.integrations.radarr_enabled = radarr_enabled
+        config.integrations.radarr_url = radarr_url
+        config.integrations.radarr_api_key = radarr_api_key
+        return config
+
+    def _make_notifier(self, **kwargs):
+        config = self._make_config(**kwargs)
+        logger = logging.getLogger("test_arr_notifier")
+        return ArrNotifier(config, logger)
+
+    def _make_model_file(self, name="test.mkv", state=ModelFile.State.DEFAULT):
+        f = ModelFile(name, False)
+        f.state = state
+        return f
+
+    def test_no_action_when_disabled(self):
+        """No scan fires when both Sonarr and Radarr are disabled."""
+        notifier = self._make_notifier(sonarr_enabled=False, radarr_enabled=False)
+        old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
+        new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            # Give threads a moment (there shouldn't be any)
+            time.sleep(0.1)
+            mock_send.assert_not_called()
+
+    def test_sonarr_fires_on_download_complete(self):
+        """Sonarr scan fires when enabled and file transitions to DOWNLOADED."""
+        notifier = self._make_notifier(sonarr_enabled=True)
+        old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
+        new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            notifier.shutdown(timeout=2)
+            mock_send.assert_called_once()
+            args = mock_send.call_args
+            self.assertEqual(args[0][0], "Sonarr")
+            self.assertIn("/api/v3/command", args[0][1])
+            self.assertEqual(args[0][2], "test-sonarr-key")
+            self.assertEqual(args[0][3]["name"], "DownloadedEpisodesScan")
+
+    def test_radarr_fires_on_download_complete(self):
+        """Radarr scan fires when enabled and file transitions to DOWNLOADED."""
+        notifier = self._make_notifier(radarr_enabled=True)
+        old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
+        new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            notifier.shutdown(timeout=2)
+            mock_send.assert_called_once()
+            args = mock_send.call_args
+            self.assertEqual(args[0][0], "Radarr")
+            self.assertEqual(args[0][3]["name"], "DownloadedMoviesScan")
+
+    def test_both_fire_when_both_enabled(self):
+        """Both Sonarr and Radarr fire when both are enabled."""
+        notifier = self._make_notifier(sonarr_enabled=True, radarr_enabled=True)
+        old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
+        new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            notifier.shutdown(timeout=2)
+            self.assertEqual(mock_send.call_count, 2)
+            service_names = {call[0][0] for call in mock_send.call_args_list}
+            self.assertEqual(service_names, {"Sonarr", "Radarr"})
+
+    def test_no_fire_on_non_downloaded_state(self):
+        """No scan fires for state transitions other than DOWNLOADED."""
+        notifier = self._make_notifier(sonarr_enabled=True, radarr_enabled=True)
+        old_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+        new_file = self._make_model_file(state=ModelFile.State.EXTRACTED)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            time.sleep(0.1)
+            mock_send.assert_not_called()
+
+    def test_no_fire_when_state_unchanged(self):
+        """No scan fires when old and new state are the same."""
+        notifier = self._make_notifier(sonarr_enabled=True)
+        old_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+        new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            time.sleep(0.1)
+            mock_send.assert_not_called()
+
+    def test_no_fire_when_url_empty(self):
+        """No scan fires when URL is empty even if enabled."""
+        notifier = self._make_notifier(sonarr_enabled=True, sonarr_url="")
+        old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
+        new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            time.sleep(0.1)
+            mock_send.assert_not_called()
+
+    def test_no_fire_when_api_key_empty(self):
+        """No scan fires when API key is empty even if enabled."""
+        notifier = self._make_notifier(sonarr_enabled=True, sonarr_api_key="")
+        old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
+        new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            time.sleep(0.1)
+            mock_send.assert_not_called()
+
+    def test_shutdown_prevents_new_scans(self):
+        """After shutdown, no new threads are started."""
+        notifier = self._make_notifier(sonarr_enabled=True)
+        notifier.shutdown(timeout=1)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
+            new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+            notifier.file_updated(old_file, new_file)
+            mock_send.assert_not_called()
+
+    def test_shutdown_waits_for_inflight(self):
+        """Shutdown joins in-flight threads."""
+        notifier = self._make_notifier(sonarr_enabled=True)
+        barrier = threading.Event()
+        started = threading.Event()
+
+        def slow_send(service, url, api_key, payload):
+            started.set()
+            barrier.wait(timeout=5)
+
+        with patch.object(notifier, "_send_post", side_effect=slow_send):
+            old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
+            new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+            notifier.file_updated(old_file, new_file)
+            started.wait(timeout=5)
+
+            with notifier._lock:
+                self.assertEqual(len(notifier._active_threads), 1)
+
+            barrier.set()
+            notifier.shutdown(timeout=2)
+
+            with notifier._lock:
+                self.assertEqual(len(notifier._active_threads), 0)
+
+    def test_thread_removed_on_exception(self):
+        """Thread is cleaned up even if _send_post raises."""
+        notifier = self._make_notifier(sonarr_enabled=True)
+        started = threading.Event()
+
+        def failing_send(service, url, api_key, payload):
+            started.set()
+            raise RuntimeError("connection refused")
+
+        with patch.object(notifier, "_send_post", side_effect=failing_send):
+            old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
+            new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+            notifier.file_updated(old_file, new_file)
+            started.wait(timeout=5)
+            notifier.shutdown(timeout=2)
+
+            with notifier._lock:
+                self.assertEqual(len(notifier._active_threads), 0)
+
+    def test_url_trailing_slash_stripped(self):
+        """Trailing slash on URL is handled correctly."""
+        notifier = self._make_notifier(sonarr_enabled=True, sonarr_url="http://localhost:8989/")
+        old_file = self._make_model_file(state=ModelFile.State.DOWNLOADING)
+        new_file = self._make_model_file(state=ModelFile.State.DOWNLOADED)
+
+        with patch.object(notifier, "_send_post") as mock_send:
+            notifier.file_updated(old_file, new_file)
+            notifier.shutdown(timeout=2)
+            url_arg = mock_send.call_args[0][1]
+            self.assertEqual(url_arg, "http://localhost:8989/api/v3/command")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/python/web/handler/integrations.py
+++ b/src/python/web/handler/integrations.py
@@ -35,7 +35,9 @@ class IntegrationsHandler(IHandler):
         if not api_key:
             return HTTPResponse(body=json.dumps({"error": f"{service} API key is not configured"}), status=400)
         if not url.startswith(("http://", "https://")):
-            return HTTPResponse(body=json.dumps({"error": f"{service} URL must start with http:// or https://"}), status=400)
+            return HTTPResponse(
+                body=json.dumps({"error": f"{service} URL must start with http:// or https://"}), status=400
+            )
 
         endpoint = url.rstrip("/") + "/api/v3/system/status"
         try:

--- a/src/python/web/handler/integrations.py
+++ b/src/python/web/handler/integrations.py
@@ -1,0 +1,58 @@
+import json
+import urllib.request
+
+from bottle import HTTPResponse
+
+from common import Config
+from common.types import overrides
+
+from ..web_app import IHandler, WebApp
+
+
+class IntegrationsHandler(IHandler):
+    """Endpoints for testing Sonarr/Radarr connectivity."""
+
+    def __init__(self, config: Config):
+        self.__config = config
+
+    @overrides(IHandler)
+    def add_routes(self, web_app: WebApp):
+        web_app.add_handler("/server/integrations/test/sonarr", self.__handle_test_sonarr)
+        web_app.add_handler("/server/integrations/test/radarr", self.__handle_test_radarr)
+
+    def __handle_test_sonarr(self):
+        cfg = self.__config.integrations
+        return self.__test_arr_connection("Sonarr", cfg.sonarr_url, cfg.sonarr_api_key)
+
+    def __handle_test_radarr(self):
+        cfg = self.__config.integrations
+        return self.__test_arr_connection("Radarr", cfg.radarr_url, cfg.radarr_api_key)
+
+    @staticmethod
+    def __test_arr_connection(service: str, url: str, api_key: str) -> HTTPResponse:
+        if not url:
+            return HTTPResponse(body=json.dumps({"error": f"{service} URL is not configured"}), status=400)
+        if not api_key:
+            return HTTPResponse(body=json.dumps({"error": f"{service} API key is not configured"}), status=400)
+        if not url.startswith(("http://", "https://")):
+            return HTTPResponse(body=json.dumps({"error": f"{service} URL must start with http:// or https://"}), status=400)
+
+        endpoint = url.rstrip("/") + "/api/v3/system/status"
+        try:
+            req = urllib.request.Request(
+                endpoint,
+                headers={"X-Api-Key": api_key},
+                method="GET",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+                version = data.get("version", "unknown")
+            return HTTPResponse(
+                body=json.dumps({"success": True, "version": version}),
+                status=200,
+            )
+        except Exception as e:
+            return HTTPResponse(
+                body=json.dumps({"error": f"Connection failed: {str(e)}"}),
+                status=502,
+            )

--- a/src/python/web/web_app_builder.py
+++ b/src/python/web/web_app_builder.py
@@ -8,6 +8,7 @@ from controller import AutoQueuePersist, Controller
 from .handler.auto_queue import AutoQueueHandler
 from .handler.config import ConfigHandler
 from .handler.controller import ControllerHandler
+from .handler.integrations import IntegrationsHandler
 from .handler.logs import LogsHandler
 from .handler.path_pairs import PathPairsHandler
 from .handler.server import ServerHandler
@@ -35,6 +36,7 @@ class WebAppBuilder:
         self.status_handler = StatusHandler(context.status)
         self.logs_handler = LogsHandler(logdir=context.args.logdir, service_name=Constants.SERVICE_NAME)
         self.path_pairs_handler = PathPairsHandler(context.path_pairs_config)
+        self.integrations_handler = IntegrationsHandler(context.config)
 
     def build(self) -> WebApp:
         web_app = WebApp(context=self.__context, controller=self.__controller)
@@ -59,6 +61,7 @@ class WebAppBuilder:
         self.status_handler.add_routes(web_app)
         self.logs_handler.add_routes(web_app)
         self.path_pairs_handler.add_routes(web_app)
+        self.integrations_handler.add_routes(web_app)
 
         web_app.add_default_routes()
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -158,28 +158,28 @@ SeedSync can notify Sonarr and Radarr when a download completes, triggering an a
 1. Go to **Settings → Integrations**
 2. Enable the integration (Sonarr, Radarr, or both)
 3. Enter the base URL (e.g. `http://sonarr:8989` or `http://radarr:7878`)
-4. Enter the API key (found in the *arr app under **Settings → General → API Key**)
+4. Enter the API key (found in the Arr app under **Settings → General → API Key**)
 5. Click **Test Connection** to verify
 
 ### How it works
 
-When a file transitions to the **Downloaded** state, SeedSync sends a `POST` to the *arr app's command API:
+When a file transitions to the **Downloaded** state, SeedSync sends a `POST` to the Arr app's command API:
 
 | App | Endpoint | Command |
 | --- | --- | --- |
 | Sonarr | `POST /api/v3/command` | `DownloadedEpisodesScan` |
 | Radarr | `POST /api/v3/command` | `DownloadedMoviesScan` |
 
-The request includes the absolute local path of the downloaded file, so the *arr app scans only that path instead of the entire download directory.
+The request includes the absolute local path of the downloaded file, so the Arr app scans only that path instead of the entire download directory.
 
 Notifications are fire-and-forget — they run in background threads and never block the download pipeline. Failed notifications are logged as warnings.
 
 :::tip
-If you run SeedSync and *arr apps in Docker, use the Docker service name as the host (e.g. `http://sonarr:8989`) and make sure all containers share a Docker network.
+If you run SeedSync and Arr apps in Docker, use the Docker service name as the host (e.g. `http://sonarr:8989`) and make sure all containers share a Docker network.
 :::
 
 :::note
-The local path sent to the *arr app is the path **inside the SeedSync container**. If your *arr app sees a different mount path for the same files, configure a [remote path mapping](https://wiki.servarr.com/sonarr/settings#remote-path-mappings) in the *arr app.
+The local path sent to the Arr app is the path **inside the SeedSync container**. If your Arr app sees a different mount path for the same files, configure a [remote path mapping](https://wiki.servarr.com/sonarr/settings#remote-path-mappings) in the Arr app.
 :::
 
 ### Configuration reference
@@ -187,8 +187,8 @@ The local path sent to the *arr app is the path **inside the SeedSync container*
 | Setting | Description |
 | --- | --- |
 | **Enable Sonarr/Radarr integration** | Toggle notifications on or off |
-| **URL** | Base URL of the *arr app (e.g. `http://localhost:8989`) |
-| **API Key** | *arr app API key (masked in the UI) |
+| **URL** | Base URL of the Arr app (e.g. `http://localhost:8989`) |
+| **API Key** | Arr app API key (masked in the UI) |
 
 ## Webhooks
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -149,9 +149,83 @@ These settings are collapsed by default under **Advanced LFTP** in the Settings 
 - **Reconnect Interval Base (s)**: Base delay in seconds before reconnecting after a failure. (`net:reconnect-interval-base`)
 - **Reconnect Interval Multiplier**: Multiplier applied to the reconnect delay after each consecutive failure. (`net:reconnect-interval-multiplier`)
 
+## Integrations (Sonarr / Radarr)
+
+SeedSync can notify Sonarr and Radarr when a download completes, triggering an automatic import scan so your media library updates immediately.
+
+### Setup
+
+1. Go to **Settings → Integrations**
+2. Enable the integration (Sonarr, Radarr, or both)
+3. Enter the base URL (e.g. `http://sonarr:8989` or `http://radarr:7878`)
+4. Enter the API key (found in the *arr app under **Settings → General → API Key**)
+5. Click **Test Connection** to verify
+
+### How it works
+
+When a file transitions to the **Downloaded** state, SeedSync sends a `POST` to the *arr app's command API:
+
+| App | Endpoint | Command |
+| --- | --- | --- |
+| Sonarr | `POST /api/v3/command` | `DownloadedEpisodesScan` |
+| Radarr | `POST /api/v3/command` | `DownloadedMoviesScan` |
+
+The request includes the absolute local path of the downloaded file, so the *arr app scans only that path instead of the entire download directory.
+
+Notifications are fire-and-forget — they run in background threads and never block the download pipeline. Failed notifications are logged as warnings.
+
+:::tip
+If you run SeedSync and *arr apps in Docker, use the Docker service name as the host (e.g. `http://sonarr:8989`) and make sure all containers share a Docker network.
+:::
+
+:::note
+The local path sent to the *arr app is the path **inside the SeedSync container**. If your *arr app sees a different mount path for the same files, configure a [remote path mapping](https://wiki.servarr.com/sonarr/settings#remote-path-mappings) in the *arr app.
+:::
+
+### Configuration reference
+
+| Setting | Description |
+| --- | --- |
+| **Enable Sonarr/Radarr integration** | Toggle notifications on or off |
+| **URL** | Base URL of the *arr app (e.g. `http://localhost:8989`) |
+| **API Key** | *arr app API key (masked in the UI) |
+
 ## Webhooks
 
-SeedSync can send HTTP POST notifications when file events occur (download complete, extraction complete, etc.). Configure the webhook URL in Settings under **Notifications**.
+SeedSync can send HTTP POST notifications when file events occur. Configure the webhook URL in Settings under **Notifications**.
+
+### Events
+
+| Event | Trigger |
+| --- | --- |
+| `download_complete` | File finished downloading |
+| `extraction_complete` | Archive extraction succeeded |
+| `extraction_failed` | Archive extraction failed |
+| `delete_complete` | File deleted |
+
+Each event can be individually enabled or disabled via the checkboxes in Settings.
+
+### Payload
+
+Webhook requests are `POST` with `Content-Type: application/json`:
+
+```json
+{
+  "event_type": "download_complete",
+  "filename": "Movie.2024.mkv",
+  "timestamp": "2024-01-15T12:34:56.789012+00:00",
+  "pair_id": "abc123",
+  "path": "Movie.2024.mkv"
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `event_type` | One of the event types above |
+| `filename` | Name of the file or directory |
+| `timestamp` | UTC ISO 8601 timestamp |
+| `pair_id` | Path pair ID (omitted if not using path pairs) |
+| `path` | Relative file path within the download directory |
 
 ## Advanced config file
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -18,6 +18,7 @@ This is the modernized fork of `ipsingh06/seedsync`, with updated dependencies a
 - **Multi-select** — bulk queue, stop, or delete files
 - Extract archives after download
 - Stage downloads on a fast disk, then move to final location
+- **Sonarr/Radarr integration** — trigger import scans on download completion
 - **Webhook notifications** — HTTP POST on download/extract events
 - Manage local and remote deletes
 - Monitor transfer status from the web UI


### PR DESCRIPTION
## Summary

- Adds Sonarr/Radarr integration that notifies *arr apps when SeedSync completes a download, triggering automatic import scans
- New `ArrNotifier` model listener POSTs `DownloadedEpisodesScan` (Sonarr) / `DownloadedMoviesScan` (Radarr) on download completion
- New `Integrations` config section with URL, API key, and enable toggle for each service
- Test Connection buttons in the Settings UI verify *arr connectivity via `/api/v3/system/status`
- Fire-and-forget daemon threads (same pattern as existing `WebhookNotifier`)

## Test plan

- [x] 313 Angular Vitest tests pass (27 test files)
- [x] Angular build succeeds
- [x] 12 unit tests for `ArrNotifier` (state transitions, config guards, shutdown/thread cleanup)
- [x] 7 integration tests for `IntegrationsHandler` (validation, mock success/failure)
- [x] 5 Angular tests for `IntegrationsService` (HTTP success/failure for both services)
- [x] 5 Angular tests for integrations options contexts (structure, field types)
- [ ] Manual: Configure Sonarr/Radarr URL + API key, verify Test Connection succeeds
- [ ] Manual: Download a file, verify *arr scan is triggered
- [ ] Manual: Verify existing webhook notifications still work unchanged

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sonarr & Radarr integration settings (URL, API key, enable toggles).
  * Test Connection buttons to verify credentials and show success/error.
  * Automatic scan notifications triggered on file download; notifications run asynchronously and respect container path mappings.

* **Documentation**
  * Added Integrations docs (configuration, testing, behavior, container/path guidance).
  * Expanded Webhook docs with events and payload details.

* **Tests**
  * Added unit, integration, and end-to-end tests covering integrations and UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->