### PR TITLE
Fix file list scrolling on Android mobile browsers

### DIFF
--- a/src/angular/src/app/pages/files/file-list.component.html
+++ b/src/angular/src/app/pages/files/file-list.component.html
@@ -22,7 +22,7 @@
         </app-bulk-action-bar>
       }
     }
-    <cdk-virtual-scroll-viewport itemSize="50" class="file-viewport">
+    <cdk-virtual-scroll-viewport itemSize="82" class="file-viewport">
         <div *cdkVirtualFor="let file of files; trackBy: identify; let isEven = even" class="file-row" [class.even]="isEven">
             <app-file
                 [file]="file"

--- a/src/angular/src/app/pages/files/file-list.component.scss
+++ b/src/angular/src/app/pages/files/file-list.component.scss
@@ -4,11 +4,23 @@
     display: none;
 }
 
-/* Virtual scroll viewport — 160px accounts for navbar (56px) + header row (40px) + file-options bar (48px) + padding (16px) */
+/* Virtual scroll viewport — chrome height accounts for sticky elements above the scroll area.
+   Desktop (≥993px): navbar (56px) + column header (40px) + file-options bar (48px) + padding (16px) = 160px
+   Mobile  (<993px): navbar (56px) + title bar (~52px) + file-options bar (~76px) + padding (16px) = 200px
+   Uses dvh (dynamic viewport height) so the container adapts when Android browser chrome hides/shows. */
 $file-list-chrome-height: 160px;
+$file-list-chrome-height-mobile: 200px;
 .file-viewport {
     height: calc(100vh - $file-list-chrome-height);
+    height: calc(100dvh - $file-list-chrome-height);
     min-height: 200px;
+}
+
+@media only screen and (max-width: $medium-max-width) {
+    .file-viewport {
+        height: calc(100vh - $file-list-chrome-height-mobile);
+        height: calc(100dvh - $file-list-chrome-height-mobile);
+    }
 }
 
 /* striped rows — use template-driven .even class instead of :nth-child

--- a/src/angular/src/app/pages/files/file-list.component.scss
+++ b/src/angular/src/app/pages/files/file-list.component.scss
@@ -29,13 +29,13 @@ $file-list-chrome-height-mobile: 200px;
     background-color: var(--ss-primary-lighter);
 }
 
-/* list separator — use top-border so recycled rows always show a separator
-   regardless of DOM position (no :last-child needed) */
-.file-row + .file-row {border-top: 1px solid var(--ss-border);}
+/* list separator — inset box-shadow draws a top divider without adding
+   to the row height, so CDK virtual scroll's fixed itemSize stays accurate */
+.file-row + .file-row {box-shadow: inset 0 1px 0 var(--ss-border);}
 
 
-/* Medium and large screens */
-@media only screen and (min-width: $medium-min-width) {
+/* Large screens — column header aligns with desktop viewport height math (≥993px) */
+@media only screen and (min-width: $large-min-width) {
     #file-list #header {
         display: flex;
     }
@@ -74,7 +74,7 @@ $file-list-chrome-height-mobile: 200px;
     }
 
     .file-row + .file-row {
-        border-top-color: rgba(255, 255, 255, 0.04);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
     }
 
     .file-row {


### PR DESCRIPTION
## Summary
- **100vh → 100dvh**: On Android Chrome/Firefox, `100vh` includes area behind browser chrome (URL bar, bottom nav). The scroll container extended below the visible screen, making bottom items unreachable and causing jumpy behavior as browser chrome hid/showed during scroll. `100dvh` adapts to the actual visible viewport. Includes `100vh` fallback for older browsers.
- **itemSize 50 → 82**: CDK virtual scroll was told rows are 50px, but actual height is ~82px (10px file padding + 62px status height + 10px file padding, with border-box). The mismatch caused scroll position miscalculations, gaps/overlaps, and inability to reach the end of long lists.
- **Mobile chrome height deduction**: Added media query for screens ≤992px using 200px deduction (vs 160px desktop) to account for the title bar (~52px) that replaces the column header row (~40px) on mobile.

## Test plan
- [ ] Verify file list scrolling on Android Chrome
- [ ] Verify file list scrolling on Android Firefox
- [ ] Verify desktop scrolling is unchanged
- [ ] Verify last file in a long list is reachable on mobile
- [ ] Verify scroll behavior when Android browser chrome hides/shows
- [ ] Run `cd src/angular && npx ng test` — all 319 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file list viewport and virtual-scroll sizing for more accurate scrolling and layout across browsers.

* **Style**
  * Improved mobile and desktop responsiveness with dynamic viewport height handling.
  * Updated row separators and dark-mode styling for consistent visual spacing and appearance.
* **Chores**
  * Added a mobile-specific layout variable to better account for on-screen browser chrome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->