### PR TITLE
Use 'with' on controller __model_lock to prevent deadlock on exception

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -600,9 +600,8 @@ class Controller:
         Returns a copy of all the model files
         :return:
         """
-        self.__model_lock.acquire()
-        model_files = self.__get_model_files()
-        self.__model_lock.release()
+        with self.__model_lock:
+            model_files = self.__get_model_files()
         return model_files
 
     def add_model_listener(self, listener: IModelListener):
@@ -611,9 +610,8 @@ class Controller:
         :param listener:
         :return:
         """
-        self.__model_lock.acquire()
-        self.__model.add_listener(listener)
-        self.__model_lock.release()
+        with self.__model_lock:
+            self.__model.add_listener(listener)
 
     def remove_model_listener(self, listener: IModelListener):
         """
@@ -621,9 +619,8 @@ class Controller:
         :param listener:
         :return:
         """
-        self.__model_lock.acquire()
-        self.__model.remove_listener(listener)
-        self.__model_lock.release()
+        with self.__model_lock:
+            self.__model.remove_listener(listener)
 
     def get_model_files_and_add_listener(self, listener: IModelListener):
         """
@@ -631,10 +628,9 @@ class Controller:
         :param listener:
         :return:
         """
-        self.__model_lock.acquire()
-        self.__model.add_listener(listener)
-        model_files = self.__get_model_files()
-        self.__model_lock.release()
+        with self.__model_lock:
+            self.__model.add_listener(listener)
+            model_files = self.__get_model_files()
         return model_files
 
     def queue_command(self, command: Command):
@@ -776,8 +772,7 @@ class Controller:
                     new_model.add_file(file)
                     seen_names_by_path[norm_path].add(file.name)
 
-            self.__model_lock.acquire()
-            try:
+            with self.__model_lock:
                 model_diff = ModelDiffUtil.diff_models(self.__model, new_model)
 
                 for diff in model_diff:
@@ -939,9 +934,6 @@ class Controller:
                         self.__persist.validated_file_names.difference_update(absent_keys)
                         self.__persist.corrupt_file_names.difference_update(absent_keys)
                         self._sync_persist_to_all_builders()
-
-            finally:
-                self.__model_lock.release()
 
         # Process extraction failures — mark as failed immediately
         for result in latest_failed_extractions:

--- a/src/python/tests/unittests/test_controller/test_controller_lock.py
+++ b/src/python/tests/unittests/test_controller/test_controller_lock.py
@@ -1,0 +1,140 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+"""Tests for Controller's __model_lock exception-safety.
+
+Regression test for https://github.com/nitrobass24/seedsync/issues/373
+
+Previously the short model-lock regions used raw acquire()/release() pairs
+with no try/finally.  An exception raised inside the locked body would leak
+the lock forever and every subsequent caller would deadlock.  After
+converting those regions to `with self.__model_lock:` blocks, the lock is
+guaranteed to release on exception.
+"""
+
+import unittest
+from threading import Lock
+from unittest.mock import MagicMock
+
+import timeout_decorator
+
+from controller import Controller
+from model import IModelListener
+
+
+class _BoomError(Exception):
+    """Custom exception used to prove the lock was released on raise."""
+
+
+class TestControllerModelLockExceptionSafety(unittest.TestCase):
+    """Verify that exceptions raised inside a model-lock region still
+    release the lock (otherwise the next caller would deadlock).
+
+    Each test wraps the "recovery" call in `timeout_decorator.timeout(5)` so
+    that a regression (leaked lock -> deadlock) fails fast in CI rather than
+    hanging the whole test suite.
+    """
+
+    def setUp(self):
+        # Build a Controller instance without running __init__ — we only need
+        # the private attributes the methods under test actually touch.
+        self.controller = Controller.__new__(Controller)
+        # Name-mangled private attributes:
+        self.controller._Controller__model_lock = Lock()
+        self.controller._Controller__model = MagicMock()
+
+    @timeout_decorator.timeout(5)
+    def test_get_model_files_releases_lock_on_exception(self):
+        # Replace the private helper with one that raises on first call, then
+        # returns normally.
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _BoomError("boom")
+            return []
+
+        # Patch the name-mangled method.
+        self.controller._Controller__get_model_files = flaky  # type: ignore[attr-defined]
+
+        # First call raises — this is the scenario that previously leaked
+        # the lock (acquire, raise, release never called).
+        with self.assertRaises(_BoomError):
+            self.controller.get_model_files()
+
+        # Second call must complete.  Before the fix this deadlocked
+        # forever because the lock was still held.
+        result = self.controller.get_model_files()
+        self.assertEqual(result, [])
+
+        # Sanity: lock must currently be free.
+        self.assertTrue(self.controller._Controller__model_lock.acquire(blocking=False))
+        self.controller._Controller__model_lock.release()
+
+    @timeout_decorator.timeout(5)
+    def test_add_model_listener_releases_lock_on_exception(self):
+        listener = MagicMock(spec=IModelListener)
+        calls = {"n": 0}
+
+        def flaky_add(_listener):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _BoomError("boom")
+
+        self.controller._Controller__model.add_listener.side_effect = flaky_add
+
+        with self.assertRaises(_BoomError):
+            self.controller.add_model_listener(listener)
+
+        # Recovery call: must not deadlock.
+        self.controller.add_model_listener(listener)
+
+        self.assertTrue(self.controller._Controller__model_lock.acquire(blocking=False))
+        self.controller._Controller__model_lock.release()
+
+    @timeout_decorator.timeout(5)
+    def test_remove_model_listener_releases_lock_on_exception(self):
+        listener = MagicMock(spec=IModelListener)
+        calls = {"n": 0}
+
+        def flaky_remove(_listener):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _BoomError("boom")
+
+        self.controller._Controller__model.remove_listener.side_effect = flaky_remove
+
+        with self.assertRaises(_BoomError):
+            self.controller.remove_model_listener(listener)
+
+        self.controller.remove_model_listener(listener)
+
+        self.assertTrue(self.controller._Controller__model_lock.acquire(blocking=False))
+        self.controller._Controller__model_lock.release()
+
+    @timeout_decorator.timeout(5)
+    def test_get_model_files_and_add_listener_releases_lock_on_exception(self):
+        listener = MagicMock(spec=IModelListener)
+        calls = {"n": 0}
+
+        def flaky_add(_listener):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _BoomError("boom")
+
+        self.controller._Controller__model.add_listener.side_effect = flaky_add
+        # __get_model_files must exist — provide a trivial stub.
+        self.controller._Controller__get_model_files = lambda: []  # type: ignore[attr-defined]
+
+        with self.assertRaises(_BoomError):
+            self.controller.get_model_files_and_add_listener(listener)
+
+        result = self.controller.get_model_files_and_add_listener(listener)
+        self.assertEqual(result, [])
+
+        self.assertTrue(self.controller._Controller__model_lock.acquire(blocking=False))
+        self.controller._Controller__model_lock.release()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #373

## Summary
- Converts all five `__model_lock.acquire()` / `release()` call sites in `src/python/controller/controller.py` to `with self.__model_lock:` blocks.
- Four short regions (`get_model_files`, `add_model_listener`, `remove_model_listener`, `get_model_files_and_add_listener`) were previously unsafe — any exception in the body permanently held the lock. This is a real deadlock bug.
- The fifth region (`__update_model`, lines ~779-944) was already using `try/finally` and was safe; converted for consistency.
- Adds `src/python/tests/unittests/test_controller/test_controller_lock.py` with four regression tests (one per public method). Each patches the locked body to raise on first call, asserts the raise propagates, then calls again under `@timeout_decorator.timeout(5)`. Pre-fix those calls deadlock; post-fix they complete.

## Test plan
- [x] `cd src/python && ruff check .` → all checks passed
- [x] `cd src/python && pyright` → 0 errors, 0 warnings
- [x] `pytest tests/unittests/test_controller/` → 296 passed (includes 4 new tests)
- [x] Manual verification: confirmed via a standalone snippet that the pre-fix `acquire()` + raise pattern does leak the lock, so the new tests genuinely guard against the regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced internal synchronization mechanisms to ensure proper resource management and prevent potential deadlock scenarios during error conditions.

* **Tests**
  * Added comprehensive regression tests to verify reliable lock behavior under exception scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->