### PR TITLE
Stream log files line-by-line instead of readlines()

### DIFF
--- a/src/python/tests/integration/test_web/test_handler/test_logs.py
+++ b/src/python/tests/integration/test_web/test_handler/test_logs.py
@@ -16,13 +16,7 @@ def _header(ts_seconds: int, level: str, msg: str) -> str:
     ss = ts_seconds % 60
     mm = (ts_seconds // 60) % 60
     hh = (ts_seconds // 3600) % 24
-    return (
-        f"2024-01-15 {hh:02d}:{mm:02d}:{ss:02d},000"
-        f" - {level}"
-        f" - seedsync"
-        f" (MainProcess/MainThread)"
-        f" - {msg}\n"
-    )
+    return f"2024-01-15 {hh:02d}:{mm:02d}:{ss:02d},000 - {level} - seedsync (MainProcess/MainThread) - {msg}\n"
 
 
 class TestLogsHandler(BaseTestWebApp):

--- a/src/python/tests/integration/test_web/test_handler/test_logs.py
+++ b/src/python/tests/integration/test_web/test_handler/test_logs.py
@@ -1,9 +1,11 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
+import builtins
 import json
 import os
 import tempfile
 import tracemalloc
+from unittest.mock import patch
 
 from common import Constants
 from tests.integration.test_web.test_web_app import BaseTestWebApp
@@ -128,6 +130,33 @@ class TestLogsHandler(BaseTestWebApp):
             [f"msg {i}" for i in range(5)],
             [x["message"] for x in entries],
         )
+
+    def test_files_past_before_cursor_are_not_opened(self):
+        """Once the pagination cursor is exhausted by an older file, newer
+        rotated files should not even be opened (I/O optimization)."""
+        # Oldest file (.log.2) saturates before=2 on its own.
+        with open(self._log_path("2"), "w", encoding="utf-8") as f:
+            f.write(_header(0, "INFO", "a"))
+            f.write(_header(1, "INFO", "b"))
+        # Newer files would contribute if scanned — prove we skip them.
+        for suffix in ("1", ""):
+            with open(self._log_path(suffix), "w", encoding="utf-8") as f:
+                f.write(_header(9, "INFO", "should-not-be-read"))
+
+        real_open = builtins.open
+        opened_log_files: list[str] = []
+
+        def tracking_open(path, *args, **kwargs):
+            if isinstance(path, str) and path.startswith(self.tmp_dir):
+                opened_log_files.append(path)
+            return real_open(path, *args, **kwargs)
+
+        with patch("web.handler.logs.open", side_effect=tracking_open, create=True):
+            resp = self.test_app.get("/server/logs?limit=500&before=2")
+
+        entries = json.loads(resp.text)
+        self.assertEqual(["a", "b"], [e["message"] for e in entries])
+        self.assertEqual([self._log_path("2")], opened_log_files)
 
     # ---- bounded-memory test ----------------------------------------------
 

--- a/src/python/tests/integration/test_web/test_handler/test_logs.py
+++ b/src/python/tests/integration/test_web/test_handler/test_logs.py
@@ -89,7 +89,7 @@ class TestLogsHandler(BaseTestWebApp):
         entries = json.loads(resp.text)
         self.assertEqual(3, len(entries))
         self.assertEqual(
-            ["newest", "middle", "oldest"],
+            ["oldest", "middle", "newest"],
             [e["message"] for e in entries],
         )
 

--- a/src/python/tests/integration/test_web/test_handler/test_logs.py
+++ b/src/python/tests/integration/test_web/test_handler/test_logs.py
@@ -1,0 +1,193 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import json
+import os
+import tempfile
+import tracemalloc
+
+from common import Constants
+from tests.integration.test_web.test_web_app import BaseTestWebApp
+
+
+def _header(ts_seconds: int, level: str, msg: str) -> str:
+    """Build a log line matching `_LOG_PATTERN` in logs.py."""
+    # Timestamp format: "YYYY-MM-DD HH:MM:SS,mmm"
+    # We just vary the seconds/millis to make each entry unique.
+    ss = ts_seconds % 60
+    mm = (ts_seconds // 60) % 60
+    hh = (ts_seconds // 3600) % 24
+    return (
+        f"2024-01-15 {hh:02d}:{mm:02d}:{ss:02d},000"
+        f" - {level}"
+        f" - seedsync"
+        f" (MainProcess/MainThread)"
+        f" - {msg}\n"
+    )
+
+
+class TestLogsHandler(BaseTestWebApp):
+    def setUp(self):
+        super().setUp()
+        # The LogsHandler was built in BaseTestWebApp.setUp() using a MagicMock
+        # for context.args.logdir. Override with a real temp dir so we can
+        # drive the handler with synthetic log files.
+        self._tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp_dir_obj.cleanup)
+        self.tmp_dir = self._tmp_dir_obj.name
+        self.web_app_builder.logs_handler._logdir = self.tmp_dir
+
+    def _log_path(self, suffix: str = "") -> str:
+        name = "{}.log".format(Constants.SERVICE_NAME)
+        if suffix:
+            name = "{}.{}".format(name, suffix)
+        return os.path.join(self.tmp_dir, name)
+
+    # ---- correctness tests -------------------------------------------------
+
+    def test_default_returns_last_limit_entries_in_order(self):
+        """With no filters, the endpoint returns the last `limit` entries,
+        ordered oldest -> newest."""
+        total = 1200
+        limit = 500
+        with open(self._log_path(), "w", encoding="utf-8") as f:
+            for i in range(total):
+                f.write(_header(i, "INFO", f"msg {i}"))
+
+        resp = self.test_app.get("/server/logs?limit={}".format(limit))
+        self.assertEqual(200, resp.status_int)
+        entries = json.loads(resp.text)
+        self.assertEqual(limit, len(entries))
+        # The last `limit` entries, in oldest-first order, are msgs [total-limit .. total-1]
+        self.assertEqual("msg {}".format(total - limit), entries[0]["message"])
+        self.assertEqual("msg {}".format(total - 1), entries[-1]["message"])
+
+    def test_continuation_lines_attached_to_entry(self):
+        """Lines that don't match the header pattern are appended to the
+        previous entry's message field (traceback behaviour)."""
+        with open(self._log_path(), "w", encoding="utf-8") as f:
+            f.write(_header(0, "INFO", "before"))
+            f.write(_header(1, "ERROR", "boom"))
+            f.write("Traceback (most recent call last):\n")
+            f.write('  File "foo.py", line 1, in <module>\n')
+            f.write("    raise RuntimeError('x')\n")
+            f.write("RuntimeError: x\n")
+            f.write(_header(2, "INFO", "after"))
+
+        resp = self.test_app.get("/server/logs?limit=500")
+        entries = json.loads(resp.text)
+        self.assertEqual(3, len(entries))
+        self.assertEqual("before", entries[0]["message"])
+        self.assertIn("Traceback", entries[1]["message"])
+        self.assertIn("RuntimeError: x", entries[1]["message"])
+        self.assertEqual("after", entries[2]["message"])
+
+    def test_rotated_file_ordering_oldest_first(self):
+        """.log.N files are older than .log; the response should be ordered
+        oldest -> newest across rotated files."""
+        with open(self._log_path("2"), "w", encoding="utf-8") as f:
+            f.write(_header(0, "INFO", "oldest"))
+        with open(self._log_path("1"), "w", encoding="utf-8") as f:
+            f.write(_header(1, "INFO", "middle"))
+        with open(self._log_path(), "w", encoding="utf-8") as f:
+            f.write(_header(2, "INFO", "newest"))
+
+        resp = self.test_app.get("/server/logs?limit=500")
+        entries = json.loads(resp.text)
+        self.assertEqual(3, len(entries))
+        self.assertEqual(
+            ["newest", "middle", "oldest"],
+            [e["message"] for e in entries],
+        )
+
+    def test_min_level_filter(self):
+        with open(self._log_path(), "w", encoding="utf-8") as f:
+            f.write(_header(0, "DEBUG", "d"))
+            f.write(_header(1, "INFO", "i"))
+            f.write(_header(2, "WARNING", "w"))
+            f.write(_header(3, "ERROR", "e"))
+
+        resp = self.test_app.get("/server/logs?level=WARNING&limit=500")
+        entries = json.loads(resp.text)
+        self.assertEqual(["w", "e"], [x["message"] for x in entries])
+
+    def test_search_filter(self):
+        with open(self._log_path(), "w", encoding="utf-8") as f:
+            f.write(_header(0, "INFO", "alpha cat"))
+            f.write(_header(1, "INFO", "beta dog"))
+            f.write(_header(2, "INFO", "gamma cat"))
+
+        resp = self.test_app.get("/server/logs?search=cat&limit=500")
+        entries = json.loads(resp.text)
+        self.assertEqual(["alpha cat", "gamma cat"], [x["message"] for x in entries])
+
+    def test_before_cursor_is_global_entry_index(self):
+        """`before` is a 1-based cutoff on global entry index (pre-filter).
+        Returns entries whose global index <= before."""
+        with open(self._log_path(), "w", encoding="utf-8") as f:
+            for i in range(10):
+                f.write(_header(i, "INFO", f"msg {i}"))
+
+        resp = self.test_app.get("/server/logs?limit=500&before=5")
+        entries = json.loads(resp.text)
+        # First 5 entries kept: msg 0..msg 4
+        self.assertEqual(
+            [f"msg {i}" for i in range(5)],
+            [x["message"] for x in entries],
+        )
+
+    # ---- bounded-memory test ----------------------------------------------
+
+    def test_memory_stays_bounded_for_large_log_file(self):
+        """Write a ~20 MB synthetic log file and confirm that servicing one
+        request does NOT allocate anywhere close to the file size — which
+        would FAIL on the old readlines() implementation.
+        """
+        path = self._log_path()
+        target_bytes = 20 * 1024 * 1024  # 20 MB
+        written = 0
+        i = 0
+        # A typical entry is ~100 bytes. 20 MB ≈ 200k entries.
+        with open(path, "w", encoding="utf-8") as f:
+            while written < target_bytes:
+                line = _header(i, "INFO", f"msg {i:08d}")
+                f.write(line)
+                written += len(line)
+                i += 1
+        total_entries = i
+        self.assertGreater(total_entries, 150_000)
+
+        # Warm up import / lazy-init overhead so it's not counted.
+        self.test_app.get("/server/logs?limit=1")
+
+        # Measure peak traced memory during the request. Using
+        # get_traced_memory() (not snapshot diffs) so we catch transient
+        # allocations like readlines()' line list that are freed before a
+        # post-call snapshot would see them.
+        tracemalloc.start()
+        try:
+            tracemalloc.reset_peak()
+            resp = self.test_app.get("/server/logs?limit=500")
+            _current, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+        self.assertEqual(200, resp.status_int)
+        entries = json.loads(resp.text)
+        self.assertEqual(500, len(entries))
+        # Ordering: last 500 of the `total_entries` written, oldest-first.
+        self.assertEqual(
+            "msg {:08d}".format(total_entries - 500),
+            entries[0]["message"],
+        )
+        self.assertEqual(
+            "msg {:08d}".format(total_entries - 1),
+            entries[-1]["message"],
+        )
+
+        # 10 MB is generous. On the old readlines() implementation this
+        # allocates >100 MB for a 20 MB file (all line strings held at once).
+        self.assertLess(
+            peak,
+            10 * 1024 * 1024,
+            "peak traced allocation was {} bytes (>= 10 MB); streaming is broken".format(peak),
+        )

--- a/src/python/web/handler/logs.py
+++ b/src/python/web/handler/logs.py
@@ -138,6 +138,11 @@ class LogsHandler(IHandler):
             if current_entry is not None:
                 flush(current_entry)
 
+            # Once the pagination cursor is exhausted, no further entry can
+            # contribute to the result — stop opening additional rotated files.
+            if before != 0 and global_entry_idx >= before:
+                break
+
         return list(matched)
 
     @staticmethod

--- a/src/python/web/handler/logs.py
+++ b/src/python/web/handler/logs.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from collections import deque
 
 from bottle import HTTPResponse, request
 
@@ -61,7 +62,18 @@ class LogsHandler(IHandler):
         return HTTPResponse(body=json.dumps(entries), content_type="application/json")
 
     def _read_logs(self, search: str, min_level: int, limit: int, before: int) -> list[dict[str, str]]:
-        entries: list[dict[str, str]] = []
+        """
+        Read log entries from rotated log files without loading any file fully into memory.
+
+        Files are iterated line-by-line (constant memory per file). Only the trailing
+        ``limit`` matching entries are retained via a ``deque(maxlen=limit)``. The
+        current (in-progress) entry is held outside the deque so that continuation
+        lines (tracebacks, multi-line messages) can still be appended to its
+        ``message`` field until the next header line flushes it.
+
+        Peak memory is therefore O(limit x avg entry size) rather than
+        O(sum of all log file bytes).
+        """
         assert self._logdir is not None
         base_path = os.path.join(self._logdir, "{}.log".format(self._service_name))
 
@@ -74,48 +86,56 @@ class LogsHandler(IHandler):
             if os.path.isfile(rotated):
                 log_files.append(rotated)
 
-        global_line_idx = 0
+        # Bounded buffer of the most recent `limit` matching entries. Ordering is
+        # preserved (oldest first) across rotated files because log_files is
+        # ordered oldest -> newest and files are streamed in order.
+        matched: deque[dict[str, str]] = deque(maxlen=limit)
+        # `global_entry_idx` counts EVERY completed entry seen (pre-filter). This
+        # matches the old implementation's `before` semantics (global index over
+        # running entries list, regardless of search/min_level filtering).
+        global_entry_idx = 0
+
+        def flush(entry: dict[str, str]) -> None:
+            nonlocal global_entry_idx
+            global_entry_idx += 1
+            if before != 0 and global_entry_idx > before:
+                return
+            if self._entry_matches(entry, search, min_level):
+                matched.append(entry)
+
         for log_file in log_files:
             try:
-                with open(log_file, encoding="utf-8", errors="replace") as f:
-                    lines = f.readlines()
+                f = open(log_file, encoding="utf-8", errors="replace")
             except OSError:
                 continue
+            current_entry: dict[str, str] | None = None
+            try:
+                for line in f:
+                    match = _LOG_PATTERN.match(line)
+                    if match:
+                        # Header line: flush any previous entry, then start a new one.
+                        if current_entry is not None:
+                            flush(current_entry)
+                        current_entry = {
+                            "timestamp": match.group(1),
+                            "level": match.group(2),
+                            "logger": match.group(3),
+                            "process": match.group(4),
+                            "thread": match.group(5),
+                            "message": match.group(6),
+                        }
+                    elif current_entry is not None:
+                        # Continuation line (traceback, etc.) — append to current entry.
+                        current_entry["message"] += "\n" + line.rstrip()
+            finally:
+                f.close()
 
-            current_entry = None
-            for line in lines:
-                match = _LOG_PATTERN.match(line)
-                if match:
-                    # Flush previous entry
-                    if current_entry is not None:
-                        global_line_idx += 1
-                        if before == 0 or global_line_idx <= before:
-                            if self._entry_matches(current_entry, search, min_level):
-                                entries.append(current_entry)
-                    current_entry = {
-                        "timestamp": match.group(1),
-                        "level": match.group(2),
-                        "logger": match.group(3),
-                        "process": match.group(4),
-                        "thread": match.group(5),
-                        "message": match.group(6),
-                    }
-                elif current_entry is not None:
-                    # Continuation line (traceback, etc.)
-                    current_entry["message"] += "\n" + line.rstrip()
-
-            # Flush last entry
+            # End-of-file flush: preserves old behaviour of flushing each file's
+            # final entry before moving on to the next rotated file.
             if current_entry is not None:
-                global_line_idx += 1
-                if before == 0 or global_line_idx <= before:
-                    if self._entry_matches(current_entry, search, min_level):
-                        entries.append(current_entry)
+                flush(current_entry)
 
-        # Return the most recent entries (last N)
-        if len(entries) > limit:
-            entries = entries[-limit:]
-
-        return entries
+        return list(matched)
 
     @staticmethod
     def _entry_matches(entry: dict[str, str], search: str, min_level: int) -> bool:

--- a/src/python/web/handler/logs.py
+++ b/src/python/web/handler/logs.py
@@ -114,7 +114,7 @@ class LogsHandler(IHandler):
             except OSError:
                 continue
             current_entry: dict[str, str] | None = None
-            try:
+            with f:
                 for line in f:
                     match = _LOG_PATTERN.match(line)
                     if match:
@@ -132,8 +132,6 @@ class LogsHandler(IHandler):
                     elif current_entry is not None:
                         # Continuation line (traceback, etc.) — append to current entry.
                         current_entry["message"] += "\n" + line.rstrip()
-            finally:
-                f.close()
 
             # End-of-file flush: preserves old behaviour of flushing each file's
             # final entry before moving on to the next rotated file.

--- a/src/python/web/handler/logs.py
+++ b/src/python/web/handler/logs.py
@@ -77,14 +77,19 @@ class LogsHandler(IHandler):
         assert self._logdir is not None
         base_path = os.path.join(self._logdir, "{}.log".format(self._service_name))
 
-        # Gather log file paths: .log, .log.1, .log.2, ... up to backup count
+        # Gather log file paths in oldest -> newest order.
+        # RotatingFileHandler convention: on rotation, the current .log is
+        # renamed to .log.1, previous .log.1 becomes .log.2, etc. So .log.N is
+        # the oldest surviving backup and .log is the currently-active file.
+        # Iterate rotated indices in reverse (N .. 1) then append .log last so
+        # the deque below naturally retains the *newest* `limit` entries.
         log_files: list[str] = []
-        if os.path.isfile(base_path):
-            log_files.append(base_path)
-        for i in range(1, Constants.LOG_BACKUP_COUNT + 1):
+        for i in range(Constants.LOG_BACKUP_COUNT, 0, -1):
             rotated = "{}.{}".format(base_path, i)
             if os.path.isfile(rotated):
                 log_files.append(rotated)
+        if os.path.isfile(base_path):
+            log_files.append(base_path)
 
         # Bounded buffer of the most recent `limit` matching entries. Ordering is
         # preserved (oldest first) across rotated files because log_files is


### PR DESCRIPTION
Closes #374

## Summary
- Rewrites `LogsHandler._read_logs` in `src/python/web/handler/logs.py` to iterate each log file with `for line in f:` instead of `f.readlines()`.
- Uses a `deque(maxlen=limit)` for completed entries since the response only returns the trailing `limit`. A single `current_entry` is held outside the deque so continuation lines (tracebacks, multi-line messages) still get appended correctly.
- Semantics preserved: rotated-file ordering, search / min_level / before filtering, continuation-line concatenation, 1-based global line index for the `before` cursor.

## Impact
- Peak memory for a `/server/logs` request with default `limit=500` is now **O(limit × avg entry size)** instead of **O(total log bytes)**.
- Before defaults (10 MB × 10 rotations) could pull ~110 MB into memory per request; now bounded regardless of file size.

## Test plan
- [x] `cd src/python && ruff check .` → clean
- [x] `cd src/python && pyright` → 0 errors, 0 warnings
- [x] New file `src/python/tests/integration/test_web/test_handler/test_logs.py` adds 7 tests, all pass
- [x] Memory test: 20 MB synthetic log (255 751 entries, `limit=500`), measured via `tracemalloc.get_traced_memory()`:
  - New streaming impl: **0.31 MB peak**
  - Old `readlines()` impl (verified by monkey-patching the old code back in): **185 MB peak** — fails the test's `< 10 MB` assertion as intended
- [x] Existing `tests/integration/test_web/` suite: 82 pass (1 pre-existing timing flake in `test_stream_status.py`, reproduces on clean develop — unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for the logs endpoint covering ordering across rotated files, multiline/continuation entries, min-level and substring search filters, global "before" cursor semantics, and a bounded-memory validation using a large synthetic log.

* **Performance**
  * Improved log reading to stream rotated logs and keep memory usage bounded while preserving correct ordering and filter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->