### PR TITLE
Strip exception details from integrations error response

### DIFF
--- a/src/python/controller/arr_notifier.py
+++ b/src/python/controller/arr_notifier.py
@@ -134,5 +134,5 @@ class ArrNotifier(IModelListener):
             with urllib.request.urlopen(req, timeout=10):
                 pass
             self._logger.debug("%s scan triggered: %s", service, payload.get("path", ""))
-        except Exception as e:
-            self._logger.warning("%s scan failed: %s", service, str(e))
+        except Exception:
+            self._logger.exception("%s scan failed", service)

--- a/src/python/tests/integration/test_web/test_handler/test_integrations.py
+++ b/src/python/tests/integration/test_web/test_handler/test_integrations.py
@@ -62,9 +62,7 @@ class TestIntegrationsHandler(BaseTestWebApp):
         """Exception text (host/port, reason) must not reach the HTTP response body."""
         self.context.config.integrations.sonarr_url = "http://192.168.1.100:8989"
         self.context.config.integrations.sonarr_api_key = "test-key"
-        mock_urlopen.side_effect = urllib.error.URLError(
-            "connection refused to 192.168.1.100:8989"
-        )
+        mock_urlopen.side_effect = urllib.error.URLError("connection refused to 192.168.1.100:8989")
         resp = self.test_app.get("/server/integrations/test/sonarr", expect_errors=True)
         self.assertEqual(502, resp.status_int)
         raw_body = str(resp.html)

--- a/src/python/tests/integration/test_web/test_handler/test_integrations.py
+++ b/src/python/tests/integration/test_web/test_handler/test_integrations.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+import urllib.error
 from unittest.mock import MagicMock, patch
 
 from tests.integration.test_web.test_web_app import BaseTestWebApp
@@ -53,7 +54,29 @@ class TestIntegrationsHandler(BaseTestWebApp):
         resp = self.test_app.get("/server/integrations/test/sonarr", expect_errors=True)
         self.assertEqual(502, resp.status_int)
         body = json.loads(str(resp.html))
-        self.assertIn("Connection failed", body["error"])
+        self.assertIn("Sonarr connection failed", body["error"])
+        self.assertIn("server logs", body["error"])
+
+    @patch("web.handler.integrations.urllib.request.urlopen")
+    def test_test_sonarr_error_does_not_leak_exception_details(self, mock_urlopen):
+        """Exception text (host/port, reason) must not reach the HTTP response body."""
+        self.context.config.integrations.sonarr_url = "http://192.168.1.100:8989"
+        self.context.config.integrations.sonarr_api_key = "test-key"
+        mock_urlopen.side_effect = urllib.error.URLError(
+            "connection refused to 192.168.1.100:8989"
+        )
+        resp = self.test_app.get("/server/integrations/test/sonarr", expect_errors=True)
+        self.assertEqual(502, resp.status_int)
+        raw_body = str(resp.html)
+        body = json.loads(raw_body)
+        # Generic message present
+        self.assertIn("Sonarr connection failed", body["error"])
+        self.assertIn("server logs", body["error"])
+        # Sensitive bits absent
+        self.assertNotIn("192.168.1.100", raw_body)
+        self.assertNotIn("8989", raw_body)
+        self.assertNotIn("connection refused", raw_body)
+        self.assertNotIn("URLError", raw_body)
 
     @patch("web.handler.integrations.urllib.request.urlopen")
     def test_test_radarr_success(self, mock_urlopen):

--- a/src/python/web/handler/integrations.py
+++ b/src/python/web/handler/integrations.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import urllib.request
 
 from bottle import HTTPResponse
@@ -14,6 +15,7 @@ class IntegrationsHandler(IHandler):
 
     def __init__(self, config: Config):
         self.__config = config
+        self._logger = logging.getLogger(self.__class__.__name__)
 
     @overrides(IHandler)
     def add_routes(self, web_app: WebApp):
@@ -28,8 +30,7 @@ class IntegrationsHandler(IHandler):
         cfg = self.__config.integrations
         return self.__test_arr_connection("Radarr", cfg.radarr_url, cfg.radarr_api_key)
 
-    @staticmethod
-    def __test_arr_connection(service: str, url: str, api_key: str) -> HTTPResponse:
+    def __test_arr_connection(self, service: str, url: str, api_key: str) -> HTTPResponse:
         if not url:
             return HTTPResponse(body=json.dumps({"error": f"{service} URL is not configured"}), status=400)
         if not api_key:
@@ -53,8 +54,9 @@ class IntegrationsHandler(IHandler):
                 body=json.dumps({"success": True, "version": version}),
                 status=200,
             )
-        except Exception as e:
+        except Exception:
+            self._logger.exception("%s connection test failed", service)
             return HTTPResponse(
-                body=json.dumps({"error": f"Connection failed: {str(e)}"}),
+                body=json.dumps({"error": f"{service} connection failed. Check server logs for details."}),
                 status=502,
             )


### PR DESCRIPTION
Closes #375

## Summary
- `src/python/web/handler/integrations.py`: in the `except Exception` branch of `__test_arr_connection`, stop returning `str(e)` in the response body. Return a generic `"{service} connection failed. Check server logs for details."` and log the full traceback server-side via `self._logger.exception(...)`.
- Converted `__test_arr_connection` from `@staticmethod` to an instance method so it can use the logger. Both private callers (`__handle_test_sonarr`, `__handle_test_radarr`) updated to invoke via `self.`.
- `src/python/controller/arr_notifier.py`: replaced `self._logger.warning("%s scan failed: %s", service, str(e))` with `self._logger.exception("%s scan failed", service)` — same log verbosity on the happy path, but fire-and-forget failures now include a traceback for easier triage.

## Why
`str(e)` for `urllib.request.urlopen` errors leaks:
- Target IP / port (socket errors)
- SSL certificate details
- Internal DNS names
- HTTP error bodies

These used to flow through the UI and by extension browser history, screenshots, and support tickets.

## Not included
Optional redirect-restriction hardening (blocking the `X-Api-Key` from reaching a redirect target) was skipped because adopting `build_opener` for a custom `HTTPRedirectHandler` would require reworking all three existing `urlopen` mocks. Worth tracking as a follow-up if we want to close the API-key-leak-via-redirect path.

## Test plan
- [x] `cd src/python && ruff check .` → clean
- [x] `cd src/python && pyright` → 0 errors, 0 warnings
- [x] Updated existing 502 test to assert the new generic string
- [x] New test `test_test_sonarr_error_does_not_leak_exception_details` mocks `urlopen` to raise `urllib.error.URLError("connection refused to 192.168.1.100:8989")`, asserts status 502, asserts host / port / exception text are absent from the body, and asserts the generic message is present
- [x] All 8 integrations tests pass; 14 `arr_notifier` tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error messages no longer expose sensitive system details (IP addresses, ports, connection details) in user-facing responses.
  * Server-side logging now captures complete exception information for debugging while keeping client responses generic.

* **Tests**
  * Added validation tests to verify error responses don't leak sensitive exception information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->