### PR TITLE
Fix lint quick-wins and graduate 7 trivial rules to error

### DIFF
--- a/src/angular/eslint.config.js
+++ b/src/angular/eslint.config.js
@@ -3,8 +3,7 @@
 // to keep the initial lint step non-fatal while the tooling PR lands. A
 // follow-up cleanup PR should graduate these to "error" and address the
 // accumulated findings (e.g. `ChangeDetectionStrategy.OnPush`, a11y on
-// interactive elements, <img> alt text, `any` casts, inject() migration,
-// ==/===, inferrable types, empty functions, Array<T> vs T[]).
+// interactive elements, <img> alt text, `any` casts).
 // See: https://github.com/nitrobass24/seedsync/issues/376
 const eslint = require("@eslint/js");
 const { defineConfig } = require("eslint/config");
@@ -47,14 +46,13 @@ module.exports = defineConfig([
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
-      // High-volume stylistic findings — demoted to "warn" per the task
-      // plan so CI stays green. Follow-up cleanup tracked in #376.
-      "@typescript-eslint/no-inferrable-types": "warn",
-      "@typescript-eslint/no-empty-function": "warn",
-      "@typescript-eslint/array-type": "warn",
-      "@typescript-eslint/consistent-indexed-object-style": "warn",
-      "@angular-eslint/prefer-inject": "warn",
-      "prefer-const": "warn",
+      // Graduated to "error" in #378 after the codebase was cleaned up.
+      "@typescript-eslint/no-inferrable-types": "error",
+      "@typescript-eslint/no-empty-function": "error",
+      "@typescript-eslint/array-type": "error",
+      "@typescript-eslint/consistent-indexed-object-style": "error",
+      "@angular-eslint/prefer-inject": "error",
+      "prefer-const": "error",
     },
   },
   {
@@ -70,7 +68,8 @@ module.exports = defineConfig([
       // High-volume template findings — demoted to "warn" for this PR.
       // Follow-up cleanup tracked in #376.
       "@angular-eslint/template/alt-text": "warn",
-      "@angular-eslint/template/eqeqeq": "warn",
+      // Graduated to "error" in #378 after the codebase was cleaned up.
+      "@angular-eslint/template/eqeqeq": "error",
     },
   },
 ]);

--- a/src/angular/src/app/app.ts
+++ b/src/angular/src/app/app.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, OnInit, ViewChild, inject } from '@angular/core';
 import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 
 import { ROUTE_INFOS, RouteInfo } from './routes';
@@ -21,13 +21,13 @@ export class App implements OnInit, AfterViewInit {
 
   private _resizeObserver: ResizeObserver | null = null;
 
-  constructor(
-    private router: Router,
-    private _domService: DomService
-  ) {
-    router.events.subscribe(() => {
+  private readonly router = inject(Router);
+  private readonly _domService = inject(DomService);
+
+  constructor() {
+    this.router.events.subscribe(() => {
       this.showSidebar = false;
-      this.activeRoute = ROUTE_INFOS.find(value => '/' + value.path === router.url);
+      this.activeRoute = ROUTE_INFOS.find(value => '/' + value.path === this.router.url);
     });
   }
 

--- a/src/angular/src/app/common/cached-reuse-strategy.ts
+++ b/src/angular/src/app/common/cached-reuse-strategy.ts
@@ -8,7 +8,7 @@ import { ActivatedRouteSnapshot, DetachedRouteHandle, RouteReuseStrategy } from 
  */
 export class CachedReuseStrategy implements RouteReuseStrategy {
 
-    handlers: {[key: string]: DetachedRouteHandle} = {};
+    handlers: Record<string, DetachedRouteHandle> = {};
 
     shouldDetach(_route: ActivatedRouteSnapshot): boolean {
         return true;

--- a/src/angular/src/app/common/eta.pipe.ts
+++ b/src/angular/src/app/common/eta.pipe.ts
@@ -12,7 +12,7 @@ export class EtaPipe implements PipeTransform {
       "s": 1
   };
 
-  transform(seconds: number = 0): string {
+  transform(seconds = 0): string {
     if (isNaN(parseFloat(String(seconds))) || !isFinite(seconds)) { return "?"; }
     if (seconds === 0) { return "0s"; }
 

--- a/src/angular/src/app/common/file-size.pipe.ts
+++ b/src/angular/src/app/common/file-size.pipe.ts
@@ -23,7 +23,7 @@ export class FileSizePipe implements PipeTransform {
     "PB"
   ];
 
-  transform(bytes: number = 0, precision: number = 2): string {
+  transform(bytes = 0, precision = 2): string {
     if (isNaN(parseFloat(String(bytes))) || !isFinite(bytes)) { return "?"; }
 
     let unit = 0;

--- a/src/angular/src/app/models/log-record.spec.ts
+++ b/src/angular/src/app/models/log-record.spec.ts
@@ -14,7 +14,7 @@ describe('logRecordFromJson', () => {
   }
 
   it('should map level_name to LogLevel enum', () => {
-    const levels: Array<[string, LogLevel]> = [
+    const levels: [string, LogLevel][] = [
       ['DEBUG', LogLevel.DEBUG],
       ['INFO', LogLevel.INFO],
       ['WARNING', LogLevel.WARNING],

--- a/src/angular/src/app/models/model-file.spec.ts
+++ b/src/angular/src/app/models/model-file.spec.ts
@@ -49,7 +49,7 @@ describe('modelFileFromJson', () => {
   });
 
   it('should map state strings to ModelFileState enum via toUpperCase', () => {
-    const states: Array<[string, ModelFileState]> = [
+    const states: [string, ModelFileState][] = [
       ['default', ModelFileState.DEFAULT],
       ['queued', ModelFileState.QUEUED],
       ['downloading', ModelFileState.DOWNLOADING],

--- a/src/angular/src/app/models/notification.ts
+++ b/src/angular/src/app/models/notification.ts
@@ -15,7 +15,7 @@ export enum NotificationLevel {
 export function createNotification(
   level: NotificationLevel,
   text: string,
-  dismissible: boolean = false,
+  dismissible = false,
 ): Notification {
   return {
     level,

--- a/src/angular/src/app/pages/files/file-options.component.html
+++ b/src/angular/src/app/pages/files/file-options.component.html
@@ -19,7 +19,7 @@
             </div>
             <div class="selection">
                 <!-- these divs only show the selected option -->
-                @if ((options | async)?.selectedStatusFilter == null) {
+                @if ((options | async)?.selectedStatusFilter === null || (options | async)?.selectedStatusFilter === undefined) {
                     <div class="sel-item" id="sel-item-all">
                         <div class="icon"></div>
                         <span class="text">All</span>
@@ -65,7 +65,7 @@
         </button>
         <div class="dropdown-menu">
             <div class="dropdown-item"
-                 [class.active]="(options | async)?.selectedStatusFilter == null"
+                 [class.active]="(options | async)?.selectedStatusFilter === null || (options | async)?.selectedStatusFilter === undefined"
                  (click)="onFilterByStatus(null)">
                 <div class="icon"></div>
                 <span class="text">All</span>

--- a/src/angular/src/app/pages/settings/option.component.html
+++ b/src/angular/src/app/pages/settings/option.component.html
@@ -1,5 +1,5 @@
 <div class="form-group"
-     [class.error]="value() == '<replace me>'">
+     [class.error]="value() === '<replace me>'">
 
   @switch (type()) {
     @case (OptionType.Text) {
@@ -7,7 +7,7 @@
         <span class="name">{{ label() }}</span>
         <input type="text"
                class="form-control"
-               [disabled]="disabled() || value() == null"
+               [disabled]="disabled() || value() === null || value() === undefined"
                [ngModel]="value()"
                (ngModelChange)="onChange($event)" />
         @if (description()) {
@@ -20,7 +20,7 @@
       <label>
         <input type="checkbox"
                class="form-check-input"
-               [disabled]="disabled() || value() == null"
+               [disabled]="disabled() || value() === null || value() === undefined"
                [ngModel]="value()"
                (ngModelChange)="onChange($event)" />
         <span class="name">{{ label() }}</span>
@@ -35,7 +35,7 @@
         <span class="name">{{ label() }}</span>
         <input type="password"
                class="form-control"
-               [disabled]="disabled() || value() == null"
+               [disabled]="disabled() || value() === null || value() === undefined"
                [ngModel]="value()"
                (ngModelChange)="onChange($event)" />
         @if (description()) {
@@ -48,7 +48,7 @@
       <label>
         <span class="name">{{ label() }}</span>
         <select class="form-select"
-                [disabled]="disabled() || value() == null"
+                [disabled]="disabled() || value() === null || value() === undefined"
                 [ngModel]="value()"
                 (ngModelChange)="onChange($event)">
           @for (option of effectiveChoices(); track option) {

--- a/src/angular/src/app/services/files/view-file.service.ts
+++ b/src/angular/src/app/services/files/view-file.service.ts
@@ -72,7 +72,7 @@ export class ViewFileService {
   }
 
   setSelected(file: ViewFile): void {
-    let viewFiles = [...this.files];
+    const viewFiles = [...this.files];
     const unSelectIndex = viewFiles.findIndex((v) => v.isSelected);
     const key = viewFileKey(file);
 
@@ -209,7 +209,7 @@ export class ViewFileService {
   private bulkAction(
     filter: (f: ViewFile) => boolean,
     action: (f: ViewFile) => Observable<WebReaction>,
-    concurrency: number = Infinity
+    concurrency = Infinity
   ): Observable<WebReaction[]> {
     const checked = this.files.filter(f => this.checkedSet.has(viewFileKey(f)) && filter(f));
     if (checked.length === 0) {
@@ -230,7 +230,7 @@ export class ViewFileService {
     this.sortComparator = comparator;
 
     this.logger.debug('Re-sorting view files');
-    let newViewFiles = [...this.files];
+    const newViewFiles = [...this.files];
     if (this.sortComparator != null) {
       newViewFiles.sort(this.sortComparator);
     }
@@ -244,7 +244,7 @@ export class ViewFileService {
   private buildViewFromModelFiles(modelFiles: Map<string, ModelFile>): void {
     this.logger.debug('Received next model files');
 
-    let newViewFiles = [...this.files];
+    const newViewFiles = [...this.files];
 
     const addedKeys: string[] = [];
     const removedKeys: string[] = [];
@@ -370,7 +370,7 @@ function modelFilesEqual(a: ModelFile, b: ModelFile): boolean {
   );
 }
 
-function createViewFile(modelFile: ModelFile, pairNameMap: Map<string, string>, isSelected: boolean = false): ViewFile {
+function createViewFile(modelFile: ModelFile, pairNameMap: Map<string, string>, isSelected = false): ViewFile {
   const localSize = modelFile.local_size ?? 0;
   const remoteSize = modelFile.remote_size ?? 0;
   let percentDownloaded: number;

--- a/src/angular/src/app/services/logs/log.service.ts
+++ b/src/angular/src/app/services/logs/log.service.ts
@@ -42,9 +42,13 @@ export class LogService implements StreamEventHandler {
         this.logsSubject.next(logRecordFromJson(JSON.parse(data)));
     }
 
-    onConnected(): void {}
+    onConnected(): void {
+        // intentional no-op
+    }
 
-    onDisconnected(): void {}
+    onDisconnected(): void {
+        // intentional no-op
+    }
 
     fetchHistory(params: LogHistoryParams = {}): Observable<LogHistoryEntry[]> {
         let httpParams = new HttpParams();

--- a/src/angular/src/app/services/utils/logger.service.ts
+++ b/src/angular/src/app/services/utils/logger.service.ts
@@ -14,24 +14,32 @@ export class LoggerService {
   get debug() {
     return this.level >= LogLevel.DEBUG
       ? console.debug.bind(console)
-      : () => {};
+      : () => {
+          // intentional no-op
+        };
   }
 
   get info() {
     return this.level >= LogLevel.INFO
       ? console.log.bind(console)
-      : () => {};
+      : () => {
+          // intentional no-op
+        };
   }
 
   get warn() {
     return this.level >= LogLevel.WARN
       ? console.warn.bind(console)
-      : () => {};
+      : () => {
+          // intentional no-op
+        };
   }
 
   get error() {
     return this.level >= LogLevel.ERROR
       ? console.error.bind(console)
-      : () => {};
+      : () => {
+          // intentional no-op
+        };
   }
 }

--- a/src/angular/src/app/services/utils/notification.service.spec.ts
+++ b/src/angular/src/app/services/utils/notification.service.spec.ts
@@ -6,7 +6,7 @@ function makeNotification(
   level: NotificationLevel,
   text: string,
   timestamp: number = Date.now(),
-  dismissible: boolean = false,
+  dismissible = false,
 ): Notification {
   return { level, text, timestamp, dismissible };
 }


### PR DESCRIPTION
Closes #378

## Summary
Fixes 28 ESLint warnings across 7 rules and graduates each to `error` in `src/angular/eslint.config.js`:

| Rule | Fixed |
|---|---:|
| `@typescript-eslint/no-inferrable-types` | 7 |
| `@angular-eslint/template/eqeqeq` | 7 |
| `@typescript-eslint/no-empty-function` | 6 |
| `prefer-const` | 3 |
| `@typescript-eslint/array-type` | 2 |
| `@angular-eslint/prefer-inject` | 2 |
| `@typescript-eslint/consistent-indexed-object-style` | 1 |

## Notable decisions
- **`eqeqeq`**: `x == null` (null-or-undefined shorthand) expanded to `x === null || x === undefined` to preserve behavior when an `| async` pipe yields `undefined`. Applied in 6 spots across `option.component.html` and `file-options.component.html`.
- **`no-empty-function`**: Intentionally empty `StreamEventHandler` methods and logger fallback arrows got `// intentional no-op` comments — none were deletable since they satisfy interface contracts / ternary branches.
- **`prefer-inject`**: `App` component has constructor-side-effect logic (router subscription). Kept a no-arg `constructor()` and moved DI to `inject()` field initializers.

## Coordination note
Three sibling PRs (#389-style) run in parallel on the same `eslint.config.js` and may have minor rule-line merge overlap. Each touches a distinct rule set. The `--max-warnings 138` CI baseline is intentionally left untouched here — it will be ratcheted in one final coordinated PR after all four cleanup PRs land.

## Test plan
- [x] `cd src/angular && npx ng lint` → 110 warnings (down from 138), zero violations of the 7 graduated rules
- [x] `cd src/angular && npx ng test --watch=false` → 319/319 pass
- [x] `cd src/angular && npx ng build` → clean

Files touched: 14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated dependency injection to use Angular's `inject()` function for cleaner code structure.
  * Updated type annotations to use TypeScript utility types and removed redundant explicit type declarations.
  * Converted variable declarations from `let` to `const` for improved immutability.

* **Style**
  * Enforced strict equality (`===`) in template comparisons for more predictable null/undefined handling.
  * Strengthened ESLint rules by promoting multiple stylistic checks from warnings to errors.

* **Chores**
  * Updated configuration comments to reflect new linting rule severities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->