### PR TITLE
Fix 55 template a11y violations (buttons + alt-text + focusable interactives)

### DIFF
--- a/src/angular/eslint.config.js
+++ b/src/angular/eslint.config.js
@@ -2,7 +2,7 @@
 // TODO(#376): Many rules below are intentionally set to "warn" (not "error")
 // to keep the initial lint step non-fatal while the tooling PR lands. A
 // follow-up cleanup PR should graduate these to "error" and address the
-// accumulated findings (e.g. `ChangeDetectionStrategy.OnPush`, `any` casts,
+// accumulated findings (e.g. `ChangeDetectionStrategy.OnPush`,
 // inject() migration, ==/===, inferrable types, empty functions,
 // Array<T> vs T[]).
 // See: https://github.com/nitrobass24/seedsync/issues/376
@@ -38,10 +38,10 @@ module.exports = defineConfig([
           style: "kebab-case",
         },
       ],
-      // Rules required by #376, all "warn" for the initial PR:
+      // Rules required by #376; most remain "warn" while targeted cleanups graduate to "error":
       "@angular-eslint/prefer-on-push-component-change-detection": "warn",
       "@angular-eslint/no-empty-lifecycle-method": "warn",
-      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-explicit-any": "error",
       // "no-unused-vars" is the one rule #376 asks to keep as "error":
       "@typescript-eslint/no-unused-vars": [
         "error",

--- a/src/angular/eslint.config.js
+++ b/src/angular/eslint.config.js
@@ -2,9 +2,9 @@
 // TODO(#376): Many rules below are intentionally set to "warn" (not "error")
 // to keep the initial lint step non-fatal while the tooling PR lands. A
 // follow-up cleanup PR should graduate these to "error" and address the
-// accumulated findings (e.g. `ChangeDetectionStrategy.OnPush`, a11y on
-// interactive elements, <img> alt text, `any` casts, inject() migration,
-// ==/===, inferrable types, empty functions, Array<T> vs T[]).
+// accumulated findings (e.g. `ChangeDetectionStrategy.OnPush`, `any` casts,
+// inject() migration, ==/===, inferrable types, empty functions,
+// Array<T> vs T[]).
 // See: https://github.com/nitrobass24/seedsync/issues/376
 const eslint = require("@eslint/js");
 const { defineConfig } = require("eslint/config");
@@ -64,12 +64,12 @@ module.exports = defineConfig([
       angular.configs.templateAccessibility,
     ],
     rules: {
-      // Required-by-#376 a11y rules, "warn" for the initial PR:
-      "@angular-eslint/template/click-events-have-key-events": "warn",
-      "@angular-eslint/template/interactive-supports-focus": "warn",
+      // A11y rules graduated to "error" in #380/#381 cleanup:
+      "@angular-eslint/template/click-events-have-key-events": "error",
+      "@angular-eslint/template/interactive-supports-focus": "error",
+      "@angular-eslint/template/alt-text": "error",
       // High-volume template findings — demoted to "warn" for this PR.
       // Follow-up cleanup tracked in #376.
-      "@angular-eslint/template/alt-text": "warn",
       "@angular-eslint/template/eqeqeq": "warn",
     },
   },

--- a/src/angular/src/app/app.html
+++ b/src/angular/src/app/app.html
@@ -4,7 +4,7 @@
 
   <div id="logo">
     <span class="image">
-      <img src="assets/logo.png" />
+      <img src="assets/logo.png" alt="" />
     </span>
     <span class="text"><b>Seed</b>Sync</span>
 
@@ -18,9 +18,14 @@
 
 <!-- Used for sidebar closing -->
 <div id="outside-sidebar"
+     role="button"
+     tabindex="0"
+     aria-label="Close sidebar"
      [class.outside-sidebar-show]="showSidebar"
      [class.outside-sidebar-hide]="!showSidebar"
-     (click)="showSidebar=false">
+     (click)="showSidebar=false"
+     (keyup.enter)="showSidebar=false"
+     (keyup.space)="showSidebar=false; $event.preventDefault()">
 </div>
 
 <div id="top-content">

--- a/src/angular/src/app/pages/autoqueue/autoqueue-page.component.html
+++ b/src/angular/src/app/pages/autoqueue/autoqueue-page.component.html
@@ -18,24 +18,28 @@
   <div id="controls" [attr.disabled]="enabled && patternsOnly ? null : true">
     @for (pattern of patterns$ | async; track pattern.pattern) {
       <div class="pattern">
-        <div
+        <button
+          type="button"
           class="button"
           appClickStopPropagation
-          [attr.disabled]="enabled && patternsOnly ? null : true"
+          [attr.aria-label]="'Remove pattern ' + pattern.pattern"
+          [disabled]="!(enabled && patternsOnly)"
           (click)="!(enabled && patternsOnly) || onRemovePattern(pattern)">
           <span>&#8722;</span>
-        </div>
+        </button>
         <span class="text">{{ pattern.pattern }}</span>
       </div>
     }
     <div id="add-pattern">
-      <div
+      <button
+        type="button"
         class="button"
         appClickStopPropagation
+        aria-label="Add pattern"
         (click)="!(newPattern && enabled && patternsOnly) || onAddPattern()"
-        [attr.disabled]="newPattern && enabled && patternsOnly ? null : true">
+        [disabled]="!(newPattern && enabled && patternsOnly)">
         <span>&#43;</span>
-      </div>
+      </button>
       <label>
         <input
           type="search"

--- a/src/angular/src/app/pages/autoqueue/autoqueue-page.component.scss
+++ b/src/angular/src/app/pages/autoqueue/autoqueue-page.component.scss
@@ -23,6 +23,11 @@
             .button {
                 @extend %button;
 
+                /* Reset native <button> appearance */
+                appearance: none;
+                font: inherit;
+                outline: inherit;
+
                 flex-grow: 0;
                 flex-direction: row;
                 padding: 8px;

--- a/src/angular/src/app/pages/autoqueue/autoqueue-page.component.scss
+++ b/src/angular/src/app/pages/autoqueue/autoqueue-page.component.scss
@@ -26,7 +26,6 @@
                 /* Reset native <button> appearance */
                 appearance: none;
                 font: inherit;
-                outline: inherit;
 
                 flex-grow: 0;
                 flex-direction: row;

--- a/src/angular/src/app/pages/files/file-options.component.html
+++ b/src/angular/src/app/pages/files/file-options.component.html
@@ -2,7 +2,7 @@
      [style.top.px]="headerHeight | async"
      [class.sticky]="(options | async)?.pinFilter">
     <div id="filter-search">
-        <img src="assets/icons/search.svg" />
+        <img src="assets/icons/search.svg" alt="" aria-hidden="true" />
         <div class="input-group">
             <input class="form-control" placeholder="Filter by name..." type="search"
                    [ngModel]="(options | async)?.nameFilter"
@@ -27,91 +27,97 @@
                 }
                 @if ((options | async)?.selectedStatusFilter === ViewFileStatus.EXTRACTED) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/extracted.svg" class="extracted" /></div>
+                        <div class="icon"><img src="assets/icons/extracted.svg" class="extracted" alt="" aria-hidden="true" /></div>
                         <span class="text">Extracted</span>
                     </div>
                 }
                 @if ((options | async)?.selectedStatusFilter === ViewFileStatus.EXTRACTING) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/extracting.svg" class="extracting" /></div>
+                        <div class="icon"><img src="assets/icons/extracting.svg" class="extracting" alt="" aria-hidden="true" /></div>
                         <span class="text">Extracting</span>
                     </div>
                 }
                 @if ((options | async)?.selectedStatusFilter === ViewFileStatus.DOWNLOADED) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/downloaded.svg" class="downloaded" /></div>
+                        <div class="icon"><img src="assets/icons/downloaded.svg" class="downloaded" alt="" aria-hidden="true" /></div>
                         <span class="text">Downloaded</span>
                     </div>
                 }
                 @if ((options | async)?.selectedStatusFilter === ViewFileStatus.DOWNLOADING) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/downloading.svg" class="downloading" /></div>
+                        <div class="icon"><img src="assets/icons/downloading.svg" class="downloading" alt="" aria-hidden="true" /></div>
                         <span class="text">Downloading</span>
                     </div>
                 }
                 @if ((options | async)?.selectedStatusFilter === ViewFileStatus.QUEUED) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/queued.svg" class="queued" /></div>
+                        <div class="icon"><img src="assets/icons/queued.svg" class="queued" alt="" aria-hidden="true" /></div>
                         <span class="text">Queued</span>
                     </div>
                 }
                 @if ((options | async)?.selectedStatusFilter === ViewFileStatus.STOPPED) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/stopped.svg" class="stopped" /></div>
+                        <div class="icon"><img src="assets/icons/stopped.svg" class="stopped" alt="" aria-hidden="true" /></div>
                         <span class="text">Stopped</span>
                     </div>
                 }
             </div>
         </button>
         <div class="dropdown-menu">
-            <div class="dropdown-item"
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.selectedStatusFilter == null"
                  (click)="onFilterByStatus(null)">
                 <div class="icon"></div>
                 <span class="text">All</span>
-            </div>
-            <div class="dropdown-item"
+            </button>
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.selectedStatusFilter === ViewFileStatus.EXTRACTED"
                  [class.disabled]="!isExtractedStatusEnabled"
+                 [disabled]="!isExtractedStatusEnabled"
                  (click)="onFilterByStatus(ViewFileStatus.EXTRACTED)">
-                <div class="icon"><img src="assets/icons/extracted.svg" class="extracted" /></div>
+                <div class="icon"><img src="assets/icons/extracted.svg" class="extracted" alt="" aria-hidden="true" /></div>
                 <span class="text">Extracted</span>
-            </div>
-            <div class="dropdown-item"
+            </button>
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.selectedStatusFilter === ViewFileStatus.EXTRACTING"
                  [class.disabled]="!isExtractingStatusEnabled"
+                 [disabled]="!isExtractingStatusEnabled"
                  (click)="onFilterByStatus(ViewFileStatus.EXTRACTING)">
-                <div class="icon"><img src="assets/icons/extracting.svg" class="extracting" /></div>
+                <div class="icon"><img src="assets/icons/extracting.svg" class="extracting" alt="" aria-hidden="true" /></div>
                 <span class="text">Extracting</span>
-            </div>
-            <div class="dropdown-item"
+            </button>
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.selectedStatusFilter === ViewFileStatus.DOWNLOADED"
                  [class.disabled]="!isDownloadedStatusEnabled"
+                 [disabled]="!isDownloadedStatusEnabled"
                  (click)="onFilterByStatus(ViewFileStatus.DOWNLOADED)">
-                <div class="icon"><img src="assets/icons/downloaded.svg" class="downloaded" /></div>
+                <div class="icon"><img src="assets/icons/downloaded.svg" class="downloaded" alt="" aria-hidden="true" /></div>
                 <span class="text">Downloaded</span>
-            </div>
-            <div class="dropdown-item"
+            </button>
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.selectedStatusFilter === ViewFileStatus.DOWNLOADING"
                  [class.disabled]="!isDownloadingStatusEnabled"
+                 [disabled]="!isDownloadingStatusEnabled"
                  (click)="onFilterByStatus(ViewFileStatus.DOWNLOADING)">
-                <div class="icon"><img src="assets/icons/downloading.svg" class="downloading" /></div>
+                <div class="icon"><img src="assets/icons/downloading.svg" class="downloading" alt="" aria-hidden="true" /></div>
                 <span class="text">Downloading</span>
-            </div>
-            <div class="dropdown-item"
+            </button>
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.selectedStatusFilter === ViewFileStatus.QUEUED"
                  [class.disabled]="!isQueuedStatusEnabled"
+                 [disabled]="!isQueuedStatusEnabled"
                  (click)="onFilterByStatus(ViewFileStatus.QUEUED)">
-                <div class="icon"><img src="assets/icons/queued.svg" class="queued" /></div>
+                <div class="icon"><img src="assets/icons/queued.svg" class="queued" alt="" aria-hidden="true" /></div>
                 <span class="text">Queued</span>
-            </div>
-            <div class="dropdown-item"
+            </button>
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.selectedStatusFilter === ViewFileStatus.STOPPED"
                  [class.disabled]="!isStoppedStatusEnabled"
+                 [disabled]="!isStoppedStatusEnabled"
                  (click)="onFilterByStatus(ViewFileStatus.STOPPED)">
-                <div class="icon"><img src="assets/icons/stopped.svg" class="stopped" /></div>
+                <div class="icon"><img src="assets/icons/stopped.svg" class="stopped" alt="" aria-hidden="true" /></div>
                 <span class="text">Stopped</span>
-            </div>
+            </button>
         </div>
     </div>
 
@@ -126,7 +132,7 @@
                 <!-- these divs only show the selected option -->
                 @if ((options | async)?.sortMethod === SortMethod.STATUS) {
                     <div class="sel-item">
-                        <div class="icon"><img src="assets/icons/states.svg" class="states" /></div>
+                        <div class="icon"><img src="assets/icons/states.svg" class="states" alt="" aria-hidden="true" /></div>
                         <span class="text">Status</span>
                     </div>
                 }
@@ -157,36 +163,36 @@
             </div>
         </button>
         <div class="dropdown-menu">
-            <div class="dropdown-item"
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.sortMethod === SortMethod.STATUS"
                  (click)="onSort(SortMethod.STATUS)">
-                <div class="icon"><img src="assets/icons/states.svg" class="states" /></div>
+                <div class="icon"><img src="assets/icons/states.svg" class="states" alt="" aria-hidden="true" /></div>
                 <span class="text">Status</span>
-            </div>
-            <div class="dropdown-item"
+            </button>
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.sortMethod === SortMethod.NAME_ASC"
                  (click)="onSort(SortMethod.NAME_ASC)">
-                <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" alt="Sort ascending" /></div>
+                <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" alt="" aria-hidden="true" /></div>
                 <span class="text">Name A&#8594;Z</span>
-            </div>
-            <div class="dropdown-item"
+            </button>
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.sortMethod === SortMethod.NAME_DESC"
                  (click)="onSort(SortMethod.NAME_DESC)">
-                <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" alt="Sort descending" /></div>
+                <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" alt="" aria-hidden="true" /></div>
                 <span class="text">Name Z&#8594;A</span>
-            </div>
-            <div class="dropdown-item"
+            </button>
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.sortMethod === SortMethod.SIZE_ASC"
                  (click)="onSort(SortMethod.SIZE_ASC)">
-                <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" alt="Sort ascending" /></div>
+                <div class="icon"><img src="assets/icons/sort-asc.svg" class="sort-asc" alt="" aria-hidden="true" /></div>
                 <span class="text">Size S&#8594;L</span>
-            </div>
-            <div class="dropdown-item"
+            </button>
+            <button type="button" class="dropdown-item"
                  [class.active]="(options | async)?.sortMethod === SortMethod.SIZE_DESC"
                  (click)="onSort(SortMethod.SIZE_DESC)">
-                <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" alt="Sort descending" /></div>
+                <div class="icon"><img src="assets/icons/sort-desc.svg" class="sort-desc" alt="" aria-hidden="true" /></div>
                 <span class="text">Size L&#8594;S</span>
-            </div>
+            </button>
         </div>
     </div>
 

--- a/src/angular/src/app/pages/files/file-options.component.scss
+++ b/src/angular/src/app/pages/files/file-options.component.scss
@@ -45,6 +45,14 @@
         user-select: none;
 
         .dropdown-item {
+            /* Reset native <button> appearance */
+            appearance: none;
+            background: none;
+            border: 0;
+            font: inherit;
+            text-align: inherit;
+            width: 100%;
+
             color: white;
             height: 32px;
 
@@ -63,7 +71,8 @@
                 background-color: var(--ss-primary);
             }
 
-            &.disabled {
+            &.disabled,
+            &[disabled] {
                 opacity: .65;
                 background-color: var(--ss-primary);
             }

--- a/src/angular/src/app/pages/files/file.component.html
+++ b/src/angular/src/app/pages/files/file.component.html
@@ -1,7 +1,14 @@
 <div class="file" [class.selected]="file().isSelected" #fileElement>
     <div class="content">
-        <div class="checkbox" (click)="onCheck($event, file())">
-            <input type="checkbox" [checked]="file().isChecked" />
+        <div class="checkbox"
+             role="checkbox"
+             tabindex="0"
+             [attr.aria-checked]="file().isChecked"
+             [attr.aria-label]="'Toggle selection for ' + file().name"
+             (click)="onCheck($event, file())"
+             (keyup.enter)="onCheck($event, file())"
+             (keyup.space)="onCheck($event, file()); $event.preventDefault()">
+            <input type="checkbox" tabindex="-1" [checked]="file().isChecked" />
         </div>
         <div class="status">
             @if (file().status === ViewFileStatus.DEFAULT && file().remoteSize > 0) {

--- a/src/angular/src/app/pages/files/file.component.ts
+++ b/src/angular/src/app/pages/files/file.component.ts
@@ -98,9 +98,10 @@ export class FileComponent implements OnChanges, OnDestroy {
     this.clearConfirmTimer();
   }
 
-  onCheck(event: MouseEvent, file: ViewFile): void {
+  onCheck(event: Event, file: ViewFile): void {
     event.stopPropagation();
-    this.checkEvent.emit({file, shiftKey: event.shiftKey});
+    const shiftKey = (event as MouseEvent | KeyboardEvent).shiftKey ?? false;
+    this.checkEvent.emit({file, shiftKey});
   }
 
   isQueueable(): boolean {

--- a/src/angular/src/app/pages/main/sidebar.component.html
+++ b/src/angular/src/app/pages/main/sidebar.component.html
@@ -3,22 +3,22 @@
     <a class="button"
        [routerLink]="routeInfo.path"
        routerLinkActive="selected">
-      <img [src]="routeInfo.icon" />
+      <img [src]="routeInfo.icon" alt="" aria-hidden="true" />
       <span class="text">{{ routeInfo.name }}</span>
     </a>
   }
 
   <hr>
 
-  <a class="button"
-     [attr.disabled]="commandsEnabled ? null : true"
+  <button type="button" class="button"
+     [disabled]="!commandsEnabled"
      (click)="!commandsEnabled || onCommandRestart()">
-    <img src="assets/icons/refresh.svg" />
+    <img src="assets/icons/refresh.svg" alt="" aria-hidden="true" />
     <span class="text">Restart</span>
-  </a>
+  </button>
 
-  <a class="button" (click)="onToggleTheme()">
+  <button type="button" class="button" (click)="onToggleTheme()">
     <i class="fa-icon" [class.fa-solid]="true" [class.fa-moon]="theme === 'light'" [class.fa-sun]="theme === 'dark'"></i>
     <span class="text">{{ theme === 'light' ? 'Dark Mode' : 'Light Mode' }}</span>
-  </a>
+  </button>
 </div>

--- a/src/angular/src/app/pages/main/sidebar.component.scss
+++ b/src/angular/src/app/pages/main/sidebar.component.scss
@@ -2,6 +2,10 @@
 
 #sidebar {
   .button {
+    /* Reset native <button> appearance (applies to both <a> and <button>) */
+    appearance: none;
+    font: inherit;
+
     background-color: inherit;
     color: inherit;
     text-decoration: none;

--- a/src/angular/src/app/pages/settings/settings-page.component.html
+++ b/src/angular/src/app/pages/settings/settings-page.component.html
@@ -35,7 +35,13 @@
       </ng-container>
 
       <div class="card">
-        <h3 class="card-header collapsible-header" (click)="toggleAdvancedLftp()">
+        <h3 class="card-header collapsible-header"
+            role="button"
+            tabindex="0"
+            [attr.aria-expanded]="!advancedLftpCollapsed"
+            (click)="toggleAdvancedLftp()"
+            (keyup.enter)="toggleAdvancedLftp()"
+            (keyup.space)="toggleAdvancedLftp(); $event.preventDefault()">
           {{ OPTIONS_CONTEXT_ADVANCED_LFTP.header }}
           <span class="collapse-indicator">{{ advancedLftpCollapsed ? '&#9654;' : '&#9660;' }}</span>
         </h3>
@@ -129,14 +135,15 @@
   </div>
 
   <div id="commands">
-    <div
+    <button
+      type="button"
       class="button"
       appClickStopPropagation
-      [attr.disabled]="commandsEnabled ? null : true"
+      [disabled]="!commandsEnabled"
       (click)="!commandsEnabled || onCommandRestart()">
-      <img src="assets/icons/refresh.svg" />
+      <img src="assets/icons/refresh.svg" alt="" aria-hidden="true" />
       <span class="text">Restart</span>
-    </div>
+    </button>
   </div>
 </div>
 

--- a/src/angular/src/app/pages/settings/settings-page.component.scss
+++ b/src/angular/src/app/pages/settings/settings-page.component.scss
@@ -66,7 +66,6 @@
             /* Reset native <button> appearance */
             appearance: none;
             font: inherit;
-            outline: inherit;
 
             flex-direction: row;
             padding: 10px;

--- a/src/angular/src/app/pages/settings/settings-page.component.scss
+++ b/src/angular/src/app/pages/settings/settings-page.component.scss
@@ -63,6 +63,11 @@
         .button {
             @extend %button;
 
+            /* Reset native <button> appearance */
+            appearance: none;
+            font: inherit;
+            outline: inherit;
+
             flex-direction: row;
             padding: 10px;
             margin-inline-end: 8px;

--- a/src/e2e-playwright/tests/pages/sidebar.page.ts
+++ b/src/e2e-playwright/tests/pages/sidebar.page.ts
@@ -17,11 +17,10 @@ export class SidebarPage {
     this.autoqueueLink = page.locator('a[href="/autoqueue"]');
     this.logsLink = page.locator('a[href="/logs"]');
     this.aboutLink = page.locator('a[href="/about"]');
-    // Restart and theme toggle are <a class="button"> not <button>
-    this.restartButton = page.locator("#sidebar a.button", {
+    this.restartButton = page.locator("#sidebar button.button", {
       hasText: "Restart",
     });
-    this.themeToggle = page.locator("#sidebar a.button", {
+    this.themeToggle = page.locator("#sidebar button.button", {
       hasText: /Dark Mode|Light Mode/,
     });
   }


### PR DESCRIPTION
Closes #380
Closes #381

## Summary
Resolves 55 template accessibility violations across 3 rules and graduates all 3 from `warn` to `error`:

| Rule | Fixed |
|---|---:|
| `@angular-eslint/template/alt-text` | 19 |
| `@angular-eslint/template/click-events-have-key-events` | 20 |
| `@angular-eslint/template/interactive-supports-focus` | 16 |

## Changes

### `<div>` / `<a>` → `<button>` refactors (16)
Whenever a click-target was a `<div>` or `<a>`, it became a `<button type="button">`. Native buttons get focus, Enter/Space activation, and ARIA announce for free.

- `autoqueue-page.component.html` — pattern +/- (2)
- `file-options.component.html` — status filter dropdown (7: All + 6 statuses), sort dropdown (5)
- `sidebar.component.html` — Restart + theme toggle (2)
- `settings-page.component.html` — Restart command (1)

### `tabindex + role + keyup` fallbacks (3)
Used only when `<button>` replacement would break layout or semantics:

- `app.html` — `#outside-sidebar` full-screen overlay (layout)
- `settings-page` — advanced-LFTP collapsible `<h3>` heading (headings can't tag-swap; used `role="button"` + `aria-expanded`)
- `file.component.html` — `.checkbox` wrapper proxy over the native input with `pointer-events: none` (complex; used `role="checkbox"` + `aria-checked`)

### `<img>` alt-text (19)
All decorative — adjacent text labels carry the meaning. Uniformly `alt="" aria-hidden="true"`.

### SCSS resets
Added `appearance: none; background: none; border: 0; font: inherit;` and friends to the new button targets in:
- `autoqueue-page.component.scss` (`.pattern .button`)
- `file-options.component.scss` (`.dropdown-item`, plus `&[disabled]` alongside `&.disabled`)
- `sidebar.component.scss` (`.button`)
- `settings-page.component.scss` (`#commands .button`)

### Code / test
- `file.component.ts`: widened `onCheck(event: Event, file)` from `MouseEvent` so it works for both click and keyup; reads `shiftKey` via safe cast.
- `src/e2e-playwright/tests/pages/sidebar.page.ts`: selector updated from `#sidebar a.button` to `#sidebar button.button`.
- No Angular unit tests needed changes.

## Coordination note
Sibling PRs run in parallel. This PR has exclusive ownership of `.html` templates — no overlap risk. `eslint.config.js` touches are limited to these 3 rules. `--max-warnings 138` left for final coordinated ratchet.

## Test plan
- [x] `cd src/angular && npx ng lint` → 83 warnings, zero for the three a11y rules
- [x] `cd src/angular && npx ng test --watch=false` → 319/319 pass
- [x] `cd src/angular && npx ng build` → clean
- [ ] **Reviewer**: manual keyboard walk — Tab through the file list and dropdowns, confirm focus rings visible, Enter/Space activates each button. `ng serve` confirmed the app boots but browser-driven smoke test wasn't run in the agent worktree.