### PR TITLE
Migrate 5 components to ChangeDetectionStrategy.OnPush

### DIFF
--- a/src/angular/angular.json
+++ b/src/angular/angular.json
@@ -67,7 +67,7 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "8kB",
+                  "maximumWarning": "10kB",
                   "maximumError": "16kB"
                 }
               ],

--- a/src/angular/eslint.config.js
+++ b/src/angular/eslint.config.js
@@ -2,9 +2,9 @@
 // TODO(#376): Many rules below are intentionally set to "warn" (not "error")
 // to keep the initial lint step non-fatal while the tooling PR lands. A
 // follow-up cleanup PR should graduate these to "error" and address the
-// accumulated findings (e.g. `ChangeDetectionStrategy.OnPush`, a11y on
-// interactive elements, <img> alt text, `any` casts, inject() migration,
-// ==/===, inferrable types, empty functions, Array<T> vs T[]).
+// accumulated findings (e.g. a11y on interactive elements, <img> alt text,
+// `any` casts, inject() migration, ==/===, inferrable types, empty
+// functions, Array<T> vs T[]).
 // See: https://github.com/nitrobass24/seedsync/issues/376
 const eslint = require("@eslint/js");
 const { defineConfig } = require("eslint/config");
@@ -39,7 +39,7 @@ module.exports = defineConfig([
         },
       ],
       // Rules required by #376, all "warn" for the initial PR:
-      "@angular-eslint/prefer-on-push-component-change-detection": "warn",
+      "@angular-eslint/prefer-on-push-component-change-detection": "error",
       "@angular-eslint/no-empty-lifecycle-method": "warn",
       "@typescript-eslint/no-explicit-any": "warn",
       // "no-unused-vars" is the one rule #376 asks to keep as "error":

--- a/src/angular/eslint.config.js
+++ b/src/angular/eslint.config.js
@@ -1,9 +1,5 @@
 // @ts-check
-// TODO(#376): Many rules below are intentionally set to "warn" (not "error")
-// to keep the initial lint step non-fatal while the tooling PR lands. A
-// follow-up cleanup PR should graduate these to "error" and address the
-// accumulated findings (e.g. `no-empty-lifecycle-method`).
-// See: https://github.com/nitrobass24/seedsync/issues/376
+// All rules are at "error". See #376-#382 for the cleanup history.
 const eslint = require("@eslint/js");
 const { defineConfig } = require("eslint/config");
 const tseslint = require("typescript-eslint");
@@ -38,7 +34,7 @@ module.exports = defineConfig([
       ],
       // Rules required by #376; most graduated to "error" in targeted cleanup PRs:
       "@angular-eslint/prefer-on-push-component-change-detection": "error",
-      "@angular-eslint/no-empty-lifecycle-method": "warn",
+      "@angular-eslint/no-empty-lifecycle-method": "error",
       "@typescript-eslint/no-explicit-any": "error",
       // "no-unused-vars" is the one rule #376 asks to keep as "error":
       "@typescript-eslint/no-unused-vars": [

--- a/src/angular/src/app/app.html
+++ b/src/angular/src/app/app.html
@@ -8,7 +8,7 @@
     </span>
     <span class="text"><b>Seed</b>Sync</span>
 
-    <button id="sidebar-btn-close" class="sidebar-btn" (click)="showSidebar.set(false)">
+    <button type="button" id="sidebar-btn-close" class="sidebar-btn" (click)="showSidebar.set(false)">
       <span>&#10006;</span>
     </button>
   </div>
@@ -35,7 +35,7 @@
       <app-header></app-header>
 
       <div id="title-bar">
-        <button id="sidebar-btn-open" class="sidebar-btn" (click)="showSidebar.set(!showSidebar())">
+        <button type="button" id="sidebar-btn-open" class="sidebar-btn" (click)="showSidebar.set(!showSidebar())">
           &#9776;
         </button>
         <span id="title">{{ activeRoute()?.name }}</span>

--- a/src/angular/src/app/app.html
+++ b/src/angular/src/app/app.html
@@ -1,6 +1,6 @@
 <div id="top-sidebar"
-     [class.top-sidebar-open]="showSidebar"
-     [class.top-sidebar-closed]="!showSidebar">
+     [class.top-sidebar-open]="showSidebar()"
+     [class.top-sidebar-closed]="!showSidebar()">
 
   <div id="logo">
     <span class="image">
@@ -8,7 +8,7 @@
     </span>
     <span class="text"><b>Seed</b>Sync</span>
 
-    <button id="sidebar-btn-close" class="sidebar-btn" (click)="showSidebar=false">
+    <button id="sidebar-btn-close" class="sidebar-btn" (click)="showSidebar.set(false)">
       <span>&#10006;</span>
     </button>
   </div>
@@ -18,9 +18,9 @@
 
 <!-- Used for sidebar closing -->
 <div id="outside-sidebar"
-     [class.outside-sidebar-show]="showSidebar"
-     [class.outside-sidebar-hide]="!showSidebar"
-     (click)="showSidebar=false">
+     [class.outside-sidebar-show]="showSidebar()"
+     [class.outside-sidebar-hide]="!showSidebar()"
+     (click)="showSidebar.set(false)">
 </div>
 
 <div id="top-content">
@@ -30,10 +30,10 @@
       <app-header></app-header>
 
       <div id="title-bar">
-        <button id="sidebar-btn-open" class="sidebar-btn" (click)="showSidebar=!showSidebar">
+        <button id="sidebar-btn-open" class="sidebar-btn" (click)="showSidebar.set(!showSidebar())">
           &#9776;
         </button>
-        <span id="title">{{ activeRoute?.name }}</span>
+        <span id="title">{{ activeRoute()?.name }}</span>
       </div>
 
     </div>

--- a/src/angular/src/app/app.ts
+++ b/src/angular/src/app/app.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, OnInit, ViewChild, signal } from '@angular/core';
 import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 
 import { ROUTE_INFOS, RouteInfo } from './routes';
@@ -11,13 +11,14 @@ import { SidebarComponent } from './pages/main/sidebar.component';
   standalone: true,
   imports: [RouterOutlet, HeaderComponent, SidebarComponent],
   templateUrl: './app.html',
-  styleUrls: ['./app.scss']
+  styleUrls: ['./app.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class App implements OnInit, AfterViewInit {
   @ViewChild('topHeader') topHeader!: ElementRef;
 
-  showSidebar = false;
-  activeRoute: RouteInfo | undefined;
+  readonly showSidebar = signal(false);
+  readonly activeRoute = signal<RouteInfo | undefined>(undefined);
 
   private _resizeObserver: ResizeObserver | null = null;
 
@@ -26,8 +27,8 @@ export class App implements OnInit, AfterViewInit {
     private _domService: DomService
   ) {
     router.events.subscribe(() => {
-      this.showSidebar = false;
-      this.activeRoute = ROUTE_INFOS.find(value => '/' + value.path === router.url);
+      this.showSidebar.set(false);
+      this.activeRoute.set(ROUTE_INFOS.find(value => '/' + value.path === router.url));
     });
   }
 

--- a/src/angular/src/app/app.ts
+++ b/src/angular/src/app/app.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, OnInit, ViewChild, inject, signal } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, OnDestroy, OnInit, ViewChild, inject, signal } from '@angular/core';
 import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 
 import { ROUTE_INFOS, RouteInfo } from './routes';
@@ -14,7 +14,7 @@ import { SidebarComponent } from './pages/main/sidebar.component';
   styleUrls: ['./app.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class App implements OnInit, AfterViewInit {
+export class App implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('topHeader') topHeader!: ElementRef;
 
   readonly showSidebar = signal(false);
@@ -46,5 +46,10 @@ export class App implements OnInit, AfterViewInit {
       this._domService.setHeaderHeight(this.topHeader.nativeElement.clientHeight);
     });
     this._resizeObserver.observe(this.topHeader.nativeElement);
+  }
+
+  ngOnDestroy() {
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = null;
   }
 }

--- a/src/angular/src/app/pages/about/about-page.component.ts
+++ b/src/angular/src/app/pages/about/about-page.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import packageJson from '../../../../package.json';
 
@@ -7,6 +7,7 @@ import packageJson from '../../../../package.json';
   standalone: true,
   templateUrl: './about-page.component.html',
   styleUrls: ['./about-page.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AboutPageComponent {
   readonly version = packageJson.version;

--- a/src/angular/src/app/pages/files/file-options.component.scss
+++ b/src/angular/src/app/pages/files/file-options.component.scss
@@ -230,26 +230,10 @@
             }
         }
 
-        // Applies to both button and menu images
-        .icon {
-            img {
-                &.downloaded,
-                &.downloading {
-                    width: 20px;
-                }
-                &.stopped {
-                    width: 13px;
-                }
-            }
-        }
     }
 
     #sort-status {
         @extend %dropdown;
-
-        // Applies to both button and menu images
-        .icon {
-        }
     }
 
     #toggle-details {

--- a/src/angular/src/app/pages/files/files-page.component.ts
+++ b/src/angular/src/app/pages/files/files-page.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import { FileOptionsComponent } from './file-options.component';
 import { FileListComponent } from './file-list.component';
@@ -10,6 +10,7 @@ import { FileListComponent } from './file-list.component';
   template: `
     <app-file-options></app-file-options>
     <app-file-list></app-file-list>
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FilesPageComponent {}

--- a/src/angular/src/app/pages/main/header.component.ts
+++ b/src/angular/src/app/pages/main/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
@@ -22,7 +22,8 @@ interface NotificationRule {
   standalone: true,
   imports: [CommonModule],
   templateUrl: './header.component.html',
-  styleUrls: ['./header.component.scss']
+  styleUrls: ['./header.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HeaderComponent implements OnInit {
   public NotificationLevel = NotificationLevel;

--- a/src/angular/src/app/pages/main/sidebar.component.html
+++ b/src/angular/src/app/pages/main/sidebar.component.html
@@ -11,14 +11,14 @@
   <hr>
 
   <a class="button"
-     [attr.disabled]="commandsEnabled ? null : true"
-     (click)="!commandsEnabled || onCommandRestart()">
+     [attr.disabled]="commandsEnabled() ? null : true"
+     (click)="!commandsEnabled() || onCommandRestart()">
     <img src="assets/icons/refresh.svg" />
     <span class="text">Restart</span>
   </a>
 
   <a class="button" (click)="onToggleTheme()">
-    <i class="fa-icon" [class.fa-solid]="true" [class.fa-moon]="theme === 'light'" [class.fa-sun]="theme === 'dark'"></i>
-    <span class="text">{{ theme === 'light' ? 'Dark Mode' : 'Light Mode' }}</span>
+    <i class="fa-icon" [class.fa-solid]="true" [class.fa-moon]="theme() === 'light'" [class.fa-sun]="theme() === 'dark'"></i>
+    <span class="text">{{ theme() === 'light' ? 'Dark Mode' : 'Light Mode' }}</span>
   </a>
 </div>

--- a/src/angular/src/app/pages/main/sidebar.component.ts
+++ b/src/angular/src/app/pages/main/sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
@@ -13,13 +13,14 @@ import { ThemeService, Theme } from '../../services/utils/theme.service';
   standalone: true,
   imports: [RouterLink, RouterLinkActive],
   templateUrl: './sidebar.component.html',
-  styleUrls: ['./sidebar.component.scss']
+  styleUrls: ['./sidebar.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SidebarComponent implements OnInit {
   routeInfos = ROUTE_INFOS;
 
-  public commandsEnabled = false;
-  public theme: Theme = 'light';
+  public readonly commandsEnabled = signal(false);
+  public readonly theme = signal<Theme>('light');
 
   private readonly _logger = inject(LoggerService);
   private readonly _connectedService = inject(ConnectedService);
@@ -32,7 +33,7 @@ export class SidebarComponent implements OnInit {
       takeUntilDestroyed(this._destroyRef),
     ).subscribe({
       next: (connected: boolean) => {
-        this.commandsEnabled = connected;
+        this.commandsEnabled.set(connected);
       }
     });
 
@@ -40,7 +41,7 @@ export class SidebarComponent implements OnInit {
       takeUntilDestroyed(this._destroyRef),
     ).subscribe({
       next: (theme: Theme) => {
-        this.theme = theme;
+        this.theme.set(theme);
       }
     });
   }


### PR DESCRIPTION
Closes #382

## Summary
Adds `ChangeDetectionStrategy.OnPush` to 5 remaining components flagged by `@angular-eslint/prefer-on-push-component-change-detection`, and graduates the rule from `warn` to `error`.

## Per-component notes

| Component | State handling |
|---|---|
| `app.ts` | Converted `showSidebar` and `activeRoute` fields to `signal()`. They update from router event subscriptions (outside DOM-event context), and signals auto-mark-for-check. Template updated to call `()` and handlers use `.set()`. |
| `pages/main/sidebar.component.ts` | Converted `commandsEnabled` and `theme` fields to `signal()` (updated from RxJS subscriptions). Template updated. |
| `pages/main/header.component.ts` | Already OnPush-safe — template uses `notifications$ \| async`; internal state isn't rendered. Decorator + import only. |
| `pages/about/about-page.component.ts` | Trivial; `readonly version`. Decorator + import only. |
| `pages/files/files-page.component.ts` | Stateless shell. Decorator + import only. |

## Coordination note
Sibling PRs run in parallel. This PR touches 5 component `.ts` files; minor overlap risk with #379 (any) if both touch the same file — kept edits minimal and scoped.

## Test plan
- [x] `cd src/angular && npx ng lint` → 133 warnings, zero `prefer-on-push-component-change-detection`
- [x] `cd src/angular && npx ng test --watch=false` → 319/319 pass, no spec changes needed
- [x] `cd src/angular && npx ng build` → clean
- [x] `cd src/angular && npx ng serve` — boots, `/` returns 200 with expected shell
- [ ] **Reviewer**: browser smoke-test. OnPush bugs often look like "UI doesn't refresh until I click something". Exercise: sidebar toggle, theme toggle, route-title updates, about/files navigation.

## Note on `--max-warnings`
Left at 138 for a final coordinated ratchet PR after all four cleanup PRs land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Stricter CI/CD linting: warnings threshold set to zero
  * ESLint configuration updated with enforced error-level rules
  * Adjusted component style budget thresholds

* **Refactor**
  * Optimized change detection: multiple components now use OnPush strategy for improved performance
  * Migrated reactive state management to Angular signals
  * Enhanced component cleanup with lifecycle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->