### PR TITLE
Add Code Health section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,43 @@ Every PR MUST include appropriate test changes. Tests are not optional — they 
 - **Naming**: Test files mirror source files — `foo.service.ts` → `foo.service.spec.ts`, `controller.py` → `test_controller.py`.
 - **No flaky tests**: Avoid `time.sleep` in tests where possible. Use `threading.Event` or barriers for synchronization. Use `timeout_decorator` for tests that might hang.
 
+## Code Health
+
+These are guidelines, not hard caps. Their real job is to slow you down and ask "is this still one concern?" Cross them when the code is clearer for it — flag in the PR body when you do.
+
+### Soft size targets
+
+| Unit | Target | When to pause |
+|------|--------|---------------|
+| File | ≤ 500 lines | At 400, ask "one concern or several?" |
+| Class | ≤ 300 lines | If state covers > 2 concerns, extract |
+| Function / method | ≤ 40 lines | Longer is OK when linear; deep nesting is not |
+| Cyclomatic complexity (per function) | ≤ 12 | Hard limit once `C901` is enabled in CI |
+
+Cyclomatic complexity is the one number that actually predicts pain — a 200-line linear function is fine; a 40-line function with 5 nested conditionals is dangerous. Use `ruff check --select C901` locally to measure.
+
+### The "before adding" rule
+
+Before adding a method to an existing class, ask:
+1. Does this belong in a sibling module/class instead?
+2. Does the class already span multiple concerns (auth + persistence + validation, etc.)? If so, extracting first is usually worth the overhead.
+3. Prefer composition over accretion — reach for a new collaborator, not a bigger class.
+
+### Signals that you should split
+
+- A focused unit test needs `cls.__new__(cls)` or broad mocking just to exercise one method.
+- The constructor initializes unrelated state (e.g., both a model and a command queue and a logger facade).
+- One method dominates the file's line count.
+- Changes in separate features keep conflicting in the same file.
+
+When you see these, open an issue for the extraction rather than working around them silently.
+
+### Enforcement
+
+- **Qualitative checks**: code review. Reviewers should push back on "this file is getting unwieldy" even without a hard rule.
+- **Mechanical checks** (Python): ruff's `C901` (cyclomatic complexity) with `max-complexity = 12`. Tracked for rollout in a follow-up issue — not yet enabled globally.
+- **Ratchet pattern**: when a bound exists but the codebase has outliers, set the threshold just above the worst and drop it over time (same pattern we use for `--max-warnings` in `ng lint`).
+
 ## GitHub Repository
 
 - **Repo**: github.com/nitrobass24/seedsync


### PR DESCRIPTION
## Summary
Adds a new **Code Health** section to `CLAUDE.md` so future work doesn't accrete into god-classes without a pushback rule.

## What's in it
- Soft size targets (file ≤ 500, class ≤ 300, method ≤ 40, complexity ≤ 12) as guidelines, not hard caps.
- The "before adding a method" rule — prefer a new collaborator over growing an existing class.
- Qualitative signals that a split is overdue (tests needing `cls.__new__`, constructors initializing unrelated state, one file dominating merge conflicts).
- Enforcement pattern: qualitative checks via review now; mechanical enforcement via `ruff C901` in a follow-up once existing outliers are fixed.

## Why now
`src/python/controller/controller.py` has grown to 1433 lines / 28 methods / 6 concerns — the canonical god-class smell. A refactor issue is being opened alongside this. The CLAUDE.md rules are the preventive half; the refactor is the curative half.

## Test plan
Docs-only change — no code affected, no tests needed.