### PR TITLE
Fix file list height on iOS/Android by measuring chrome dynamically

### DIFF
--- a/src/angular/src/app/pages/files/file-list.component.scss
+++ b/src/angular/src/app/pages/files/file-list.component.scss
@@ -4,23 +4,18 @@
     display: none;
 }
 
-/* Virtual scroll viewport — chrome height accounts for sticky elements above the scroll area.
-   Desktop (≥993px): navbar (56px) + column header (40px) + file-options bar (48px) + padding (16px) = 160px
-   Mobile  (<993px): navbar (56px) + title bar (~52px) + file-options bar (~76px) + padding (16px) = 200px
-   Uses dvh (dynamic viewport height) so the container adapts when Android browser chrome hides/shows. */
-$file-list-chrome-height: 160px;
-$file-list-chrome-height-mobile: 200px;
+/* Virtual scroll viewport height = visible viewport − everything stacked above.
+   The chrome height is measured at runtime and exposed via
+   --file-list-chrome-height (see FileListComponent). Measurement handles
+   notification banners, the file-options bar wrapping differently per width,
+   and browser chrome differences between iOS Safari/Chrome and Android.
+   The 160px fallback matches the desktop layout if the variable is unset
+   (e.g. before the ResizeObserver runs or if it is unavailable).
+   dvh adapts to the visible viewport; vh is the fallback for older browsers. */
 .file-viewport {
-    height: calc(100vh - $file-list-chrome-height);
-    height: calc(100dvh - $file-list-chrome-height);
+    height: calc(100vh - var(--file-list-chrome-height, 160px));
+    height: calc(100dvh - var(--file-list-chrome-height, 160px));
     min-height: 200px;
-}
-
-@media only screen and (max-width: $medium-max-width) {
-    .file-viewport {
-        height: calc(100vh - $file-list-chrome-height-mobile);
-        height: calc(100dvh - $file-list-chrome-height-mobile);
-    }
 }
 
 /* striped rows — use template-driven .even class instead of :nth-child
@@ -34,7 +29,7 @@ $file-list-chrome-height-mobile: 200px;
 .file-row + .file-row {box-shadow: inset 0 1px 0 var(--ss-border);}
 
 
-/* Large screens — column header aligns with desktop viewport height math (≥993px) */
+/* Large screens — show the column header row (replaces the mobile title bar) */
 @media only screen and (min-width: $large-min-width) {
     #file-list #header {
         display: flex;

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -447,9 +447,11 @@ describe('FileListComponent', () => {
       document.documentElement.style.removeProperty('--file-list-chrome-height');
       topHeader.remove();
       fileOptions.remove();
-      if (originalResizeObserver) {
-        (globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
-          originalResizeObserver;
+      const g = globalThis as unknown as { ResizeObserver?: typeof ResizeObserver };
+      if (originalResizeObserver !== undefined) {
+        g.ResizeObserver = originalResizeObserver;
+      } else {
+        delete g.ResizeObserver;
       }
       window.requestAnimationFrame = originalRaf;
     });

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -405,6 +405,7 @@ describe('FileListComponent', () => {
     let observerState: FakeObserverState;
     let originalResizeObserver: typeof ResizeObserver | undefined;
     let originalRaf: typeof window.requestAnimationFrame;
+    let originalScrollYDescriptor: PropertyDescriptor | undefined;
     let rafCallbacks: FrameRequestCallback[];
     let topHeader: HTMLElement;
     let fileOptions: HTMLElement;
@@ -441,6 +442,12 @@ describe('FileListComponent', () => {
         rafCallbacks.push(cb);
         return rafCallbacks.length;
       }) as typeof window.requestAnimationFrame;
+
+      // Pin scrollY so chrome-height assertions are deterministic regardless
+      // of prior-test scroll state. Capture the original descriptor so we can
+      // restore JSDOM's live getter after the test.
+      originalScrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY');
+      Object.defineProperty(window, 'scrollY', { value: 0, configurable: true });
     });
 
     afterEach(() => {
@@ -454,6 +461,11 @@ describe('FileListComponent', () => {
         delete g.ResizeObserver;
       }
       window.requestAnimationFrame = originalRaf;
+      if (originalScrollYDescriptor) {
+        Object.defineProperty(window, 'scrollY', originalScrollYDescriptor);
+      } else {
+        delete (window as unknown as { scrollY?: number }).scrollY;
+      }
     });
 
     function flushRaf(): void {
@@ -484,7 +496,6 @@ describe('FileListComponent', () => {
         top: 137.4, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0,
         toJSON: () => ({}),
       } as DOMRect);
-      Object.defineProperty(window, 'scrollY', { value: 0, configurable: true });
 
       // Trigger the observer callback and flush the rAF-scheduled update.
       observerState.callback?.([], {} as ResizeObserver);

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { BehaviorSubject, Observable, of, EMPTY } from 'rxjs';
 import { ScrollingModule } from '@angular/cdk/scrolling';
@@ -389,5 +389,120 @@ describe('FileListComponent', () => {
     component.onBulkStop();
 
     expect(logger.info).toHaveBeenCalledWith('stopped');
+  });
+
+  // --- Dynamic chrome-height observer ---
+
+  describe('chrome-height observer', () => {
+    // Capture the ResizeObserver callback so the test can trigger it on demand,
+    // and record which elements were observed/unobserved.
+    interface FakeObserverState {
+      callback: ResizeObserverCallback | null;
+      observed: Element[];
+      disconnected: boolean;
+    }
+
+    let observerState: FakeObserverState;
+    let originalResizeObserver: typeof ResizeObserver | undefined;
+    let originalRaf: typeof window.requestAnimationFrame;
+    let rafCallbacks: FrameRequestCallback[];
+    let topHeader: HTMLElement;
+    let fileOptions: HTMLElement;
+
+    beforeEach(() => {
+      // The outer beforeEach already built a fixture with the real ResizeObserver.
+      // Destroy it so we can rebuild under a fake and get deterministic behaviour.
+      fixture?.destroy();
+      document.documentElement.style.removeProperty('--file-list-chrome-height');
+
+      // Extra chrome elements above the file list — the observer queries the
+      // document for these so they have to live in the real DOM.
+      topHeader = document.createElement('div');
+      topHeader.id = 'top-header';
+      fileOptions = document.createElement('div');
+      fileOptions.id = 'file-options';
+      document.body.prepend(fileOptions);
+      document.body.prepend(topHeader);
+
+      observerState = { callback: null, observed: [], disconnected: false };
+      originalResizeObserver = (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+      (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver =
+        class FakeResizeObserver {
+          constructor(cb: ResizeObserverCallback) { observerState.callback = cb; }
+          observe(el: Element): void { observerState.observed.push(el); }
+          unobserve(): void { /* noop */ }
+          disconnect(): void { observerState.disconnected = true; }
+        };
+
+      // Run any queued rAF callbacks synchronously for deterministic assertions.
+      rafCallbacks = [];
+      originalRaf = window.requestAnimationFrame;
+      window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb);
+        return rafCallbacks.length;
+      }) as typeof window.requestAnimationFrame;
+    });
+
+    afterEach(() => {
+      document.documentElement.style.removeProperty('--file-list-chrome-height');
+      topHeader.remove();
+      fileOptions.remove();
+      if (originalResizeObserver) {
+        (globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+          originalResizeObserver;
+      }
+      window.requestAnimationFrame = originalRaf;
+    });
+
+    function flushRaf(): void {
+      const pending = rafCallbacks;
+      rafCallbacks = [];
+      pending.forEach(cb => cb(performance.now()));
+    }
+
+    it('observes top-header, file-options, and the host element', () => {
+      // Re-create the fixture so ngAfterViewInit runs with our fake observer.
+      fixture = TestBed.createComponent(FileListComponent);
+      (fixture.nativeElement as HTMLElement).style.height = '400px';
+      fixture.detectChanges();
+
+      expect(observerState.observed).toContain(topHeader);
+      expect(observerState.observed).toContain(fileOptions);
+      expect(observerState.observed).toContain(fixture.nativeElement);
+    });
+
+    it('sets --file-list-chrome-height from the viewport element position', () => {
+      fixture = TestBed.createComponent(FileListComponent);
+      (fixture.nativeElement as HTMLElement).style.height = '400px';
+      fixture.detectChanges();
+
+      const viewportEl = fixture.nativeElement.querySelector('cdk-virtual-scroll-viewport') as HTMLElement;
+      // Pin a known top offset — the observer should round it up and expose it.
+      vi.spyOn(viewportEl, 'getBoundingClientRect').mockReturnValue({
+        top: 137.4, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0,
+        toJSON: () => ({}),
+      } as DOMRect);
+      Object.defineProperty(window, 'scrollY', { value: 0, configurable: true });
+
+      // Trigger the observer callback and flush the rAF-scheduled update.
+      observerState.callback?.([], {} as ResizeObserver);
+      flushRaf();
+
+      expect(document.documentElement.style.getPropertyValue('--file-list-chrome-height'))
+        .toBe('138px');
+    });
+
+    it('disconnects the observer and clears the CSS var on destroy', () => {
+      fixture = TestBed.createComponent(FileListComponent);
+      (fixture.nativeElement as HTMLElement).style.height = '400px';
+      fixture.detectChanges();
+
+      document.documentElement.style.setProperty('--file-list-chrome-height', '123px');
+      fixture.destroy();
+
+      expect(observerState.disconnected).toBe(true);
+      expect(document.documentElement.style.getPropertyValue('--file-list-chrome-height'))
+        .toBe('');
+    });
   });
 });

--- a/src/angular/src/app/pages/files/file-list.component.ts
+++ b/src/angular/src/app/pages/files/file-list.component.ts
@@ -1,4 +1,14 @@
-import { Component, ChangeDetectionStrategy, DestroyRef, inject } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  NgZone,
+  OnDestroy,
+  ViewChild,
+  inject,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AsyncPipe } from '@angular/common';
 import { Observable } from 'rxjs';
@@ -22,11 +32,18 @@ import { BulkActionBarComponent } from './bulk-action-bar.component';
   styleUrls: ['./file-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class FileListComponent {
+export class FileListComponent implements AfterViewInit, OnDestroy {
+  @ViewChild(CdkVirtualScrollViewport) viewport?: CdkVirtualScrollViewport;
+
   private readonly logger = inject(LoggerService);
   private readonly viewFileService = inject(ViewFileService);
   private readonly viewFileOptionsService = inject(ViewFileOptionsService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly elRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly zone = inject(NgZone);
+
+  private resizeObserver: ResizeObserver | null = null;
+  private pendingFrame: number | null = null;
 
   files: Observable<ViewFile[]> = this.viewFileService.filteredFiles$;
   options: Observable<ViewFileOptions> = this.viewFileOptionsService.options$;
@@ -35,6 +52,65 @@ export class FileListComponent {
 
   static identify(_index: number, item: ViewFile): string {
     return fileKey(item.pairId, item.name);
+  }
+
+  ngAfterViewInit(): void {
+    this.installChromeHeightObserver();
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+    if (this.pendingFrame !== null) {
+      cancelAnimationFrame(this.pendingFrame);
+      this.pendingFrame = null;
+    }
+    document.documentElement.style.removeProperty('--file-list-chrome-height');
+  }
+
+  // The virtual-scroll viewport's height must equal
+  //   100dvh − (sticky top header + file-options bar + column header + bulk-action-bar)
+  // Hardcoding those heights breaks whenever a breakpoint shifts, a notification
+  // banner appears, or the browser's own chrome changes between iOS Safari/Chrome
+  // and Android Chrome/Firefox. Instead, measure the viewport's page-Y position
+  // (everything stacked above it flows into that offset) and expose it to CSS.
+  private installChromeHeightObserver(): void {
+    if (typeof ResizeObserver === 'undefined') return;
+    const viewportEl = this.viewport?.elementRef.nativeElement as HTMLElement | undefined;
+    if (!viewportEl) return;
+
+    this.zone.runOutsideAngular(() => {
+      const update = (): void => {
+        this.pendingFrame = null;
+        const top = viewportEl.getBoundingClientRect().top + window.scrollY;
+        const chrome = Math.max(0, Math.ceil(top));
+        document.documentElement.style.setProperty(
+          '--file-list-chrome-height', `${chrome}px`,
+        );
+        this.viewport?.checkViewportSize();
+      };
+
+      const schedule = (): void => {
+        if (this.pendingFrame !== null) return;
+        this.pendingFrame = requestAnimationFrame(update);
+      };
+
+      this.resizeObserver = new ResizeObserver(schedule);
+
+      // Observe the elements whose size contributes to the chrome above the
+      // list. The #file-list host covers the column header and bulk-action-bar
+      // because they live inside it above .file-viewport.
+      const targets: (Element | null)[] = [
+        document.querySelector('#top-header'),
+        document.querySelector('#file-options'),
+        this.elRef.nativeElement,
+      ];
+      for (const t of targets) {
+        if (t) this.resizeObserver!.observe(t);
+      }
+
+      schedule();
+    });
   }
 
   onSelect(file: ViewFile): void {


### PR DESCRIPTION
## Summary

PR #371 fixed Android scroll, but iOS/Chrome still shows empty space below the file list. The 160px (desktop) and 200px (mobile) deductions hardcoded in the viewport `calc()` are larger than the actual rendered chrome on iOS, and they also don't adapt to notification banners or different `#file-options` wrapping at intermediate widths.

- Add a `ResizeObserver` on `#top-header`, `#file-options`, and the `#file-list` host (the last covers the column header and bulk-action-bar that live above `.file-viewport` inside the host).
- Measure `.file-viewport.getBoundingClientRect().top + window.scrollY` — everything stacked above the list flows into that offset — and expose it as `--file-list-chrome-height`.
- Rewrite the calc to read the CSS var with a 160px fallback; drop the brittle mobile media query since measurement is now breakpoint-agnostic.
- Runs outside the Angular zone with rAF throttling to avoid change-detection churn, and calls `checkViewportSize()` so CDK re-measures after the height updates.

Works the same across iOS Safari/Chrome, Android Chrome/Firefox, and desktop because it measures the actual rendered layout rather than guessing per-breakpoint.

## Test plan

- [x] `cd src/angular && npx ng lint` — no new warnings in the changed files
- [x] `cd src/angular && npx ng test` — 322 tests pass (3 new)
- [ ] Verify file list fills the screen on iOS Safari
- [ ] Verify file list fills the screen on iOS Chrome
- [ ] Verify file list fills the screen on Android Chrome
- [ ] Verify file list fills the screen on Android Firefox
- [ ] Verify desktop layout still fills the screen (no column-header gap)
- [ ] Verify bottom item is reachable in a long list on each browser
- [ ] Verify height recalculates when a notification banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File list viewport now sizes dynamically using runtime measurements, improving layout accuracy across banners and mobile/desktop differences and providing a safe fallback for older browsers.
  * Ensures viewport height updates are applied and cleared when the view is torn down.

* **Tests**
  * Added deterministic tests to verify viewport height updates, observer behavior, and proper cleanup on destroy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->