### PR TITLE
Resolve 6 deferred ruff ignores (#399 Phase 1)

### DIFF
--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -19,7 +19,7 @@ def _strtobool(val: str) -> bool:
     elif val in ("n", "no", "f", "false", "off", "0"):
         return False
     else:
-        raise ValueError("invalid truth value %r" % (val,))
+        raise ValueError(f"invalid truth value {val!r}")
 
 
 class ConfigError(AppError):

--- a/src/python/lftp/job_status.py
+++ b/src/python/lftp/job_status.py
@@ -80,7 +80,7 @@ class LftpJobStatus:
         Returns list of pairs (filename, transfer state)
         :return:
         """
-        return list(zip(self.__active_files_state.keys(), self.__active_files_state.values(), strict=False))
+        return list(self.__active_files_state.items())
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, LftpJobStatus):

--- a/src/python/lftp/job_status.py
+++ b/src/python/lftp/job_status.py
@@ -80,7 +80,7 @@ class LftpJobStatus:
         Returns list of pairs (filename, transfer state)
         :return:
         """
-        return list(zip(self.__active_files_state.keys(), self.__active_files_state.values()))
+        return list(zip(self.__active_files_state.keys(), self.__active_files_state.values(), strict=False))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, LftpJobStatus):

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -37,21 +37,17 @@ select = [
     "UP",  # pyupgrade
 ]
 ignore = [
-    "E501",  # line too long — defer to PR 2
-    "E721",  # type comparison — existing pattern uses type() intentionally
-    "E722",  # bare except — one instance in legacy e2e script
-    "E741",  # ambiguous variable name — single-letter vars in context
-    "UP032", # f-string — too much churn for auto-fix PR, defer to PR 2
+    "UP032", # f-string — 305 auto-fixable occurrences, separate PR (#399 Phase 2)
     "UP046", # non-pep695-generic-class — requires Python 3.12+ syntax migration
-    "B904",  # raise-without-from — defer to PR 2
-    "B905",  # zip-without-explicit-strict — defer to PR 2
-    "B024",  # abstract-base-class-without-abstract-method — existing pattern
-    "UP031", # printf-string-formatting — defer to PR 2
+    "B904",  # raise-without-from — 25 manual fixes, separate PR (#399 Phase 3)
+    "B024",  # abstract-base-class-without-abstract-method — intentional pattern
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "I001"]  # re-exports, import order is load-order sensitive
 "tests/**" = ["W291"]  # trailing whitespace in test string literals (lftp output data)
+"tests/**/test_job_status_parser.py" = ["E501"]  # long lines are lftp output test data
+"model/file.py" = ["E721"]  # intentional type() comparisons for enum-style state checks
 "scan_fs.py" = ["UP006", "UP035", "UP045"]  # must use typing.List/Optional for Python 3.5 compat on remote
 
 [tool.ruff.lint.isort]

--- a/src/python/tests/unittests/test_controller/test_model_builder.py
+++ b/src/python/tests/unittests/test_controller/test_model_builder.py
@@ -1872,7 +1872,7 @@ class TestSharedLocalDeduplication(unittest.TestCase):
         aggregate = Model()
         aggregate.set_base_logger(logging.getLogger("test"))
 
-        for builder, lp in zip(builders, local_paths, strict=False):
+        for builder, lp in zip(builders, local_paths, strict=True):
             norm_path = os.path.normpath(os.path.abspath(lp))
             if norm_path not in seen_names_by_path:
                 seen_names_by_path[norm_path] = set()

--- a/src/python/tests/unittests/test_controller/test_model_builder.py
+++ b/src/python/tests/unittests/test_controller/test_model_builder.py
@@ -1777,9 +1777,9 @@ class TestModelBuilder(unittest.TestCase):
     def test_build_state_validating(self):
         """Files with active validate statuses should be in VALIDATING state."""
         r = [SystemFile("a", 100, False)]
-        l = [SystemFile("a", 100, False)]
+        local_files = [SystemFile("a", 100, False)]
         self.model_builder.set_remote_files(r)
-        self.model_builder.set_local_files(l)
+        self.model_builder.set_local_files(local_files)
         self.model_builder.set_validate_statuses(
             [
                 ValidateStatus("a", False, ValidateStatus.State.VALIDATING),
@@ -1872,7 +1872,7 @@ class TestSharedLocalDeduplication(unittest.TestCase):
         aggregate = Model()
         aggregate.set_base_logger(logging.getLogger("test"))
 
-        for builder, lp in zip(builders, local_paths):
+        for builder, lp in zip(builders, local_paths, strict=False):
             norm_path = os.path.normpath(os.path.abspath(lp))
             if norm_path not in seen_names_by_path:
                 seen_names_by_path[norm_path] = set()

--- a/src/python/web/serialize/serialize.py
+++ b/src/python/web/serialize/serialize.py
@@ -12,7 +12,7 @@ class Serialize(ABC):
     def _sse_pack(self, event: str, data: str) -> str:
         """Pack data in SSE format"""
         buffer = ""
-        buffer += "event: %s\n" % event
-        buffer += "data: %s\n" % data
+        buffer += f"event: {event}\n"
+        buffer += f"data: {data}\n"
         buffer += "\n"
         return buffer


### PR DESCRIPTION
Closes #399 Phase 1 (partial — Phase 1 only)

## Summary
Removes 6 of 10 deferred ruff ignore entries, reducing the ignore list from 10 → 4.

## Changes

| Rule | Action | Details |
|------|--------|---------|
| `E722` | **Removed** | 0 violations remain |
| `E741` | **Removed** | Renamed `l` → `local_files` in `test_model_builder.py:1780` |
| `B905` | **Removed** | Added `strict=False` to 2 `zip()` calls |
| `UP031` | **Removed** | Converted 3 printf-style formats to f-strings |
| `E501` | **Moved** to per-file-ignore | All 24 violations are lftp test data in `test_job_status_parser.py` |
| `E721` | **Moved** to per-file-ignore | All 11 violations are intentional `type()` checks in `model/file.py` |

## Remaining ignore list (4 entries)
- `UP032` — 305 f-string conversions (Phase 2, auto-fixable)
- `B904` — 25 raise-without-from fixes (Phase 3, manual)
- `UP046` — keep (Python 3.12 syntax migration, low value)
- `B024` — keep (intentional ABC pattern)

## Test plan
- [x] `ruff check` — all checks passed
- [x] `ruff format --check` — 164 files already formatted
- [x] `pytest tests/unittests/test_controller/test_model_builder.py` — 66 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to enforce stricter code quality standards
  * Improved internal code formatting consistency
* **Tests**
  * Enhanced test clarity and robustness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->