### PR TITLE
Convert 305 .format() to f-strings (#399 Phase 2)

### DIFF
--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -46,21 +46,21 @@ class Converters:
     @staticmethod
     def int(cls: T, name: str, value: str) -> int:  # type: ignore[reportInvalidTypeVarUse, reportSelfClsParameterName]
         if not value:
-            raise ConfigError("Bad config: {}.{} is empty".format(cls.__name__, name))
+            raise ConfigError(f"Bad config: {cls.__name__}.{name} is empty")
         try:
             val = int(value)
         except ValueError:
-            raise ConfigError("Bad config: {}.{} ({}) must be an integer value".format(cls.__name__, name, value))
+            raise ConfigError(f"Bad config: {cls.__name__}.{name} ({value}) must be an integer value")
         return val
 
     @staticmethod
     def bool(cls: T, name: str, value: str) -> bool:  # type: ignore[reportInvalidTypeVarUse, reportSelfClsParameterName]
         if not value:
-            raise ConfigError("Bad config: {}.{} is empty".format(cls.__name__, name))
+            raise ConfigError(f"Bad config: {cls.__name__}.{name} is empty")
         try:
             val = bool(_strtobool(value))
         except ValueError:
-            raise ConfigError("Bad config: {}.{} ({}) must be a boolean value".format(cls.__name__, name, value))
+            raise ConfigError(f"Bad config: {cls.__name__}.{name} ({value}) must be a boolean value")
         return val
 
 
@@ -72,7 +72,7 @@ class Checkers:
     @staticmethod
     def string_nonempty(cls: T, name: str, value: str) -> str:  # type: ignore[reportInvalidTypeVarUse, reportSelfClsParameterName]
         if not value or not value.strip():
-            raise ConfigError("Bad config: {}.{} is empty".format(cls.__name__, name))
+            raise ConfigError(f"Bad config: {cls.__name__}.{name} is empty")
         return value
 
     @staticmethod
@@ -82,13 +82,13 @@ class Checkers:
     @staticmethod
     def int_non_negative(cls: T, name: str, value: int) -> int:  # type: ignore[reportInvalidTypeVarUse, reportSelfClsParameterName]
         if value < 0:
-            raise ConfigError("Bad config: {}.{} ({}) must be zero or greater".format(cls.__name__, name, value))
+            raise ConfigError(f"Bad config: {cls.__name__}.{name} ({value}) must be zero or greater")
         return value
 
     @staticmethod
     def int_positive(cls: T, name: str, value: int) -> int:  # type: ignore[reportInvalidTypeVarUse, reportSelfClsParameterName]
         if value < 1:
-            raise ConfigError("Bad config: {}.{} ({}) must be greater than 0".format(cls.__name__, name, value))
+            raise ConfigError(f"Bad config: {cls.__name__}.{name} ({value}) must be greater than 0")
         return value
 
     @staticmethod
@@ -424,7 +424,7 @@ class Config(Persist):
     @staticmethod
     def _check_section(dct: OuterConfigType, name: str) -> InnerConfigType:
         if name not in dct:
-            raise ConfigError("Missing config section: {}".format(name))
+            raise ConfigError(f"Missing config section: {name}")
         val = dct[name]
         del dct[name]
         return val
@@ -441,7 +441,7 @@ class Config(Persist):
         try:
             config_parser.read_string(content)
         except (configparser.MissingSectionHeaderError, configparser.ParsingError) as e:
-            raise PersistError("Error parsing Config - {}: {}".format(type(e).__name__, str(e)))
+            raise PersistError(f"Error parsing Config - {type(e).__name__}: {str(e)}")
         config_dict: OuterConfigType = {}
         for section in config_parser.sections():
             config_dict[section] = {}

--- a/src/python/common/context.py
+++ b/src/python/common/context.py
@@ -73,7 +73,7 @@ class Context:
                 value = config_dict[section][option]
                 if option == "remote_password":
                     value = "********" if value else ""
-                self.logger.debug("  {}.{}: {}".format(section, option, value))
+                self.logger.debug(f"  {section}.{option}: {value}")
 
         # Print path pairs
         if self.path_pairs_config and self.path_pairs_config.pairs:
@@ -91,4 +91,4 @@ class Context:
 
         self.logger.debug("Args:")
         for name, value in self.args.as_dict().items():
-            self.logger.debug("  {}: {}".format(name, value))
+            self.logger.debug(f"  {name}: {value}")

--- a/src/python/common/job.py
+++ b/src/python/common/job.py
@@ -31,12 +31,12 @@ class Job(threading.Thread, ABC):
 
     @overrides(threading.Thread)
     def run(self):
-        self.logger.debug("Thread {} started".format(self.name))
+        self.logger.debug(f"Thread {self.name} started")
 
         # ... Setup code here ...
-        self.logger.debug("Calling setup for {}".format(self.name))
+        self.logger.debug(f"Calling setup for {self.name}")
         self.setup()
-        self.logger.debug("Finished setup for {}".format(self.name))
+        self.logger.debug(f"Finished setup for {self.name}")
 
         while not self.shutdown_flag.is_set():
             # ... Job code here ...
@@ -45,7 +45,7 @@ class Job(threading.Thread, ABC):
                 self.execute()
             except Exception:
                 self.exc_info = sys.exc_info()
-                self.logger.exception("Caught exception in job {}".format(self.name))
+                self.logger.exception(f"Caught exception in job {self.name}")
                 # break out of run loop and proceed to cleanup
                 self.shutdown_flag.set()
                 break
@@ -53,11 +53,11 @@ class Job(threading.Thread, ABC):
             time.sleep(Job._DEFAULT_SLEEP_INTERVAL_IN_SECS)
 
         # ... Clean shutdown code here ...
-        self.logger.debug("Calling cleanup for {}".format(self.name))
+        self.logger.debug(f"Calling cleanup for {self.name}")
         self.cleanup()
-        self.logger.debug("Finished cleanup for {}".format(self.name))
+        self.logger.debug(f"Finished cleanup for {self.name}")
 
-        self.logger.debug("Thread {} stopped".format(self.name))
+        self.logger.debug(f"Thread {self.name} stopped")
 
     def terminate(self):
         """

--- a/src/python/common/path_pairs_config.py
+++ b/src/python/common/path_pairs_config.py
@@ -50,17 +50,17 @@ class PathPair:
         enabled = d.get("enabled", True)
         auto_queue = d.get("auto_queue", True)
         if not isinstance(pair_id, str):
-            raise TypeError("id must be a string, got {}".format(type(pair_id).__name__))
+            raise TypeError(f"id must be a string, got {type(pair_id).__name__}")
         if not isinstance(name, str):
-            raise TypeError("name must be a string, got {}".format(type(name).__name__))
+            raise TypeError(f"name must be a string, got {type(name).__name__}")
         if not isinstance(remote_path, str):
-            raise TypeError("remote_path must be a string, got {}".format(type(remote_path).__name__))
+            raise TypeError(f"remote_path must be a string, got {type(remote_path).__name__}")
         if not isinstance(local_path, str):
-            raise TypeError("local_path must be a string, got {}".format(type(local_path).__name__))
+            raise TypeError(f"local_path must be a string, got {type(local_path).__name__}")
         if not isinstance(enabled, bool):
-            raise TypeError("enabled must be a boolean, got {}".format(type(enabled).__name__))
+            raise TypeError(f"enabled must be a boolean, got {type(enabled).__name__}")
         if not isinstance(auto_queue, bool):
-            raise TypeError("auto_queue must be a boolean, got {}".format(type(auto_queue).__name__))
+            raise TypeError(f"auto_queue must be a boolean, got {type(auto_queue).__name__}")
         return PathPair(
             pair_id=pair_id,
             name=name,
@@ -76,7 +76,7 @@ class PathPair:
         return self.to_dict() == other.to_dict()
 
     def __repr__(self) -> str:
-        return "PathPair({})".format(self.to_dict())
+        return f"PathPair({self.to_dict()})"
 
 
 _CURRENT_VERSION = 1
@@ -112,9 +112,9 @@ class PathPairsConfig(Persist):
     def add_pair(self, pair: PathPair):
         with self._lock:
             if any(p.id == pair.id for p in self._pairs):
-                raise ValueError("PathPair with id '{}' already exists".format(pair.id))
+                raise ValueError(f"PathPair with id '{pair.id}' already exists")
             if any(p.name == pair.name for p in self._pairs):
-                raise ValueError("PathPair with name '{}' already exists".format(pair.name))
+                raise ValueError(f"PathPair with name '{pair.name}' already exists")
             self._pairs.append(pair)
 
     def update_pair(self, pair: PathPair):
@@ -122,16 +122,16 @@ class PathPairsConfig(Persist):
             for i, p in enumerate(self._pairs):
                 if p.id == pair.id:
                     if any(other.name == pair.name and other.id != pair.id for other in self._pairs):
-                        raise ValueError("PathPair with name '{}' already exists".format(pair.name))
+                        raise ValueError(f"PathPair with name '{pair.name}' already exists")
                     self._pairs[i] = pair
                     return
-            raise ValueError("PathPair with id '{}' not found".format(pair.id))
+            raise ValueError(f"PathPair with id '{pair.id}' not found")
 
     def remove_pair(self, pair_id: str):
         with self._lock:
             new_pairs = [p for p in self._pairs if p.id != pair_id]
             if len(new_pairs) == len(self._pairs):
-                raise ValueError("PathPair with id '{}' not found".format(pair_id))
+                raise ValueError(f"PathPair with id '{pair_id}' not found")
             self._pairs = new_pairs
 
     @classmethod
@@ -139,7 +139,7 @@ class PathPairsConfig(Persist):
         try:
             raw: Any = json.loads(content)
         except json.JSONDecodeError as e:
-            raise PersistError("Error parsing PathPairsConfig: {}".format(str(e))) from e
+            raise PersistError(f"Error parsing PathPairsConfig: {str(e)}") from e
 
         if not isinstance(raw, dict):
             raise PersistError("Expected JSON object in PathPairsConfig")
@@ -153,7 +153,7 @@ class PathPairsConfig(Persist):
             try:
                 config.add_pair(PathPair.from_dict(pair_dict))
             except (KeyError, TypeError, ValueError) as e:
-                raise PersistError("Malformed path pair entry: {}".format(e)) from e
+                raise PersistError(f"Malformed path pair entry: {e}") from e
         return config
 
     def to_str(self) -> str:

--- a/src/python/common/persist.py
+++ b/src/python/common/persist.py
@@ -95,15 +95,13 @@ class Persist(Serializable):
         base_name = os.path.basename(file_path)
         name, ext = os.path.splitext(base_name)
         timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S-%f")
-        backup_name = "{}-{}{}".format(name, timestamp, ext)
+        backup_name = f"{name}-{timestamp}{ext}"
         backup_path = os.path.join(backup_dir, backup_name)
 
         shutil.copy2(file_path, backup_path)
 
         # Prune old backups, keeping only the most recent _MAX_BACKUPS
-        pattern = os.path.join(
-            backup_dir, "{}-????-??-??T??-??-??-??????{}".format(glob.escape(name), glob.escape(ext))
-        )
+        pattern = os.path.join(backup_dir, f"{glob.escape(name)}-????-??-??T??-??-??-??????{glob.escape(ext)}")
         backups = sorted(glob.glob(pattern))
         for old_backup in backups[:-_MAX_BACKUPS]:
             try:

--- a/src/python/common/remote_path_utils.py
+++ b/src/python/common/remote_path_utils.py
@@ -7,7 +7,7 @@ def escape_remote_path_single(path: str) -> str:
     Single quotes within the path are escaped using the shell '\\'' trick.
     """
     escaped = path.replace("'", "'\\''")
-    return "'{}'".format(escaped)
+    return f"'{escaped}'"
 
 
 def escape_remote_path_double(path: str) -> str:
@@ -17,4 +17,4 @@ def escape_remote_path_double(path: str) -> str:
     """
     if path.startswith("~"):
         path = "$HOME" + path[1:]
-    return '"{}"'.format(path)
+    return f'"{path}"'

--- a/src/python/controller/auto_queue.py
+++ b/src/python/controller/auto_queue.py
@@ -103,7 +103,7 @@ class AutoQueuePersist(Persist):
                 persist.add_pattern(AutoQueuePattern.from_str(pattern))
             return persist
         except (json.decoder.JSONDecodeError, KeyError) as e:
-            raise PersistError("Error parsing AutoQueuePersist - {}: {}".format(type(e).__name__, str(e)))
+            raise PersistError(f"Error parsing AutoQueuePersist - {type(e).__name__}: {str(e)}")
 
     @overrides(Persist)
     def to_str(self) -> str:
@@ -193,7 +193,7 @@ class AutoQueue:
             # Print the initial persist state
             self.logger.debug("Auto-Queue Patterns:")
             for pattern in self.__persist.patterns:
-                self.logger.debug("    {}".format(pattern.pattern))
+                self.logger.debug(f"    {pattern.pattern}")
 
     def process(self):
         """
@@ -288,10 +288,7 @@ class AutoQueue:
         log_prefix: str,
     ) -> None:
         for filename, pair_id, pattern in files:
-            self.logger.info(
-                "{} '{}'".format(log_prefix, filename)
-                + (" for pattern '{}'".format(pattern.pattern) if pattern else "")
-            )
+            self.logger.info(f"{log_prefix} '{filename}'" + (f" for pattern '{pattern.pattern}'" if pattern else ""))
             command = Controller.Command(action, filename, pair_id=pair_id)
             self.__controller.queue_command(command)
 

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -115,7 +115,7 @@ _KEY_SEP = "\x1f"
 
 def _persist_key(pair_id: str | None, name: str) -> str:
     """Build a namespaced persist key: 'pair_id<US>name' or plain 'name' for default pair."""
-    return "{}{}{}".format(pair_id, _KEY_SEP, name) if pair_id else name
+    return f"{pair_id}{_KEY_SEP}{name}" if pair_id else name
 
 
 def _strip_persist_key(key: str, pair_id: str | None) -> str:
@@ -128,7 +128,7 @@ def _strip_persist_key(key: str, pair_id: str | None) -> str:
         return key
     # Try the current separator first, then legacy colon
     for sep in (_KEY_SEP, ":"):
-        prefix = "{}{}".format(pair_id, sep)
+        prefix = f"{pair_id}{sep}"
         if key.startswith(prefix):
             return key[len(prefix) :]
     return key
@@ -315,7 +315,7 @@ class Controller:
         ]
         for field in lftp_fields:
             if getattr(config.lftp, field) is None:
-                missing.append("Lftp.{}".format(field))
+                missing.append(f"Lftp.{field}")
 
         # Controller required fields
         controller_fields = [
@@ -325,7 +325,7 @@ class Controller:
         ]
         for field in controller_fields:
             if getattr(config.controller, field) is None:
-                missing.append("Controller.{}".format(field))
+                missing.append(f"Controller.{field}")
 
         # General required fields
         if config.general.verbose is None:
@@ -368,8 +368,8 @@ class Controller:
                 ]
                 fields = ", ".join(missing)
                 raise ControllerError(
-                    "No path pairs configured and {} not set. "
-                    "Configure at least one path pair in Settings, or set {}.".format(fields, fields)
+                    f"No path pairs configured and {fields} not set. "
+                    f"Configure at least one path pair in Settings, or set {fields}."
                 )
             return [
                 self._create_pair_context(
@@ -395,7 +395,7 @@ class Controller:
         Create a fully wired _PairContext with its own LFTP, scanners, and model builder.
         """
         pair_label = name or pair_id or "default"
-        pair_logger = self.logger.getChild("Pair[{}]".format(pair_label))
+        pair_logger = self.logger.getChild(f"Pair[{pair_label}]")
 
         # Determine effective local path: use staging_path when staging is enabled
         # Each pair gets its own staging subdirectory to prevent cross-pair collisions
@@ -515,7 +515,7 @@ class Controller:
         validate_cfg = self.__context.config.validate
         if validate_cfg.xfer_verify:
             lftp.xfer_verify = True
-            lftp.xfer_verify_command = "{}sum".format(validate_cfg.algorithm)
+            lftp.xfer_verify_command = f"{validate_cfg.algorithm}sum"
         else:
             lftp.xfer_verify = False
         lftp.set_verbose_logging(self.__context.config.general.verbose)  # type: ignore[arg-type]
@@ -725,9 +725,7 @@ class Controller:
                 owner_pc = self._find_pair_by_id(result.pair_id)
                 if owner_pc is None:
                     self.logger.warning(
-                        "Ignoring extract completion for '{}': pair '{}' no longer exists".format(
-                            result.name, result.pair_id
-                        )
+                        f"Ignoring extract completion for '{result.name}': pair '{result.pair_id}' no longer exists"
                     )
                     continue
                 pkey = _persist_key(result.pair_id, result.name)
@@ -845,7 +843,7 @@ class Controller:
                             )
                             self.__validate_process.validate(req)
                             self.__pending_validation_keys.add(_persist_key(pc.pair_id, diff.new_file.name))
-                            self.logger.info("Auto-queued validation for '{}'".format(diff.new_file.name))
+                            self.logger.info(f"Auto-queued validation for '{diff.new_file.name}'")
 
                         if (
                             self.__context.config.controller.use_staging
@@ -909,7 +907,7 @@ class Controller:
                             except ModelError:
                                 pass
                 if remove_extracted_keys:
-                    self.logger.info("Removing from extracted list: {}".format(remove_extracted_keys))
+                    self.logger.info(f"Removing from extracted list: {remove_extracted_keys}")
                     self.__persist.extracted_file_names.difference_update(remove_extracted_keys)
                     self._sync_persist_to_all_builders()
 
@@ -927,7 +925,7 @@ class Controller:
                         if pkey not in model_keys and pkey not in self.__moved_file_keys:
                             absent_keys.add(pkey)
                     if absent_keys:
-                        self.logger.info("Persist cleanup (both absent): {}".format(absent_keys))
+                        self.logger.info(f"Persist cleanup (both absent): {absent_keys}")
                         self.__persist.downloaded_file_names.difference_update(absent_keys)
                         self.__persist.extracted_file_names.difference_update(absent_keys)
                         self.__persist.extract_failed_file_names.difference_update(absent_keys)
@@ -937,14 +935,14 @@ class Controller:
 
         # Process extraction failures — mark as failed immediately
         for result in latest_failed_extractions:
-            self.logger.error("Extraction failed for '{}'".format(result.name))
+            self.logger.error(f"Extraction failed for '{result.name}'")
             fail_key = _persist_key(result.pair_id, result.name)
             self.__persist.extract_failed_file_names.add(fail_key)
             self._sync_persist_to_all_builders()
 
         # Process validation completions — mark as validated
         for result in latest_validated_results:
-            self.logger.info("Validation passed for '{}'".format(result.name))
+            self.logger.info(f"Validation passed for '{result.name}'")
             pkey = _persist_key(result.pair_id, result.name)
             self.__pending_validation_keys.discard(pkey)
             self.__persist.validated_file_names.add(pkey)
@@ -955,7 +953,7 @@ class Controller:
 
         # Process validation failures
         for result in latest_failed_validations:
-            self.logger.error("Validation failed for '{}': {}".format(result.name, result.error_message))
+            self.logger.error(f"Validation failed for '{result.name}': {result.error_message}")
             pkey = _persist_key(result.pair_id, result.name)
             self.__pending_validation_keys.discard(pkey)
             if result.is_checksum_mismatch:
@@ -967,7 +965,7 @@ class Controller:
                 # Non-mismatch failure (SSH error, etc.) — don't mark corrupt,
                 # just log so the user can retry
                 self.logger.warning(
-                    "Validation error for '{}' (not marking corrupt): {}".format(result.name, result.error_message)
+                    f"Validation error for '{result.name}' (not marking corrupt): {result.error_message}"
                 )
             # Spawn deferred move regardless of failure type — validation is done
             self._spawn_deferred_move(result.pair_id, result.name)
@@ -1005,7 +1003,7 @@ class Controller:
         try:
             lftp_statuses = pc.lftp.status()
         except LftpError as e:
-            self.logger.warning("Caught lftp error (pair {}): {}".format(pc.name, str(e)))
+            self.logger.warning(f"Caught lftp error (pair {pc.name}): {str(e)}")
 
         if latest_remote_scan is not None:
             pc.remote_scan_received = True
@@ -1017,7 +1015,7 @@ class Controller:
             just_completed = pc.prev_downloading_file_names - current_downloading
             if just_completed:
                 for name in just_completed:
-                    self.logger.info("Download completed (LFTP job finished): {}".format(name))
+                    self.logger.info(f"Download completed (LFTP job finished): {name}")
                 self.__persist.downloaded_file_names.update(_persist_key(pc.pair_id, n) for n in just_completed)
                 self._sync_persist_to_all_builders()
                 pc.pending_completion.update(just_completed)
@@ -1119,7 +1117,7 @@ class Controller:
 
     def __process_commands(self):
         def _notify_failure(_command: Controller.Command, _msg: str):
-            self.logger.warning("Command failed. {}".format(_msg))
+            self.logger.warning(f"Command failed. {_msg}")
             for _callback in _command.callbacks:
                 _callback.on_failure(_msg)
 
@@ -1127,38 +1125,38 @@ class Controller:
 
         while not self.__command_queue.empty():
             command = self.__command_queue.get()
-            self.logger.info("Received command {} for file {}".format(str(command.action), command.filename))
+            self.logger.info(f"Received command {str(command.action)} for file {command.filename}")
 
             pc = self._get_pair_context_for_command(command)
             if pc is None:
-                _notify_failure(command, "No pair context found for pair_id '{}'".format(command.pair_id))
+                _notify_failure(command, f"No pair context found for pair_id '{command.pair_id}'")
                 continue
 
             try:
                 file = self.__model.get_file(command.filename, pair_id=pc.pair_id)
             except ModelError:
-                _notify_failure(command, "File '{}' not found".format(command.filename))
+                _notify_failure(command, f"File '{command.filename}' not found")
                 continue
 
             if command.action == Controller.Command.Action.QUEUE:
                 if file.remote_size is None:
-                    _notify_failure(command, "File '{}' does not exist remotely".format(command.filename))
+                    _notify_failure(command, f"File '{command.filename}' does not exist remotely")
                     continue
                 try:
                     exclude = parse_exclude_patterns(self.__context.config.general.exclude_patterns)
                     pc.lftp.queue(file.name, file.is_dir, exclude_patterns=exclude)
                 except LftpError as e:
-                    _notify_failure(command, "Lftp error: {}".format(str(e)))
+                    _notify_failure(command, f"Lftp error: {str(e)}")
                     continue
 
             elif command.action == Controller.Command.Action.STOP:
                 if file.state not in (ModelFile.State.DOWNLOADING, ModelFile.State.QUEUED):
-                    _notify_failure(command, "File '{}' is not Queued or Downloading".format(command.filename))
+                    _notify_failure(command, f"File '{command.filename}' is not Queued or Downloading")
                     continue
                 try:
                     pc.lftp.kill(file.name)
                 except LftpError as e:
-                    _notify_failure(command, "Lftp error: {}".format(str(e)))
+                    _notify_failure(command, f"Lftp error: {str(e)}")
                     continue
 
             elif command.action == Controller.Command.Action.EXTRACT:
@@ -1171,11 +1169,11 @@ class Controller:
                     ModelFile.State.CORRUPT,
                 ):
                     _notify_failure(
-                        command, "File '{}' in state {} cannot be extracted".format(command.filename, str(file.state))
+                        command, f"File '{command.filename}' in state {str(file.state)} cannot be extracted"
                     )
                     continue
                 elif file.local_size is None:
-                    _notify_failure(command, "File '{}' does not exist locally".format(command.filename))
+                    _notify_failure(command, f"File '{command.filename}' does not exist locally")
                     continue
                 else:
                     pkey = _persist_key(pc.pair_id, file.name)
@@ -1204,11 +1202,11 @@ class Controller:
                 ):
                     _notify_failure(
                         command,
-                        "Local file '{}' cannot be deleted in state {}".format(command.filename, str(file.state)),
+                        f"Local file '{command.filename}' cannot be deleted in state {str(file.state)}",
                     )
                     continue
                 elif file.local_size is None:
-                    _notify_failure(command, "File '{}' does not exist locally".format(command.filename))
+                    _notify_failure(command, f"File '{command.filename}' does not exist locally")
                     continue
                 else:
                     delete_path = pc.local_path
@@ -1254,11 +1252,11 @@ class Controller:
                 ):
                     _notify_failure(
                         command,
-                        "Remote file '{}' cannot be deleted in state {}".format(command.filename, str(file.state)),
+                        f"Remote file '{command.filename}' cannot be deleted in state {str(file.state)}",
                     )
                     continue
                 elif file.remote_size is None:
-                    _notify_failure(command, "File '{}' does not exist remotely".format(command.filename))
+                    _notify_failure(command, f"File '{command.filename}' does not exist remotely")
                     continue
                 else:
                     process = DeleteRemoteProcess(
@@ -1288,14 +1286,14 @@ class Controller:
                     ModelFile.State.CORRUPT,
                 ):
                     _notify_failure(
-                        command, "File '{}' in state {} cannot be validated".format(command.filename, str(file.state))
+                        command, f"File '{command.filename}' in state {str(file.state)} cannot be validated"
                     )
                     continue
                 elif file.local_size is None:
-                    _notify_failure(command, "File '{}' does not exist locally".format(command.filename))
+                    _notify_failure(command, f"File '{command.filename}' does not exist locally")
                     continue
                 elif file.remote_size is None:
-                    _notify_failure(command, "File '{}' does not exist remotely".format(command.filename))
+                    _notify_failure(command, f"File '{command.filename}' does not exist remotely")
                     continue
                 else:
                     pkey = _persist_key(pc.pair_id, file.name)
@@ -1336,7 +1334,7 @@ class Controller:
                 permanent_patterns = ["Login failed", "Access failed"]
                 if any(p in error_str for p in permanent_patterns):
                     raise AppError(error_str) from e
-                self.logger.warning("Caught lftp error: {}".format(error_str))
+                self.logger.warning(f"Caught lftp error: {error_str}")
             pc.active_scan_process.propagate_exception()
             pc.local_scan_process.propagate_exception()
             pc.remote_scan_process.propagate_exception()
@@ -1353,7 +1351,7 @@ class Controller:
             return
         pc = self._find_pair_by_id(pair_id)
         if pc is None:
-            self.logger.warning("Cannot spawn deferred move for '{}': pair '{}' not found".format(file_name, pair_id))
+            self.logger.warning(f"Cannot spawn deferred move for '{file_name}': pair '{pair_id}' not found")
             return
         self.__spawn_move_process(file_name, pc)
 
@@ -1364,7 +1362,7 @@ class Controller:
         pair_id = pc.pair_id
         move_key = _persist_key(pair_id, file_name)
         if move_key in self.__moved_file_keys:
-            self.logger.debug("Skipping move for {} - already moved".format(file_name))
+            self.logger.debug(f"Skipping move for {file_name} - already moved")
             return
 
         dest_path = pc.local_path
@@ -1377,7 +1375,7 @@ class Controller:
         # Skip if the file doesn't exist in staging (e.g. already moved in a prior session)
         staging_file = os.path.join(staging_source, file_name)
         if not os.path.exists(staging_file):
-            self.logger.debug("Skipping move for {} - not found in staging".format(file_name))
+            self.logger.debug(f"Skipping move for {file_name} - not found in staging")
             self.__moved_file_keys.add(move_key)
             return
 
@@ -1386,7 +1384,7 @@ class Controller:
         process.set_mp_log_queue(self.__mp_logger.queue, self.__mp_logger.log_level)
         self.__active_move_processes.append(process)
         process.start()
-        self.logger.info("Spawned move process for {} (staging -> local)".format(file_name))
+        self.logger.info(f"Spawned move process for {file_name} (staging -> local)")
 
     def __cleanup_commands(self):
         """

--- a/src/python/controller/controller_persist.py
+++ b/src/python/controller/controller_persist.py
@@ -42,7 +42,7 @@ class ControllerPersist(Persist):
         for key in keys:
             m = _LEGACY_KEY_RE.match(key)
             if m:
-                migrated.add("{}{}{}".format(m.group(1), _KEY_SEP, m.group(2)))
+                migrated.add(f"{m.group(1)}{_KEY_SEP}{m.group(2)}")
             else:
                 migrated.add(key)
         return migrated
@@ -68,7 +68,7 @@ class ControllerPersist(Persist):
             persist.corrupt_file_names = ControllerPersist._migrate_legacy_keys(persist.corrupt_file_names)
             return persist
         except (json.decoder.JSONDecodeError, KeyError) as e:
-            raise PersistError("Error parsing ControllerPersist - {}: {}".format(type(e).__name__, str(e)))
+            raise PersistError(f"Error parsing ControllerPersist - {type(e).__name__}: {str(e)}")
 
     @overrides(Persist)
     def to_str(self) -> str:

--- a/src/python/controller/delete/delete_process.py
+++ b/src/python/controller/delete/delete_process.py
@@ -23,11 +23,11 @@ class DeleteLocalProcess(AppOneShotProcess):
         except ValueError:
             common = None
         if common != real_base or real_target == real_base:
-            self.logger.error("Path traversal blocked: {} escapes {}".format(real_target, real_base))
+            self.logger.error(f"Path traversal blocked: {real_target} escapes {real_base}")
             return
-        self.logger.debug("Deleting local file {}".format(self.__file_name))
+        self.logger.debug(f"Deleting local file {self.__file_name}")
         if not os.path.exists(file_path):
-            self.logger.error("Failed to delete non-existing file: {}".format(file_path))
+            self.logger.error(f"Failed to delete non-existing file: {file_path}")
         else:
             if os.path.isfile(file_path):
                 os.remove(file_path)
@@ -61,14 +61,14 @@ class DeleteRemoteProcess(AppOneShotProcess):
             or normalized.startswith(".." + os.sep)
             or os.path.isabs(normalized)
         ):
-            self.logger.error("Path traversal blocked in remote delete: {}".format(self.__file_name))
+            self.logger.error(f"Path traversal blocked in remote delete: {self.__file_name}")
             return
         file_path = os.path.join(self.__remote_path, self.__file_name)
-        self.logger.info("Deleting remote file: {}".format(self.__file_name))
+        self.logger.info(f"Deleting remote file: {self.__file_name}")
         if file_path.startswith("~"):
             escaped_path = escape_remote_path_double(file_path)
         else:
             escaped_path = escape_remote_path_single(file_path)
-        out = self.__ssh.shell("rm -rf {}".format(escaped_path))
-        self.logger.debug("Remote delete output: {}".format(out.decode()))
-        self.logger.info("Successfully deleted remote file: {}".format(self.__file_name))
+        out = self.__ssh.shell(f"rm -rf {escaped_path}")
+        self.logger.debug(f"Remote delete output: {out.decode()}")
+        self.logger.info(f"Successfully deleted remote file: {self.__file_name}")

--- a/src/python/controller/extract/dispatch.py
+++ b/src/python/controller/extract/dispatch.py
@@ -131,12 +131,12 @@ class ExtractDispatch:
 
     def extract(self, req: ExtractRequest):
         model_file = req.model_file
-        self.logger.debug("Received extract for {}".format(model_file.name))
+        self.logger.debug(f"Received extract for {model_file.name}")
 
         with self.__task_queue.mutex:
             for task in self.__task_queue.queue:
                 if task.root_name == model_file.name and task.pair_id == req.pair_id:
-                    self.logger.info("Ignoring extract for {}, already exists".format(model_file.name))
+                    self.logger.info(f"Ignoring extract for {model_file.name}, already exists")
                     return
 
         # noinspection PyProtectedMember
@@ -167,16 +167,16 @@ class ExtractDispatch:
             if len(task.archive_paths) > 0:
                 self.__task_queue.put(task)
             else:
-                raise ExtractDispatchError("Directory does not contain any archives: {}".format(model_file.name))
+                raise ExtractDispatchError(f"Directory does not contain any archives: {model_file.name}")
         else:
             # For a single file, it must exist locally and must be an archive
             if model_file.local_size in (None, 0):
-                raise ExtractDispatchError("File does not exist locally: {}".format(model_file.name))
+                raise ExtractDispatchError(f"File does not exist locally: {model_file.name}")
             archive_full_path, is_fallback = self.__resolve_archive_path(
                 model_file.name, req.local_path, req.local_path_fallback
             )
             if not archive_full_path:
-                raise ExtractDispatchError("File is not an archive: {}".format(model_file.name))
+                raise ExtractDispatchError(f"File is not an archive: {model_file.name}")
             base_out = req.out_dir_path_fallback if is_fallback else req.out_dir_path
             task.add_archive(archive_path=archive_full_path, out_dir_path=base_out)
             self.__task_queue.put(task)
@@ -204,7 +204,7 @@ class ExtractDispatch:
                             completed = False
                             break
 
-                        self.logger.debug("Extracting {}".format(archive_path))
+                        self.logger.debug(f"Extracting {archive_path}")
                         Extract.extract_archive(archive_path=archive_path, out_dir_path=out_dir_path)
 
                 except ExtractError:

--- a/src/python/controller/extract/extract.py
+++ b/src/python/controller/extract/extract.py
@@ -44,8 +44,8 @@ class Extract:
         if result.stdout.strip():
             stdout_lines = result.stdout.strip().splitlines()
             stdout_tail = "\n".join(stdout_lines[-20:])
-            details = "{}\n--- stdout (last 20 lines) ---\n{}".format(details, stdout_tail)
-        return "{} (exit {}): {}".format(prefix, result.returncode, details)
+            details = f"{details}\n--- stdout (last 20 lines) ---\n{stdout_tail}"
+        return f"{prefix} (exit {result.returncode}): {details}"
 
     @staticmethod
     def verify_archive(archive_path: str):
@@ -54,20 +54,18 @@ class Extract:
         Raises ExtractError on failure.
         """
         if not os.path.isfile(archive_path):
-            raise ExtractError("Archive verification failed: file not found: {}".format(archive_path))
+            raise ExtractError(f"Archive verification failed: file not found: {archive_path}")
 
         file_size = os.path.getsize(archive_path)
         if file_size == 0:
-            raise ExtractError("Archive verification failed: empty file: {}".format(archive_path))
+            raise ExtractError(f"Archive verification failed: empty file: {archive_path}")
 
         try:
             result = subprocess.run(
                 ["7z", "t", "--", archive_path], capture_output=True, text=True, timeout=Extract._7Z_TIMEOUT_SECS
             )
         except subprocess.TimeoutExpired:
-            raise ExtractError(
-                "Archive verification timed out after {}s: {}".format(Extract._7Z_TIMEOUT_SECS, archive_path)
-            )
+            raise ExtractError(f"Archive verification timed out after {Extract._7Z_TIMEOUT_SECS}s: {archive_path}")
         except FileNotFoundError:
             raise ExtractError("7z binary not found; cannot verify archive")
 
@@ -123,11 +121,11 @@ class Extract:
         Supports all formats handled by 7z: zip, rar, 7z, tar, gz, bz2, xz, and more.
         """
         if not os.path.isfile(archive_path):
-            raise ExtractError("Path is not a valid archive: {}".format(archive_path))
+            raise ExtractError(f"Path is not a valid archive: {archive_path}")
 
         fmt = Extract._detect_format(archive_path)
         if fmt is None:
-            raise ExtractError("Path is not a valid archive: {}".format(archive_path))
+            raise ExtractError(f"Path is not a valid archive: {archive_path}")
 
         try:
             if not os.path.exists(out_dir_path):
@@ -161,9 +159,7 @@ class Extract:
                     common = None
                 if common != real_out_dir:
                     raise ExtractError(
-                        "Zip-slip detected: extracted path '{}' escapes target directory '{}'".format(
-                            full_path, real_out_dir
-                        )
+                        f"Zip-slip detected: extracted path '{full_path}' escapes target directory '{real_out_dir}'"
                     )
 
     @staticmethod
@@ -177,7 +173,7 @@ class Extract:
                 timeout=Extract._7Z_TIMEOUT_SECS,
             )
         except subprocess.TimeoutExpired:
-            raise ExtractError("7z timed out after {}s: {}".format(Extract._7Z_TIMEOUT_SECS, archive_path))
+            raise ExtractError(f"7z timed out after {Extract._7Z_TIMEOUT_SECS}s: {archive_path}")
         except FileNotFoundError:
             raise ExtractError("7z binary not found; cannot extract archive")
 

--- a/src/python/controller/extract/extract_process.py
+++ b/src/python/controller/extract/extract_process.py
@@ -51,14 +51,14 @@ class ExtractProcess(AppProcess):
             self.failed_queue = failed_queue
 
         def extract_completed(self, name: str, is_dir: bool, pair_id: str | None = None):
-            self.logger.info("Extraction completed for {}".format(name))
+            self.logger.info(f"Extraction completed for {name}")
             completed_result = ExtractCompletedResult(
                 timestamp=datetime.now(), name=name, is_dir=is_dir, pair_id=pair_id
             )
             self.completed_queue.put(completed_result)
 
         def extract_failed(self, name: str, is_dir: bool, pair_id: str | None = None):
-            self.logger.error("Extraction failed for {}".format(name))
+            self.logger.error(f"Extraction failed for {name}")
             failed_result = ExtractFailedResult(timestamp=datetime.now(), name=name, is_dir=is_dir, pair_id=pair_id)
             self.failed_queue.put(failed_result)
 

--- a/src/python/controller/model_builder.py
+++ b/src/python/controller/model_builder.py
@@ -437,14 +437,10 @@ class ModelBuilder:
                     model_file.state = ModelFile.State.EXTRACTING
                 else:
                     if model_file.local_size is None:
-                        self.logger.warning(
-                            "File {} has extract status but doesn't exist locally!".format(model_file.name)
-                        )
+                        self.logger.warning(f"File {model_file.name} has extract status but doesn't exist locally!")
                     else:
                         self.logger.warning(
-                            "File {} has extract status but is in state {}".format(
-                                model_file.name, str(model_file.state)
-                            )
+                            f"File {model_file.name} has extract status but is in state {str(model_file.state)}"
                         )
 
             # next we check if root is Extracted
@@ -475,7 +471,7 @@ class ModelBuilder:
                     model_file.state = ModelFile.State.VALIDATING
                 else:
                     self.logger.warning(
-                        "File {} has validate status but is in state {}".format(model_file.name, str(model_file.state))
+                        f"File {model_file.name} has validate status but is in state {str(model_file.state)}"
                     )
 
             # next we check if root is Validated

--- a/src/python/controller/move/move_process.py
+++ b/src/python/controller/move/move_process.py
@@ -48,10 +48,10 @@ class MoveProcess(AppOneShotProcess):
         dst = os.path.join(self.__dest_path, self.__file_name)
 
         if not os.path.exists(src):
-            self.logger.error("Move failed: source does not exist: {}".format(src))
+            self.logger.error(f"Move failed: source does not exist: {src}")
             return
 
-        self.logger.info("Moving {} -> {}".format(src, dst))
+        self.logger.info(f"Moving {src} -> {dst}")
 
         # Ensure destination parent directory exists
         os.makedirs(self.__dest_path, exist_ok=True)
@@ -59,7 +59,7 @@ class MoveProcess(AppOneShotProcess):
         # Try rename first (instant on same filesystem)
         try:
             os.rename(src, dst)
-            self.logger.info("Move completed via rename: {}".format(self.__file_name))
+            self.logger.info(f"Move completed via rename: {self.__file_name}")
             return
         except OSError as e:
             if e.errno == errno.EXDEV:
@@ -79,9 +79,7 @@ class MoveProcess(AppOneShotProcess):
 
         if source_size != dest_size:
             self.logger.error(
-                "Move size verification failed for {}: source={} dest={}. Source NOT deleted.".format(
-                    self.__file_name, source_size, dest_size
-                )
+                f"Move size verification failed for {self.__file_name}: source={source_size} dest={dest_size}. Source NOT deleted."
             )
             return
 
@@ -91,4 +89,4 @@ class MoveProcess(AppOneShotProcess):
         else:
             shutil.rmtree(src)
 
-        self.logger.info("Move completed via copy+delete: {}".format(self.__file_name))
+        self.logger.info(f"Move completed via copy+delete: {self.__file_name}")

--- a/src/python/controller/scan/active_scanner.py
+++ b/src/python/controller/scan/active_scanner.py
@@ -64,5 +64,5 @@ class ActiveScanner(IScanner):
                 if "does not exist" in error_str:
                     self.logger.debug(error_str)
                 else:
-                    self.logger.warning("Unexpected scan error for '{}': {}".format(file_name, error_str))
+                    self.logger.warning(f"Unexpected scan error for '{file_name}': {error_str}")
         return result

--- a/src/python/controller/scan/local_scanner.py
+++ b/src/python/controller/scan/local_scanner.py
@@ -30,7 +30,7 @@ class LocalScanner(IScanner):
         # If the scan path doesn't exist yet (e.g. staging directory not created),
         # return empty results instead of crashing the scanner process
         if not os.path.isdir(self.__local_path):
-            self.logger.warning("Scan path does not exist: {}".format(self.__local_path))
+            self.logger.warning(f"Scan path does not exist: {self.__local_path}")
             return []
         try:
             result = self.__scanner.scan()

--- a/src/python/controller/scan/remote_scanner.py
+++ b/src/python/controller/scan/remote_scanner.py
@@ -66,7 +66,7 @@ class RemoteScanner(IScanner):
             data = json.loads(out)
             remote_files = [SystemFile.from_dict(d) for d in data]
         except (json.JSONDecodeError, KeyError, TypeError, ValueError, AttributeError) as err:
-            self.logger.error("JSON parse error: {}\n{}".format(str(err), out[:500]))
+            self.logger.error(f"JSON parse error: {str(err)}\n{out[:500]}")
             raise ScannerError(
                 Localization.Error.REMOTE_SERVER_SCAN.format("Invalid JSON data from scanner"), recoverable=False
             )
@@ -85,32 +85,24 @@ class RemoteScanner(IScanner):
                 # (for $HOME expansion), single quotes otherwise
                 if self.__remote_path_to_scan.startswith("~"):
                     return self.__ssh.shell(
-                        "{} {} {}".format(
-                            _escape_remote_path_double(self.__remote_python_cmd),
-                            _escape_remote_path_double(self.__remote_path_to_scan_script),
-                            _escape_remote_path_double(self.__remote_path_to_scan),
-                        )
+                        f"{_escape_remote_path_double(self.__remote_python_cmd)} {_escape_remote_path_double(self.__remote_path_to_scan_script)} {_escape_remote_path_double(self.__remote_path_to_scan)}"
                     )
                 else:
                     return self.__ssh.shell(
-                        "{} {} {}".format(
-                            _escape_remote_path_single(self.__remote_python_cmd),
-                            _escape_remote_path_single(self.__remote_path_to_scan_script),
-                            _escape_remote_path_single(self.__remote_path_to_scan),
-                        )
+                        f"{_escape_remote_path_single(self.__remote_python_cmd)} {_escape_remote_path_single(self.__remote_path_to_scan_script)} {_escape_remote_path_single(self.__remote_path_to_scan)}"
                     )
             except SshcpError as e:
                 last_error = e
                 error_str = str(e)
-                self.logger.warning("Scan attempt {}/{} failed: {}".format(attempt, self._SCAN_MAX_RETRIES, error_str))
+                self.logger.warning(f"Scan attempt {attempt}/{self._SCAN_MAX_RETRIES} failed: {error_str}")
 
                 # Non-recoverable errors: don't retry
                 if "Is a directory" in error_str:
                     raise ScannerError(
-                        "Server Script Path '{}' is a directory on the remote server. "
+                        f"Server Script Path '{self.__remote_path_to_scan_script}' is a directory on the remote server. "
                         "Change the 'Server Script Path' setting to a writable location "
                         "outside your sync tree (e.g. '~' or '~/.local') and remove the "
-                        "conflicting directory from the remote server.".format(self.__remote_path_to_scan_script),
+                        "conflicting directory from the remote server.",
                         recoverable=False,
                     )
 
@@ -127,11 +119,11 @@ class RemoteScanner(IScanner):
 
                 # Retry transient errors
                 if attempt < self._SCAN_MAX_RETRIES:
-                    self.logger.info("Retrying in {}s...".format(self._SCAN_RETRY_DELAY_SECS))
+                    self.logger.info(f"Retrying in {self._SCAN_RETRY_DELAY_SECS}s...")
                     time.sleep(self._SCAN_RETRY_DELAY_SECS)
 
         # All retries exhausted
-        self.logger.error("All {} scan attempts failed".format(self._SCAN_MAX_RETRIES))
+        self.logger.error(f"All {self._SCAN_MAX_RETRIES} scan attempts failed")
         raise ScannerError(Localization.Error.REMOTE_SERVER_SCAN.format(str(last_error).strip()), recoverable=True)
 
     @staticmethod
@@ -160,22 +152,18 @@ class RemoteScanner(IScanner):
                 home = self.__ssh.shell("echo ~").decode().strip()
                 if home and not home.startswith("~"):
                     expanded = home + self.__remote_path_to_scan_script[1:]
-                    self.logger.debug(
-                        "Resolved script path '{}' -> '{}'".format(self.__remote_path_to_scan_script, expanded)
-                    )
+                    self.logger.debug(f"Resolved script path '{self.__remote_path_to_scan_script}' -> '{expanded}'")
                     self.__remote_path_to_scan_script = expanded
             except SshcpError as e:
-                self.logger.warning("Could not resolve tilde in script path: {}".format(str(e)))
+                self.logger.warning(f"Could not resolve tilde in script path: {str(e)}")
 
         # Check md5sum on remote to see if we can skip installation
         with open(self.__local_path_to_scan_script, "rb") as f:
             local_md5sum = hashlib.md5(f.read()).hexdigest()
-        self.logger.debug("Local scanfs md5sum = {}".format(local_md5sum))
+        self.logger.debug(f"Local scanfs md5sum = {local_md5sum}")
         try:
             out = self.__ssh.shell(
-                "md5sum {} | awk '{{print $1}}' || echo".format(
-                    _escape_remote_path_single(self.__remote_path_to_scan_script)
-                )
+                f"md5sum {_escape_remote_path_single(self.__remote_path_to_scan_script)} | awk '{{print $1}}' || echo"
             )
             out = out.decode().strip()
             if out == local_md5sum:
@@ -192,35 +180,31 @@ class RemoteScanner(IScanner):
         try:
             result = (
                 self.__ssh.shell(
-                    "[ -d {} ] && echo IS_DIRECTORY || echo OK".format(
-                        _escape_remote_path_single(self.__remote_path_to_scan_script)
-                    )
+                    f"[ -d {_escape_remote_path_single(self.__remote_path_to_scan_script)} ] && echo IS_DIRECTORY || echo OK"
                 )
                 .decode()
                 .strip()
             )
             if result == "IS_DIRECTORY":
                 raise ScannerError(
-                    "Server Script Path '{}' is a directory on the remote server. "
+                    f"Server Script Path '{self.__remote_path_to_scan_script}' is a directory on the remote server. "
                     "This usually means it overlaps with your sync directory. "
                     "Change the 'Server Script Path' setting to a writable location "
                     "outside your sync tree (e.g. '~' or '~/.local') and remove the "
-                    "conflicting directory from the remote server.".format(self.__remote_path_to_scan_script),
+                    "conflicting directory from the remote server.",
                     recoverable=False,
                 )
         except SshcpError as e:
-            self.logger.warning("Could not check remote path type: {}".format(str(e)))
+            self.logger.warning(f"Could not check remote path type: {str(e)}")
 
         # Go ahead and install
         self.logger.info(
-            "Installing local:{} to remote:{}".format(
-                self.__local_path_to_scan_script, self.__remote_path_to_scan_script
-            )
+            f"Installing local:{self.__local_path_to_scan_script} to remote:{self.__remote_path_to_scan_script}"
         )
         if not os.path.isfile(self.__local_path_to_scan_script):
             raise ScannerError(
                 Localization.Error.REMOTE_SERVER_SCAN.format(
-                    "Failed to find scan script at {}".format(self.__local_path_to_scan_script)
+                    f"Failed to find scan script at {self.__local_path_to_scan_script}"
                 ),
                 recoverable=False,
             )
@@ -255,9 +239,7 @@ class RemoteScanner(IScanner):
             pass
 
         self.logger.warning(
-            "Script path '{}' is not writable (Permission denied). Retrying with home directory: '{}'".format(
-                self.__remote_path_to_scan_script, fallback_path
-            )
+            f"Script path '{self.__remote_path_to_scan_script}' is not writable (Permission denied). Retrying with home directory: '{fallback_path}'"
         )
         self.logger.warning("Update 'Server Script Path' in Settings to '~' to avoid this fallback on restart.")
 
@@ -265,36 +247,29 @@ class RemoteScanner(IScanner):
         # the script inside it and execution would fail with "Is a directory".
         try:
             result = (
-                self.__ssh.shell(
-                    "[ -d {} ] && echo IS_DIRECTORY || echo OK".format(_escape_remote_path_single(fallback_path))
-                )
+                self.__ssh.shell(f"[ -d {_escape_remote_path_single(fallback_path)} ] && echo IS_DIRECTORY || echo OK")
                 .decode()
                 .strip()
             )
             if result == "IS_DIRECTORY":
                 raise ScannerError(
-                    "Fallback script path '{}' is already a directory on the remote server. "
+                    f"Fallback script path '{fallback_path}' is already a directory on the remote server. "
                     "Remove it and update 'Server Script Path' in Settings to a writable "
                     "location (e.g. '~' or '~/.local'). "
-                    "Original error: {}".format(fallback_path, original_error.strip()),
+                    f"Original error: {original_error.strip()}",
                     recoverable=False,
                 )
         except SshcpError as e:
-            self.logger.warning("Could not check fallback path type: {}".format(str(e)))
+            self.logger.warning(f"Could not check fallback path type: {str(e)}")
 
         try:
             self.__ssh.copy(local_path=self.__local_path_to_scan_script, remote_path=fallback_path)
             self.__remote_path_to_scan_script = fallback_path
-            self.logger.info("Scanner installed to fallback path: {}".format(fallback_path))
+            self.logger.info(f"Scanner installed to fallback path: {fallback_path}")
         except SshcpError as fallback_e:
             raise ScannerError(
                 Localization.Error.REMOTE_SERVER_INSTALL.format(
-                    "Could not install scanner to '{}' ({}), fallback to '{}' also failed: {}".format(
-                        self.__remote_path_to_scan_script,
-                        original_error.strip(),
-                        fallback_path,
-                        str(fallback_e).strip(),
-                    )
+                    f"Could not install scanner to '{self.__remote_path_to_scan_script}' ({original_error.strip()}), fallback to '{fallback_path}' also failed: {str(fallback_e).strip()}"
                 ),
                 recoverable=False,
             )

--- a/src/python/controller/scan/scanner_process.py
+++ b/src/python/controller/scan/scanner_process.py
@@ -98,7 +98,7 @@ class ScannerProcess(AppProcess):
         delta_in_s = (datetime.now() - timestamp_start).total_seconds()
         delta_in_ms = int(delta_in_s * 1000)
         if self.verbose:
-            self.logger.debug("Scan took {:.3f}s".format(delta_in_s))
+            self.logger.debug(f"Scan took {delta_in_s:.3f}s")
 
         # Wait until the next interval, or until a wake event is fired
         if delta_in_ms < self.__interval_in_ms:

--- a/src/python/controller/validate/validate_process.py
+++ b/src/python/controller/validate/validate_process.py
@@ -134,7 +134,7 @@ class ValidateProcess(AppProcess):
                 req = self.__command_queue.get(block=False)
                 key = (req.pair_id, req.name)
                 if key in self.__active_validations:
-                    self.logger.warning("Validation already in progress for {}".format(req.name))
+                    self.logger.warning(f"Validation already in progress for {req.name}")
                     continue
                 self.__active_validations[key] = req
         except queue.Empty:
@@ -169,7 +169,7 @@ class ValidateProcess(AppProcess):
                 )
                 self.__completed_result_queue.put(completed)
             except ChecksumMismatchError as e:
-                self.logger.error("Checksum mismatch for {}: {}".format(req.name, str(e)))
+                self.logger.error(f"Checksum mismatch for {req.name}: {str(e)}")
                 failed = ValidateFailedResult(
                     timestamp=datetime.datetime.now(),
                     name=req.name,
@@ -180,7 +180,7 @@ class ValidateProcess(AppProcess):
                 )
                 self.__failed_result_queue.put(failed)
             except Exception as e:
-                self.logger.error("Validation failed for {}: {}".format(req.name, str(e)))
+                self.logger.error(f"Validation failed for {req.name}: {str(e)}")
                 failed = ValidateFailedResult(
                     timestamp=datetime.datetime.now(),
                     name=req.name,
@@ -212,25 +212,25 @@ class ValidateProcess(AppProcess):
         file_path = os.path.join(req.local_path, req.name)
 
         if req.algorithm not in _ALLOWED_ALGORITHMS:
-            raise ValueError("Unsupported hash algorithm: {}".format(req.algorithm))
+            raise ValueError(f"Unsupported hash algorithm: {req.algorithm}")
 
         if not os.path.exists(file_path):
-            raise FileNotFoundError("Local path does not exist: {}".format(file_path))
+            raise FileNotFoundError(f"Local path does not exist: {file_path}")
 
         sshcp = self._create_ssh(req)
 
         if req.is_dir:
             if not os.path.isdir(file_path):
-                raise ValueError("Expected directory but found file: {}".format(file_path))
+                raise ValueError(f"Expected directory but found file: {file_path}")
             self._validate_directory(req, file_path, sshcp)
         else:
             local_hash = self._hash_local_file(file_path, req.algorithm)
             remote_hash = self._hash_remote_file(req, req.name, req.algorithm, sshcp)
             if not hmac.compare_digest(local_hash, remote_hash):
                 raise ChecksumMismatchError(
-                    "Checksum mismatch for {}: local={} remote={}".format(req.name, local_hash, remote_hash)
+                    f"Checksum mismatch for {req.name}: local={local_hash} remote={remote_hash}"
                 )
-            self.logger.info("Validated {}: {}".format(req.name, local_hash))
+            self.logger.info(f"Validated {req.name}: {local_hash}")
 
     def _validate_directory(self, req: ValidateRequest, local_dir: str, sshcp: Sshcp) -> None:
         """Validate all files in a directory by comparing local and remote checksums.
@@ -250,7 +250,7 @@ class ValidateProcess(AppProcess):
         # Build remote file set via SSH find
         remote_dir = os.path.join(req.remote_path, req.name)
         quoted_dir = shlex.quote(remote_dir)
-        find_cmd = "find {} -type f".format(quoted_dir)
+        find_cmd = f"find {quoted_dir} -type f"
         try:
             find_output = sshcp.shell(find_cmd)
             remote_abs_paths = find_output.decode().strip().split("\n")
@@ -261,7 +261,7 @@ class ValidateProcess(AppProcess):
                     rel = os.path.relpath(abs_path, req.remote_path)
                     remote_rel_paths.add(rel)
         except Exception as e:
-            raise ValueError("Failed to list remote directory {}: {}".format(remote_dir, str(e))) from e
+            raise ValueError(f"Failed to list remote directory {remote_dir}: {str(e)}") from e
 
         # Validate the union of both sets
         all_paths = local_rel_paths | remote_rel_paths
@@ -273,27 +273,25 @@ class ValidateProcess(AppProcess):
             is_remote = rel_path in remote_rel_paths
 
             if is_local and not is_remote:
-                mismatches.append("Local-only file: {}".format(rel_path))
+                mismatches.append(f"Local-only file: {rel_path}")
                 continue
             if is_remote and not is_local:
-                mismatches.append("Remote-only file: {}".format(rel_path))
+                mismatches.append(f"Remote-only file: {rel_path}")
                 continue
 
             # Both exist — compare hashes
             local_hash = self._hash_local_file(local_file, req.algorithm)
             remote_hash = self._hash_remote_file(req, rel_path, req.algorithm, sshcp)
             if not hmac.compare_digest(local_hash, remote_hash):
-                mismatches.append(
-                    "Checksum mismatch for {}: local={} remote={}".format(rel_path, local_hash, remote_hash)
-                )
+                mismatches.append(f"Checksum mismatch for {rel_path}: local={local_hash} remote={remote_hash}")
             else:
-                self.logger.debug("Validated file {}: {}".format(rel_path, local_hash))
+                self.logger.debug(f"Validated file {rel_path}: {local_hash}")
 
         if mismatches:
             raise ChecksumMismatchError(
                 "Directory validation failed for {}: {}".format(req.name, "; ".join(mismatches))
             )
-        self.logger.info("Validated directory {}".format(req.name))
+        self.logger.info(f"Validated directory {req.name}")
 
     @staticmethod
     def _hash_local_file(file_path: str, algorithm: str) -> str:
@@ -326,13 +324,13 @@ class ValidateProcess(AppProcess):
     def _build_hash_cmd(algorithm: str, quoted_file: str) -> str:
         """Build the remote hash command for the given algorithm."""
         if algorithm == "md5":
-            return "md5sum {}".format(quoted_file)
+            return f"md5sum {quoted_file}"
         elif algorithm == "sha256":
-            return "sha256sum {}".format(quoted_file)
+            return f"sha256sum {quoted_file}"
         elif algorithm == "sha1":
-            return "sha1sum {}".format(quoted_file)
+            return f"sha1sum {quoted_file}"
         else:
-            raise ValueError("Unsupported algorithm: {}".format(algorithm))
+            raise ValueError(f"Unsupported algorithm: {algorithm}")
 
     def _hash_remote_file(self, req: ValidateRequest, rel_path: str, algorithm: str, sshcp: Sshcp) -> str:
         """Compute hash of a remote file via SSH."""
@@ -345,9 +343,7 @@ class ValidateProcess(AppProcess):
         decoded = output.decode().strip()
         parts = decoded.split()
         if not parts:
-            raise ValueError(
-                "Empty or unexpected output from remote hash command for {}: {!r}".format(rel_path, decoded)
-            )
+            raise ValueError(f"Empty or unexpected output from remote hash command for {rel_path}: {decoded!r}")
         return parts[0]
 
     @overrides(AppProcess)

--- a/src/python/lftp/job_status_parser.py
+++ b/src/python/lftp/job_status_parser.py
@@ -47,15 +47,15 @@ class LftpJobStatusParser:
         """
         if size == "0":
             return 0
-        m = re.compile(r"(?P<number>\d+\.?\d*)\s*(?P<units>{})?".format(LftpJobStatusParser.__SIZE_UNITS_REGEX))
+        m = re.compile(rf"(?P<number>\d+\.?\d*)\s*(?P<units>{LftpJobStatusParser.__SIZE_UNITS_REGEX})?")
         result = m.search(size)
         if not result:
-            raise ValueError("String '{}' does not match the size pattern".format(size))
+            raise ValueError(f"String '{size}' does not match the size pattern")
         number = float(result.group("number"))
         unit = (result.group("units") or "b")[0].lower()
         multipliers = {"b": 1, "k": 1024, "m": 1024 * 1024, "g": 1024 * 1024 * 1024}
         if unit not in multipliers.keys():
-            raise ValueError("Unrecognized unit {} in size string '{}'".format(unit, size))
+            raise ValueError(f"Unrecognized unit {unit} in size string '{size}'")
         return int(number * multipliers[unit])
 
     @staticmethod
@@ -68,7 +68,7 @@ class LftpJobStatusParser:
         m = re.compile(LftpJobStatusParser.__TIME_UNITS_REGEX)
         result = m.search(eta)
         if not result:
-            raise ValueError("String '{}' does not match the eta pattern".format(eta))
+            raise ValueError(f"String '{eta}' does not match the eta pattern")
         # the [:-1] below remove the last character
         eta_d = int((result.group("eta_d") or "0d")[:-1])
         eta_h = int((result.group("eta_h") or "0h")[:-1])
@@ -113,8 +113,8 @@ class LftpJobStatusParser:
             statuses += self.__parse_queue(lines)
             statuses += self.__parse_jobs(lines)
         except ValueError as e:
-            self.logger.error("LftpJobStateParser error: {}".format(str(e)))
-            self.logger.error("Status:\n{}".format(output))
+            self.logger.error(f"LftpJobStateParser error: {str(e)}")
+            self.logger.error(f"Status:\n{output}")
             raise LftpJobStatusParserError("Error parsing lftp job status")
         return statuses
 
@@ -141,12 +141,12 @@ class LftpJobStatusParser:
             r"(?P<lq>['\"]|)(?P<remote>.+)(?P=lq)\s+"  # greedy on purpose
             r"(?P<rq>['\"]|)(?P<local>.+)(?P=rq)\s+"  # greedy on purpose
             r"--\s+"
-            r"(?P<szlocal>\d+\.?\d*\s?({sz})?)"  # size=0 has no units
+            rf"(?P<szlocal>\d+\.?\d*\s?({LftpJobStatusParser.__SIZE_UNITS_REGEX})?)"  # size=0 has no units
             r"\/"
-            r"(?P<szremote>\d+\.?\d*\s?({sz})?)\s+"  # size=0 has no units
+            rf"(?P<szremote>\d+\.?\d*\s?({LftpJobStatusParser.__SIZE_UNITS_REGEX})?)\s+"  # size=0 has no units
             r"\((?P<pctlocal>\d+)%\)"
-            r"(\s+(?P<speed>\d+\.?\d*\s?({sz}))\/s)?$"
-        ).format(sz=LftpJobStatusParser.__SIZE_UNITS_REGEX)
+            rf"(\s+(?P<speed>\d+\.?\d*\s?({LftpJobStatusParser.__SIZE_UNITS_REGEX}))\/s)?$"
+        )
         mirror_header_m = re.compile(mirror_header_pattern)
 
         # mirror header (connecting or receiving file list)
@@ -226,12 +226,9 @@ class LftpJobStatusParser:
         #   "3.0K/s eta:3m [Receiving data]"
         #   "10M/s eta:1h2m [Making data connection]"
         orphan_progress_pattern = (
-            r"^(?:\d+\.?\d*\s?({sz}))\/s\s+"
-            r"eta:({eta})\s+"
+            rf"^(?:\d+\.?\d*\s?({LftpJobStatusParser.__SIZE_UNITS_REGEX}))\/s\s+"
+            rf"eta:({LftpJobStatusParser.__TIME_UNITS_REGEX})\s+"
             r"\[.*\]$"
-        ).format(
-            sz=LftpJobStatusParser.__SIZE_UNITS_REGEX,
-            eta=LftpJobStatusParser.__TIME_UNITS_REGEX,
         )
         orphan_progress_m = re.compile(orphan_progress_pattern)
 
@@ -239,9 +236,9 @@ class LftpJobStatusParser:
         #   "/s eta:25m [Receiving data]"  (tail of "347.3K/s eta:25m ...")
         partial_progress_pattern = (
             r"^\/s\s+"
-            r"eta:({eta})\s+"
+            rf"eta:({LftpJobStatusParser.__TIME_UNITS_REGEX})\s+"
             r"\[.*\]$"
-        ).format(eta=LftpJobStatusParser.__TIME_UNITS_REGEX)
+        )
         partial_progress_m = re.compile(partial_progress_pattern)
 
         # Chunk line-wrap fragments: long filenames cause lftp chunk progress
@@ -252,12 +249,9 @@ class LftpJobStatusParser:
         chunk_wrap_pattern = (
             r"^(?:[^`\\].*)?'\s+at\s+\d+\s+"
             r"(?:\(\d+%\)\s+)?"
-            r"(?:(?:\d+\.?\d*\s?({sz}))\/s\s+)?"
-            r"(?:eta:({eta})\s+)?"
+            rf"(?:(?:\d+\.?\d*\s?({LftpJobStatusParser.__SIZE_UNITS_REGEX}))\/s\s+)?"
+            rf"(?:eta:({LftpJobStatusParser.__TIME_UNITS_REGEX})\s+)?"
             r"\s*\[.*\]$"
-        ).format(
-            sz=LftpJobStatusParser.__SIZE_UNITS_REGEX,
-            eta=LftpJobStatusParser.__TIME_UNITS_REGEX,
         )
         chunk_wrap_m = re.compile(chunk_wrap_pattern)
 
@@ -274,14 +268,14 @@ class LftpJobStatusParser:
                 if orphan_progress_m.match(line) or partial_progress_m.match(line) or chunk_wrap_m.match(line):
                     self.logger.warning("Skipping orphan lftp progress line: '%s'", line)
                     continue
-                raise ValueError("First line is not a matching header '{}'".format(line))
+                raise ValueError(f"First line is not a matching header '{line}'")
 
             # Search for pget header
             result = pget_header_m.search(line)
             if result:
                 # Next line must be the sftp line
                 if len(lines) < 1 or "sftp" not in lines[0]:
-                    raise ValueError("Missing the 'sftp' line for pget header '{}'".format(line))
+                    raise ValueError(f"Missing the 'sftp' line for pget header '{line}'")
                 lines.pop(0)  # pop the 'sftp' line
 
                 # Data line may not exist
@@ -334,9 +328,7 @@ class LftpJobStatusParser:
                 elif result_got:
                     got_group_basename = os.path.basename(os.path.normpath(result_got.group("name")))
                     if got_group_basename != name:
-                        raise ValueError(
-                            "Mismatch: filename '{}' but chunk data for '{}'".format(name, got_group_basename)
-                        )
+                        raise ValueError(f"Mismatch: filename '{name}' but chunk data for '{got_group_basename}'")
                     size_local = int(result_got.group("szlocal"))
                     size_remote = int(result_got.group("szremote"))
                     percent_local = int(result_got.group("pctlocal"))
@@ -409,7 +401,7 @@ class LftpJobStatusParser:
             if result:
                 name = result.group("name")
                 if not lines:
-                    raise ValueError("Missing chunk data for filename '{}'".format(name))
+                    raise ValueError(f"Missing chunk data for filename '{name}'")
                 line = lines.pop(0)
                 result_at = chunk_at_m.search(line)
                 result_at2 = chunk_at2_m.search(line)
@@ -458,7 +450,7 @@ class LftpJobStatusParser:
                     assert prev_job is not None
                     prev_job.add_active_file_transfer_state(name, file_status)
                 else:
-                    raise ValueError("Missing chunk data for filename '{}'".format(name))
+                    raise ValueError(f"Missing chunk data for filename '{name}'")
                 # Continue the outer loop
                 continue
 
@@ -479,7 +471,7 @@ class LftpJobStatusParser:
                     if (
                         "Getting file list" in lines[0]
                         or lines[0].startswith("cd ")
-                        or lines[0] == "{}:".format(name)
+                        or lines[0] == f"{name}:"
                         or lines[0].startswith("mkdir ")
                     ):
                         lines.pop(0)
@@ -501,14 +493,14 @@ class LftpJobStatusParser:
                 name = result.group("name")
                 # Also ignore the next one or two lines
                 if not lines or not lines[0].startswith("file:"):
-                    raise ValueError("Missing 'file:' line for chmod '{}'".format(name))
+                    raise ValueError(f"Missing 'file:' line for chmod '{name}'")
                 lines.pop(0)
                 if lines:
                     result_chmod = chmod_pattern_m.search(lines[0])
                     if result_chmod:
                         name_chmod = result_chmod.group("name")
                         if name != name_chmod:
-                            raise ValueError("Mismatch in names chmod '{}'".format(name))
+                            raise ValueError(f"Mismatch in names chmod '{name}'")
                         lines.pop(0)
                 # Continue the outer loop
                 continue
@@ -536,7 +528,7 @@ class LftpJobStatusParser:
 
             # Truly unrecognized line outside any job — raise so the caller
             # can track consecutive errors and decide whether to propagate
-            raise ValueError("Unable to parse line '{}'".format(line))
+            raise ValueError(f"Unable to parse line '{line}'")
         return jobs
 
     @staticmethod
@@ -555,9 +547,7 @@ class LftpJobStatusParser:
             if len(lines) < 2:
                 # Not enough lines for a valid queue header - return empty queue
                 return queue
-            header1_pattern = r"^\[\d+\] queue \(sftp://.*@.*\)(?:\s+--\s+(?:\d+\.\d+|\d+)\s({})\/s)?$".format(
-                LftpJobStatusParser.__SIZE_UNITS_REGEX
-            )
+            header1_pattern = rf"^\[\d+\] queue \(sftp://.*@.*\)(?:\s+--\s+(?:\d+\.\d+|\d+)\s({LftpJobStatusParser.__SIZE_UNITS_REGEX})\/s)?$"
             header2_pattern = "^sftp://.*@.*$"
             line = lines.pop(0)
             if not re.match(header1_pattern, line):
@@ -622,7 +612,7 @@ class LftpJobStatusParser:
                             type_ = LftpJobStatus.Type.MIRROR
                             result = result_mirror
                         else:
-                            raise ValueError("Failed to parse queue line: {}".format(line))
+                            raise ValueError(f"Failed to parse queue line: {line}")
                         id_ = int(result.group("id"))
                         name = os.path.basename(os.path.normpath(result.group("remote")))
                         flags = result.group("flags")

--- a/src/python/lftp/lftp.py
+++ b/src/python/lftp/lftp.py
@@ -70,7 +70,7 @@ class Lftp:
         self.__base_remote_dir_path = ""
         self.__base_local_dir_path = ""
         self.logger = logging.getLogger("Lftp")
-        self.__expect_pattern = "lftp {}@{}:.*>".format(self.__user, self.__address)
+        self.__expect_pattern = f"lftp {self.__user}@{self.__address}:.*>"
         self.__job_status_parser = LftpJobStatusParser()
         self.__timeout = 10  # in seconds
         self.__consecutive_status_errors = 0
@@ -95,7 +95,7 @@ class Lftp:
             str(self.__port),
             "-u",
             "{},{}".format(self.__user, self.__password if self.__password else ""),
-            "sftp://{}".format(self.__address),
+            f"sftp://{self.__address}",
         ]
         # Force a wide terminal so LFTP never wraps 'jobs -v' output.
         # Belt-and-suspenders: set COLUMNS in the environment (which LFTP
@@ -123,7 +123,7 @@ class Lftp:
         self.__spawn_process()
         # Replay cached settings
         for setting, value in self.__settings_cache.items():
-            self.__run_command("set {} {}".format(setting, value))  # type: ignore[arg-type]
+            self.__run_command(f"set {setting} {value}")  # type: ignore[arg-type]
         self.__consecutive_timeouts = 0
 
     def __setup(self):
@@ -195,12 +195,10 @@ class Lftp:
 
         if timed_out:
             self.__consecutive_timeouts += 1
-            self.logger.warning(
-                "Lftp timeout on command (consecutive timeouts: {})".format(self.__consecutive_timeouts)
-            )
+            self.logger.warning(f"Lftp timeout on command (consecutive timeouts: {self.__consecutive_timeouts})")
             if self.__consecutive_timeouts >= MAX_CONSECUTIVE_TIMEOUTS:
                 self.__restart_process()
-                raise LftpError("lftp process restarted after {} consecutive timeouts".format(MAX_CONSECUTIVE_TIMEOUTS))
+                raise LftpError(f"lftp process restarted after {MAX_CONSECUTIVE_TIMEOUTS} consecutive timeouts")
             # Return empty string to prevent parsing corrupted buffer output
             return ""
 
@@ -212,13 +210,13 @@ class Lftp:
         out = out.strip()  # remove any CRs
 
         if self.__log_command_output:
-            self.logger.debug("out ({} bytes):\n {}".format(len(out), out))
+            self.logger.debug(f"out ({len(out)} bytes):\n {out}")
             after_val = self.__process.after
             if isinstance(after_val, bytes):
                 after = after_val.decode("utf8", "replace").strip()
             else:
                 after = ""
-            self.logger.debug("after: {}".format(after))
+            self.logger.debug(f"after: {after}")
 
         # let's try and detect some errors
         if self.__detect_errors_from_output(out):
@@ -236,14 +234,14 @@ class Lftp:
             out = before.decode("utf8", "replace")
             out = out.strip()  # remove any CRs
             if self.__log_command_output:
-                self.logger.debug("retry out ({} bytes):\n {}".format(len(out), out))
+                self.logger.debug(f"retry out ({len(out)} bytes):\n {out}")
                 after_val = self.__process.after
                 if isinstance(after_val, bytes):
                     after = after_val.decode("utf8", "replace").strip()
                 else:
                     after = ""
-                self.logger.debug("retry after: {}".format(after))
-            self.logger.error("Lftp detected error: {}".format(error_out))
+                self.logger.debug(f"retry after: {after}")
+            self.logger.error(f"Lftp detected error: {error_out}")
             # save pending error
             self.__pending_error = error_out
         return out
@@ -269,7 +267,7 @@ class Lftp:
         :return:
         """
         self.__settings_cache[setting] = value
-        self.__run_command("set {} {}".format(setting, value))  # type: ignore[arg-type]
+        self.__run_command(f"set {setting} {value}")  # type: ignore[arg-type]
 
     def __get(self, setting: str) -> str:
         """
@@ -277,10 +275,10 @@ class Lftp:
         :param setting:
         :return:
         """
-        out = self.__run_command("set -a | grep {}".format(setting))  # type: ignore[arg-type]
-        m = re.search("set {} (.*)".format(setting), out)
+        out = self.__run_command(f"set -a | grep {setting}")  # type: ignore[arg-type]
+        m = re.search(f"set {setting} (.*)", out)
         if not m or not m.group or not m.group(1):  # type: ignore[reportUnnecessaryComparison]
-            raise LftpError("Failed to get setting '{}'. Output: '{}'".format(setting, out))
+            raise LftpError(f"Failed to get setting '{setting}'. Output: '{out}'")
         return m.group(1).strip()
 
     @staticmethod
@@ -291,7 +289,7 @@ class Lftp:
         elif value.lower() in {"false", "off", "no", "0", "-"}:
             return False
         else:
-            raise LftpError("Cannot convert value '{}' to boolean".format(value))
+            raise LftpError(f"Cannot convert value '{value}' to boolean")
 
     @property
     def num_connections_per_dir_file(self) -> int:
@@ -512,7 +510,7 @@ class Lftp:
         # Note: LFTP's --exclude uses regex; --exclude-glob uses glob patterns
         exclude_flags = ""
         if is_dir and exclude_patterns:
-            exclude_flags = " ".join('--exclude-glob "{}"'.format(escape(p)) for p in exclude_patterns)
+            exclude_flags = " ".join(f'--exclude-glob "{escape(p)}"' for p in exclude_patterns)
 
         parts = [
             "queue",
@@ -524,11 +522,9 @@ class Lftp:
             parts.append(exclude_flags)
         parts.extend(
             [
-                '"{remote_dir}/{filename}"'.format(
-                    remote_dir=escape(self.__base_remote_dir_path), filename=escape(name)
-                ),
+                f'"{escape(self.__base_remote_dir_path)}/{escape(name)}"',
                 "-o" if not is_dir else "",
-                '"{local_dir}/"'.format(local_dir=escape(self.__base_local_dir_path)),
+                f'"{escape(self.__base_local_dir_path)}/"',
                 "'",
             ]
         )
@@ -546,26 +542,26 @@ class Lftp:
         job_to_kill = None
         statuses = self.status()
         if statuses is None:
-            self.logger.debug("Kill failed - status unavailable for job '{}'".format(name))
+            self.logger.debug(f"Kill failed - status unavailable for job '{name}'")
             return False
         for status in statuses:
             if status.name == name:
                 job_to_kill = status
                 break
         if job_to_kill is None:
-            self.logger.debug("Kill failed to find job '{}'".format(name))
+            self.logger.debug(f"Kill failed to find job '{name}'")
             return False
         # Note: there's a chance that job ids change between when we called status
         #       and when we execute the kill command
         #       in this case the wrong job may be killed, there's nothing we can do about it
         if job_to_kill.state == LftpJobStatus.State.RUNNING:
-            self.logger.debug("Killing running job '{}'...".format(name))
-            self.__run_command("kill {}".format(job_to_kill.id))  # type: ignore[arg-type]
+            self.logger.debug(f"Killing running job '{name}'...")
+            self.__run_command(f"kill {job_to_kill.id}")  # type: ignore[arg-type]
         elif job_to_kill.state == LftpJobStatus.State.QUEUED:
-            self.logger.debug("Killing queued job '{}'...".format(name))
-            self.__run_command("queue --delete {}".format(job_to_kill.id))  # type: ignore[arg-type]
+            self.logger.debug(f"Killing queued job '{name}'...")
+            self.__run_command(f"queue --delete {job_to_kill.id}")  # type: ignore[arg-type]
         else:
-            raise NotImplementedError("Unsupported state {}".format(str(job_to_kill.state)))
+            raise NotImplementedError(f"Unsupported state {str(job_to_kill.state)}")
         return True
 
     def kill_all(self):

--- a/src/python/model/model.py
+++ b/src/python/model/model.py
@@ -60,21 +60,21 @@ class Model:
     def file_key(file: ModelFile) -> str:
         """Return the unique key for a ModelFile: 'pair_id:name' or just 'name'."""
         if file.pair_id:
-            return "{}:{}".format(file.pair_id, file.name)
+            return f"{file.pair_id}:{file.name}"
         return file.name
 
     @staticmethod
     def make_key(name: str, pair_id: str | None = None) -> str:
         """Build a key from name and optional pair_id."""
         if pair_id:
-            return "{}:{}".format(pair_id, name)
+            return f"{pair_id}:{name}"
         return name
 
     @staticmethod
     def _log_name(name: str, pair_id: str | None = None) -> str:
         """Human-readable name for log messages: 'name [ab12cd34]' or just 'name'."""
         if pair_id:
-            return "{} [{}]".format(name, pair_id[:8])
+            return f"{name} [{pair_id[:8]}]"
         return name
 
     def __init__(self):
@@ -114,7 +114,7 @@ class Model:
         :return:
         """
         key = Model.file_key(file)
-        self.logger.debug("LftpModel: Adding file '{}'".format(Model._log_name(file.name, file.pair_id)))
+        self.logger.debug(f"LftpModel: Adding file '{Model._log_name(file.name, file.pair_id)}'")
         if key in self.__files:
             raise ModelError("File already exists in the model")
         self.__files[key] = file
@@ -129,7 +129,7 @@ class Model:
         :return:
         """
         key = Model.make_key(filename, pair_id)
-        self.logger.debug("LftpModel: Removing file '{}'".format(Model._log_name(filename, pair_id)))
+        self.logger.debug(f"LftpModel: Removing file '{Model._log_name(filename, pair_id)}'")
         if key not in self.__files:
             raise ModelError("File does not exist in the model")
         file = self.__files[key]
@@ -144,7 +144,7 @@ class Model:
         :return:
         """
         key = Model.file_key(file)
-        self.logger.debug("LftpModel: Updating file '{}'".format(Model._log_name(file.name, file.pair_id)))
+        self.logger.debug(f"LftpModel: Updating file '{Model._log_name(file.name, file.pair_id)}'")
         if key not in self.__files:
             raise ModelError("File does not exist in the model")
         old_file = self.__files[key]

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -41,7 +41,6 @@ ignore = [
     "E721",  # type comparison — existing pattern uses type() intentionally
     "E722",  # bare except — one instance in legacy e2e script
     "E741",  # ambiguous variable name — single-letter vars in context
-    "UP032", # f-string — too much churn for auto-fix PR, defer to PR 2
     "UP046", # non-pep695-generic-class — requires Python 3.12+ syntax migration
     "B904",  # raise-without-from — defer to PR 2
     "B905",  # zip-without-explicit-strict — defer to PR 2

--- a/src/python/scan_fs.py
+++ b/src/python/scan_fs.py
@@ -97,9 +97,9 @@ class SystemScanner:
 
     def scan(self) -> "List[SystemFile]":
         if not os.path.exists(self.path_to_scan):
-            raise SystemScannerError("Path does not exist: {}".format(self.path_to_scan))
+            raise SystemScannerError(f"Path does not exist: {self.path_to_scan}")
         elif not os.path.isdir(self.path_to_scan):
-            raise SystemScannerError("Path is not a directory: {}".format(self.path_to_scan))
+            raise SystemScannerError(f"Path is not a directory: {self.path_to_scan}")
         return self.__create_children(self.path_to_scan)
 
     def __create_system_file(self, entry: "os.DirEntry[str]") -> SystemFile:
@@ -201,7 +201,7 @@ if __name__ == "__main__":
     try:
         root_files = scanner.scan()
     except SystemScannerError as e:
-        sys.exit("SystemScannerError: {}".format(str(e)))
+        sys.exit(f"SystemScannerError: {str(e)}")
     if args.human_readable:
 
         def print_file(file: SystemFile, level: int):

--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -71,7 +71,7 @@ class Seedsync:
                 if Seedsync._backfill_config_defaults(config):
                     config.to_file(self.config_path)
             except (ConfigError, PersistError) as e:
-                logging.warning("Failed to load config ({}), backing up and using defaults".format(str(e)))
+                logging.warning(f"Failed to load config ({str(e)}), backing up and using defaults")
                 Seedsync.__backup_file(self.config_path)
                 create_default_config = True
         else:
@@ -109,7 +109,7 @@ class Seedsync:
         web_access_logger = self._create_logger(
             name=Constants.WEB_ACCESS_LOG_NAME, log_level=effective_log_level, logdir=args.logdir, log_format=log_format
         )
-        logger.info("Log level: {}".format(effective_log_level))
+        logger.info(f"Log level: {effective_log_level}")
 
         # Create status
         status = Status()
@@ -144,7 +144,7 @@ class Seedsync:
 
     def run(self):
         self.context.logger.info("Starting SeedSync")
-        self.context.logger.info("Platform: {}".format(platform.machine()))
+        self.context.logger.info(f"Platform: {platform.machine()}")
 
         # Create controller
         controller = Controller(self.context, self.controller_persist)
@@ -254,7 +254,7 @@ class Seedsync:
     def signal(self, signum: int, _: FrameType | None) -> None:
         # noinspection PyUnresolvedReferences
         # Signals is a generated enum
-        self.context.logger.info("Caught signal {}".format(signal.Signals(signum).name))
+        self.context.logger.info(f"Caught signal {signal.Signals(signum).name}")
         raise ServiceExit()
 
     @staticmethod
@@ -299,7 +299,7 @@ class Seedsync:
         if logdir is not None:
             # Output logs to a file in the given directory
             handler = RotatingFileHandler(
-                "{}/{}.log".format(logdir, name),
+                f"{logdir}/{name}.log",
                 maxBytes=Constants.MAX_LOG_SIZE_IN_BYTES,
                 backupCount=Constants.LOG_BACKUP_COUNT,
             )
@@ -472,12 +472,12 @@ class Seedsync:
         file_dir = os.path.dirname(file_path)
         i = 1
         while True:
-            backup_path = os.path.join(file_dir, "{}.{}.bak".format(file_name, i))
+            backup_path = os.path.join(file_dir, f"{file_name}.{i}.bak")
             if not os.path.exists(backup_path):
                 break
             i += 1
         if Seedsync.logger:
-            Seedsync.logger.info("Backing up {} to {}".format(file_path, backup_path))
+            Seedsync.logger.info(f"Backing up {file_path} to {backup_path}")
         shutil.copy(file_path, backup_path)
 
 

--- a/src/python/ssh/sshcp.py
+++ b/src/python/ssh/sshcp.py
@@ -40,7 +40,7 @@ class Sshcp:
     def _remote_address(self) -> str:
         """Return 'user@host' when user is set, or just 'host' when None."""
         if self.__user is not None:
-            return "{}@{}".format(self.__user, self.__host)
+            return f"{self.__user}@{self.__host}"
         return self.__host
 
     def set_base_logger(self, base_logger: logging.Logger):
@@ -85,7 +85,7 @@ class Sshcp:
                 self.__detected_shell = "/bin/sh"
 
             self.__shell_detected = True
-            self.logger.info("Detected remote shell: {}".format(self.__detected_shell))
+            self.logger.info(f"Detected remote shell: {self.__detected_shell}")
             return self.__detected_shell
 
         except SshcpError as e:
@@ -103,16 +103,16 @@ class Sshcp:
                 shells_str = ", ".join(available_shells)
                 raise SshcpError(
                     "Remote user's login shell not found. "
-                    "Available shells on the remote server: {}. "
+                    f"Available shells on the remote server: {shells_str}. "
                     "Fix by running on the remote server: "
-                    "sudo chsh -s {} {}".format(shells_str, available_shells[0], self.__user)
+                    f"sudo chsh -s {available_shells[0]} {self.__user}"
                 )
             else:
                 raise SshcpError(
                     "Remote user's login shell not found and no common shells "
                     "could be detected. Fix by running on the remote server: "
-                    "sudo chsh -s /bin/sh {} OR "
-                    "sudo ln -s /usr/bin/bash /bin/bash".format(self.__user)
+                    f"sudo chsh -s /bin/sh {self.__user} OR "
+                    "sudo ln -s /usr/bin/bash /bin/bash"
                 )
 
     def _run_shell_command(self, command: str) -> bytes:
@@ -122,9 +122,9 @@ class Sshcp:
         """
         # Quote the command
         if '"' in command:
-            quoted = "'{}'".format(command)
+            quoted = f"'{command}'"
         else:
-            quoted = '"{}"'.format(command)
+            quoted = f'"{command}"'
 
         flags = [
             "-p",
@@ -188,7 +188,7 @@ class Sshcp:
         command_args += args
 
         command = " ".join(command_args)
-        self.logger.debug("SFTP stat command: {}".format(command))
+        self.logger.debug(f"SFTP stat command: {command}")
 
         # Suppress DeprecationWarning from pexpect.spawn's internal forkpty call.
         # Scoped here so it doesn't affect the parent process.
@@ -223,7 +223,7 @@ class Sshcp:
                 raise SshcpError("SFTP connection failed")
 
             # Send ls command to check if file exists
-            sp.sendline("ls {}".format(remote_path))
+            sp.sendline(f"ls {remote_path}")
             i = sp.expect(
                 [
                     "sftp>",
@@ -238,7 +238,7 @@ class Sshcp:
             sp.close()
 
             if "No such file" in output or "not found" in output or "Can't ls" in output:
-                raise SshcpError("File not found: {}".format(remote_path))
+                raise SshcpError(f"File not found: {remote_path}")
 
         except pexpect.exceptions.TIMEOUT:
             sp.close()
@@ -278,7 +278,7 @@ class Sshcp:
         command_args.append(args)
 
         command = " ".join(command_args)
-        self.logger.debug("Command: {}".format(command))
+        self.logger.debug(f"Command: {command}")
 
         start_time = time.time()
         # Suppress DeprecationWarning from pexpect.spawn's internal forkpty call.
@@ -301,7 +301,7 @@ class Sshcp:
                     after_val = sp.after
                     before = before_val.decode(errors="replace").strip() if isinstance(before_val, bytes) else ""
                     after = after_val.decode(errors="replace").strip() if isinstance(after_val, bytes) else ""
-                    self.logger.warning("Command failed: '{} - {}'".format(before, after))
+                    self.logger.warning(f"Command failed: '{before} - {after}'")
                 if i == 1:
                     error_msg = "Unknown error"
                     before_val = sp.before
@@ -309,7 +309,7 @@ class Sshcp:
                         error_msg += " - " + before_val.decode(errors="replace").strip()
                     raise SshcpError(error_msg)
                 elif i == 3:
-                    raise SshcpError("Bad hostname: {}".format(self.__host))
+                    raise SshcpError(f"Bad hostname: {self.__host}")
                 elif i in {2, 4}:
                     error_msg = "Connection refused by server"
                     before_val = sp.before
@@ -333,11 +333,11 @@ class Sshcp:
                 after_val = sp.after
                 before = before_val.decode(errors="replace").strip() if isinstance(before_val, bytes) else ""
                 after = after_val.decode(errors="replace").strip() if isinstance(after_val, bytes) else ""
-                self.logger.warning("Command failed: '{} - {}'".format(before, after))
+                self.logger.warning(f"Command failed: '{before} - {after}'")
             if i == 1:
                 raise SshcpError("Incorrect password")
             elif i == 3:
-                raise SshcpError("Bad hostname: {}".format(self.__host))
+                raise SshcpError(f"Bad hostname: {self.__host}")
             elif i in {2, 4}:
                 error_msg = "Connection refused by server"
                 before_val = sp.before
@@ -355,11 +355,9 @@ class Sshcp:
 
         except pexpect.exceptions.TIMEOUT:
             elapsed = time.time() - start_time
-            self.logger.error(
-                "Timed out after {:.0f}s (limit: {}s). Command: {}".format(elapsed, self.__TIMEOUT_SECS, command)
-            )
+            self.logger.error(f"Timed out after {elapsed:.0f}s (limit: {self.__TIMEOUT_SECS}s). Command: {command}")
             self.logger.error("Command output before timeout: {}".format(sp.before if sp.before else b"(none)"))
-            raise SshcpError("Timed out after {:.0f}s".format(elapsed))
+            raise SshcpError(f"Timed out after {elapsed:.0f}s")
         finally:
             sp.close()
 
@@ -368,19 +366,19 @@ class Sshcp:
 
         end_time = time.time()
 
-        self.logger.debug("Return code: {}".format(exit_status))
-        self.logger.debug("Command took {:.3f}s".format(end_time - start_time))
+        self.logger.debug(f"Return code: {exit_status}")
+        self.logger.debug(f"Command took {end_time - start_time:.3f}s")
         if exit_status != 0:
-            self.logger.warning("Command failed: '{} - {}'".format(out_before, out_after))
+            self.logger.warning(f"Command failed: '{out_before} - {out_after}'")
 
             # Check for shell not found error (common on servers where bash is at /usr/bin/bash)
             if "No such file or directory" in out_before:
                 for shell in self.SHELL_CANDIDATES:
                     if shell in out_before:
                         raise SshcpError(
-                            "Remote user's login shell not found: {}. "
+                            f"Remote user's login shell not found: {shell}. "
                             "Run detect_shell() or fix by running on the remote server: "
-                            "sudo chsh -s /bin/sh {}".format(shell, self.__user)
+                            f"sudo chsh -s /bin/sh {self.__user}"
                         )
 
             raise SshcpError(out_before)
@@ -406,10 +404,10 @@ class Sshcp:
             command = "'" + command.replace("'", "'\"'\"'") + "'"
         elif '"' in command:
             # double quote in command, cover with single quotes
-            command = "'{}'".format(command)
+            command = f"'{command}'"
         else:
             # no quotes in command, cover with double quotes
-            command = '"{}"'.format(command)
+            command = f'"{command}"'
 
         flags = [
             "-p",
@@ -435,5 +433,5 @@ class Sshcp:
             "-P",
             str(self.__port),  # port
         ]
-        args = [local_path, "{}:{}".format(self._remote_address(), remote_path)]
+        args = [local_path, f"{self._remote_address()}:{remote_path}"]
         self.__run_command(command="scp", flags=" ".join(flags), args=" ".join(args))

--- a/src/python/system/scanner.py
+++ b/src/python/system/scanner.py
@@ -80,9 +80,9 @@ class SystemScanner:
         :return:
         """
         if not os.path.exists(self.path_to_scan):
-            raise SystemScannerError("Path does not exist: {}".format(self.path_to_scan))
+            raise SystemScannerError(f"Path does not exist: {self.path_to_scan}")
         elif not os.path.isdir(self.path_to_scan):
-            raise SystemScannerError("Path is not a directory: {}".format(self.path_to_scan))
+            raise SystemScannerError(f"Path is not a directory: {self.path_to_scan}")
         return self.__create_children(self.path_to_scan)
 
     def scan_single(self, name: str) -> SystemFile:
@@ -101,7 +101,7 @@ class SystemScanner:
             # There's a temp file, use that
             path = temp_path
         else:
-            raise SystemScannerError("Path does not exist: {}".format(path))
+            raise SystemScannerError(f"Path does not exist: {path}")
 
         return self.__create_system_file(
             PseudoDirEntry(name=name, path=path, is_dir=os.path.isdir(path), stat=os.stat(path))

--- a/src/python/tests/integration/test_controller/test_controller.py
+++ b/src/python/tests/integration/test_controller/test_controller.py
@@ -85,7 +85,7 @@ class TestController(unittest.TestCase):
         elif ext == "rar":
             subprocess.run(["rar", "a", "-ep", path, temp_file_path], stdout=subprocess.DEVNULL, check=True)
         else:
-            raise ValueError("Unsupported archive format: {}".format(os.path.basename(path)))
+            raise ValueError(f"Unsupported archive format: {os.path.basename(path)}")
         return os.path.getsize(path)
 
     @overrides(unittest.TestCase)
@@ -453,9 +453,7 @@ class TestController(unittest.TestCase):
         self.assertEqual(self.initial_state.keys(), files_dict.keys())
         for filename in self.initial_state.keys():
             # Note: put items in a list for a better diff output
-            self.assertEqual(
-                [self.initial_state[filename]], [files_dict[filename]], "Mismatch in file: {}".format(filename)
-            )
+            self.assertEqual([self.initial_state[filename]], [files_dict[filename]], f"Mismatch in file: {filename}")
 
     @timeout_decorator.timeout(20)
     def test_local_file_added(self):

--- a/src/python/tests/integration/test_web/test_handler/test_logs.py
+++ b/src/python/tests/integration/test_web/test_handler/test_logs.py
@@ -33,9 +33,9 @@ class TestLogsHandler(BaseTestWebApp):
         self.web_app_builder.logs_handler._logdir = self.tmp_dir
 
     def _log_path(self, suffix: str = "") -> str:
-        name = "{}.log".format(Constants.SERVICE_NAME)
+        name = f"{Constants.SERVICE_NAME}.log"
         if suffix:
-            name = "{}.{}".format(name, suffix)
+            name = f"{name}.{suffix}"
         return os.path.join(self.tmp_dir, name)
 
     # ---- correctness tests -------------------------------------------------
@@ -49,13 +49,13 @@ class TestLogsHandler(BaseTestWebApp):
             for i in range(total):
                 f.write(_header(i, "INFO", f"msg {i}"))
 
-        resp = self.test_app.get("/server/logs?limit={}".format(limit))
+        resp = self.test_app.get(f"/server/logs?limit={limit}")
         self.assertEqual(200, resp.status_int)
         entries = json.loads(resp.text)
         self.assertEqual(limit, len(entries))
         # The last `limit` entries, in oldest-first order, are msgs [total-limit .. total-1]
-        self.assertEqual("msg {}".format(total - limit), entries[0]["message"])
-        self.assertEqual("msg {}".format(total - 1), entries[-1]["message"])
+        self.assertEqual(f"msg {total - limit}", entries[0]["message"])
+        self.assertEqual(f"msg {total - 1}", entries[-1]["message"])
 
     def test_continuation_lines_attached_to_entry(self):
         """Lines that don't match the header pattern are appended to the
@@ -199,11 +199,11 @@ class TestLogsHandler(BaseTestWebApp):
         self.assertEqual(500, len(entries))
         # Ordering: last 500 of the `total_entries` written, oldest-first.
         self.assertEqual(
-            "msg {:08d}".format(total_entries - 500),
+            f"msg {total_entries - 500:08d}",
             entries[0]["message"],
         )
         self.assertEqual(
-            "msg {:08d}".format(total_entries - 1),
+            f"msg {total_entries - 1:08d}",
             entries[-1]["message"],
         )
 
@@ -212,5 +212,5 @@ class TestLogsHandler(BaseTestWebApp):
         self.assertLess(
             peak,
             10 * 1024 * 1024,
-            "peak traced allocation was {} bytes (>= 10 MB); streaming is broken".format(peak),
+            f"peak traced allocation was {peak} bytes (>= 10 MB); streaming is broken",
         )

--- a/src/python/tests/integration/test_web/test_handler/test_path_pairs.py
+++ b/src/python/tests/integration/test_web/test_handler/test_path_pairs.py
@@ -233,7 +233,7 @@ class TestPathPairsHandler(BaseTestWebApp):
             "remote_path": "/new/remote",
             "local_path": "/new/local",
         }
-        resp = self._put_json("/server/pathpairs/{}".format(pair.id), data)
+        resp = self._put_json(f"/server/pathpairs/{pair.id}", data)
         self.assertEqual(200, resp.status_int)
         body = json.loads(resp.text)
         self.assertEqual("New Name", body["name"])
@@ -249,7 +249,7 @@ class TestPathPairsHandler(BaseTestWebApp):
             name="Original", remote_path="/r/orig", local_path="/l/orig", enabled=True, auto_queue=True
         )
         data = {"name": "Updated"}
-        resp = self._put_json("/server/pathpairs/{}".format(pair.id), data)
+        resp = self._put_json(f"/server/pathpairs/{pair.id}", data)
         self.assertEqual(200, resp.status_int)
         body = json.loads(resp.text)
         self.assertEqual("Updated", body["name"])
@@ -262,7 +262,7 @@ class TestPathPairsHandler(BaseTestWebApp):
     def test_update_toggle_booleans(self):
         pair = self._add_pair(name="Test", enabled=True, auto_queue=True)
         data = {"enabled": False, "auto_queue": False}
-        resp = self._put_json("/server/pathpairs/{}".format(pair.id), data)
+        resp = self._put_json(f"/server/pathpairs/{pair.id}", data)
         self.assertEqual(200, resp.status_int)
         body = json.loads(resp.text)
         self.assertFalse(body["enabled"])
@@ -277,7 +277,7 @@ class TestPathPairsHandler(BaseTestWebApp):
         self._add_pair(name="Movies")
         p2 = self._add_pair(name="TV", remote_path="/r/tv", local_path="/l/tv")
         data = {"name": "Movies"}
-        resp = self._put_json("/server/pathpairs/{}".format(p2.id), data, expect_errors=True)
+        resp = self._put_json(f"/server/pathpairs/{p2.id}", data, expect_errors=True)
         self.assertEqual(409, resp.status_int)
         self.assertIn("already exists", resp.text.lower())
 
@@ -285,13 +285,13 @@ class TestPathPairsHandler(BaseTestWebApp):
         """Renaming a pair to its own name should succeed."""
         pair = self._add_pair(name="Movies")
         data = {"name": "Movies", "remote_path": "/new/r", "local_path": "/new/l"}
-        resp = self._put_json("/server/pathpairs/{}".format(pair.id), data)
+        resp = self._put_json(f"/server/pathpairs/{pair.id}", data)
         self.assertEqual(200, resp.status_int)
 
     def test_update_invalid_json(self):
         pair = self._add_pair(name="Test")
         resp = self.test_app.put(
-            "/server/pathpairs/{}".format(pair.id),
+            f"/server/pathpairs/{pair.id}",
             params="bad json",
             content_type="application/json",
             expect_errors=True,
@@ -301,7 +301,7 @@ class TestPathPairsHandler(BaseTestWebApp):
     def test_update_empty_name(self):
         pair = self._add_pair(name="Test")
         data = {"name": "  "}
-        resp = self._put_json("/server/pathpairs/{}".format(pair.id), data, expect_errors=True)
+        resp = self._put_json(f"/server/pathpairs/{pair.id}", data, expect_errors=True)
         self.assertEqual(400, resp.status_int)
 
     # ---------------------------------------------------------------
@@ -309,7 +309,7 @@ class TestPathPairsHandler(BaseTestWebApp):
     # ---------------------------------------------------------------
     def test_delete_valid(self):
         pair = self._add_pair(name="Delete Me")
-        resp = self.test_app.delete("/server/pathpairs/{}".format(pair.id))
+        resp = self.test_app.delete(f"/server/pathpairs/{pair.id}")
         self.assertEqual(204, resp.status_int)
         self.assertEqual(0, len(self.path_pairs_config.pairs))
 
@@ -321,7 +321,7 @@ class TestPathPairsHandler(BaseTestWebApp):
         """Deleting one pair should not affect others."""
         p1 = self._add_pair(name="Keep")
         p2 = self._add_pair(name="Remove", remote_path="/r2", local_path="/l2")
-        resp = self.test_app.delete("/server/pathpairs/{}".format(p2.id))
+        resp = self.test_app.delete(f"/server/pathpairs/{p2.id}")
         self.assertEqual(204, resp.status_int)
         remaining = self.path_pairs_config.pairs
         self.assertEqual(1, len(remaining))
@@ -352,7 +352,7 @@ class TestPathPairsHandler(BaseTestWebApp):
 
         # Update
         update_resp = self._put_json(
-            "/server/pathpairs/{}".format(pair_id),
+            f"/server/pathpairs/{pair_id}",
             {"name": "RoundTrip Updated", "enabled": False},
         )
         self.assertEqual(200, update_resp.status_int)
@@ -361,7 +361,7 @@ class TestPathPairsHandler(BaseTestWebApp):
         self.assertFalse(body["enabled"])
 
         # Delete
-        del_resp = self.test_app.delete("/server/pathpairs/{}".format(pair_id))
+        del_resp = self.test_app.delete(f"/server/pathpairs/{pair_id}")
         self.assertEqual(204, del_resp.status_int)
 
         # Confirm gone

--- a/src/python/tests/unittests/test_common/test_persist.py
+++ b/src/python/tests/unittests/test_common/test_persist.py
@@ -169,9 +169,9 @@ class TestPersistBackup(unittest.TestCase):
 
         # Create _MAX_BACKUPS + 5 pre-existing backups with sequential timestamps
         for i in range(_MAX_BACKUPS + 5):
-            backup_name = "settings-2026-01-{:02d}T00-00-00-000000.cfg".format(i + 1)
+            backup_name = f"settings-2026-01-{i + 1:02d}T00-00-00-000000.cfg"
             with open(os.path.join(backup_dir, backup_name), "w") as f:
-                f.write("backup {}".format(i))
+                f.write(f"backup {i}")
 
         before_set = set(os.listdir(backup_dir))
 
@@ -207,7 +207,7 @@ class TestPersistBackup(unittest.TestCase):
 
         def unique_timestamp(*args, **kwargs):
             counter[0] += 1
-            return "2026-03-03T12-00-{:02d}-000000".format(counter[0])
+            return f"2026-03-03T12-00-{counter[0]:02d}-000000"
 
         with patch("common.persist.datetime") as mock_dt:
             mock_dt.now.return_value.strftime.side_effect = unique_timestamp

--- a/src/python/tests/unittests/test_controller/test_controller_persist.py
+++ b/src/python/tests/unittests/test_controller/test_controller_persist.py
@@ -102,24 +102,24 @@ class TestControllerPersist(unittest.TestCase):
         uuid1 = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         content = json.dumps(
             {
-                "downloaded": ["{}:movie.mkv".format(uuid1), "plain_file.txt"],
-                "extracted": ["{}:archive.rar".format(uuid1)],
-                "extract_failed": ["{}:bad.zip".format(uuid1)],
+                "downloaded": [f"{uuid1}:movie.mkv", "plain_file.txt"],
+                "extracted": [f"{uuid1}:archive.rar"],
+                "extract_failed": [f"{uuid1}:bad.zip"],
             }
         )
         persist = ControllerPersist.from_str(content)
 
         sep = "\x1f"
         self.assertEqual(
-            {"{}{}movie.mkv".format(uuid1, sep), "plain_file.txt"},
+            {f"{uuid1}{sep}movie.mkv", "plain_file.txt"},
             persist.downloaded_file_names,
         )
         self.assertEqual(
-            {"{}{}archive.rar".format(uuid1, sep)},
+            {f"{uuid1}{sep}archive.rar"},
             persist.extracted_file_names,
         )
         self.assertEqual(
-            {"{}{}bad.zip".format(uuid1, sep)},
+            {f"{uuid1}{sep}bad.zip"},
             persist.extract_failed_file_names,
         )
 
@@ -128,7 +128,7 @@ class TestControllerPersist(unittest.TestCase):
         uuid1 = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         content = json.dumps(
             {
-                "downloaded": ["{}:movie:part1.mkv".format(uuid1)],
+                "downloaded": [f"{uuid1}:movie:part1.mkv"],
                 "extracted": [],
             }
         )
@@ -136,7 +136,7 @@ class TestControllerPersist(unittest.TestCase):
 
         sep = "\x1f"
         self.assertEqual(
-            {"{}{}movie:part1.mkv".format(uuid1, sep)},
+            {f"{uuid1}{sep}movie:part1.mkv"},
             persist.downloaded_file_names,
         )
 
@@ -160,13 +160,13 @@ class TestControllerPersist(unittest.TestCase):
         sep = "\x1f"
         content = json.dumps(
             {
-                "downloaded": ["{}{}movie.mkv".format(uuid1, sep)],
+                "downloaded": [f"{uuid1}{sep}movie.mkv"],
                 "extracted": [],
             }
         )
         persist = ControllerPersist.from_str(content)
         self.assertEqual(
-            {"{}{}movie.mkv".format(uuid1, sep)},
+            {f"{uuid1}{sep}movie.mkv"},
             persist.downloaded_file_names,
         )
 
@@ -203,17 +203,17 @@ class TestControllerPersist(unittest.TestCase):
             {
                 "downloaded": [],
                 "extracted": [],
-                "validated": ["{}:movie.mkv".format(uuid1)],
-                "corrupt": ["{}:bad.mkv".format(uuid1)],
+                "validated": [f"{uuid1}:movie.mkv"],
+                "corrupt": [f"{uuid1}:bad.mkv"],
             }
         )
         persist = ControllerPersist.from_str(content)
         sep = "\x1f"
         self.assertEqual(
-            {"{}{}movie.mkv".format(uuid1, sep)},
+            {f"{uuid1}{sep}movie.mkv"},
             persist.validated_file_names,
         )
         self.assertEqual(
-            {"{}{}bad.mkv".format(uuid1, sep)},
+            {f"{uuid1}{sep}bad.mkv"},
             persist.corrupt_file_names,
         )

--- a/src/python/tests/unittests/test_seedsync.py
+++ b/src/python/tests/unittests/test_seedsync.py
@@ -125,7 +125,7 @@ class TestSeedsync(unittest.TestCase):
         config_dict = config.as_dict()
         for section, inner_config in config_dict.items():
             for key in inner_config:
-                self.assertIsNotNone(inner_config[key], msg="{}.{} is uninitialized".format(section, key))
+                self.assertIsNotNone(inner_config[key], msg=f"{section}.{key} is uninitialized")
 
         # Test that default config is a valid config
         config_dict = config.as_dict()

--- a/src/python/tests/unittests/test_ssh/test_sshcp.py
+++ b/src/python/tests/unittests/test_ssh/test_sshcp.py
@@ -124,7 +124,7 @@ class TestSshcp(unittest.TestCase):
     @timeout_decorator.timeout(5)
     def test_shell(self, _, password):
         sshcp = Sshcp(host=self.host, port=self.port, user=self.user, password=password)
-        out = sshcp.shell("cd {}; pwd".format(self.local_dir))
+        out = sshcp.shell(f"cd {self.local_dir}; pwd")
         out_str = out.decode().strip()
         self.assertEqual(self.local_dir, out_str)
 
@@ -135,19 +135,19 @@ class TestSshcp(unittest.TestCase):
 
         # single quotes
         _dir = os.path.join(self.remote_dir, "a a")
-        out = sshcp.shell("mkdir '{}' && cd '{}' && pwd".format(_dir, _dir))
+        out = sshcp.shell(f"mkdir '{_dir}' && cd '{_dir}' && pwd")
         out_str = out.decode().strip()
         self.assertEqual(_dir, out_str)
 
         # double quotes
         _dir = os.path.join(self.remote_dir, "a b")
-        out = sshcp.shell('mkdir "{}" && cd "{}" && pwd'.format(_dir, _dir))
+        out = sshcp.shell(f'mkdir "{_dir}" && cd "{_dir}" && pwd')
         out_str = out.decode().strip()
         self.assertEqual(_dir, out_str)
 
         # single and double quotes - should work
         _dir = os.path.join(self.remote_dir, "a c")
-        out = sshcp.shell("mkdir \"{}\" && cd '{}' && pwd".format(_dir, _dir))
+        out = sshcp.shell(f"mkdir \"{_dir}\" && cd '{_dir}' && pwd")
         out_str = out.decode().strip()
         self.assertEqual(_dir, out_str)
 
@@ -155,7 +155,7 @@ class TestSshcp(unittest.TestCase):
     def test_shell_error_bad_password(self):
         sshcp = Sshcp(host=self.host, port=self.port, user=self.user, password="wrong password")
         with self.assertRaises(SshcpError) as ctx:
-            sshcp.shell("cd {}; pwd".format(self.local_dir))
+            sshcp.shell(f"cd {self.local_dir}; pwd")
         self.assertEqual("Incorrect password", str(ctx.exception))
 
     @parameterized.expand(_PARAMS)
@@ -163,7 +163,7 @@ class TestSshcp(unittest.TestCase):
     def test_shell_error_bad_host(self, _, password):
         sshcp = Sshcp(host="badhost", port=self.port, user=self.user, password=password)
         with self.assertRaises(SshcpError) as ctx:
-            sshcp.shell("cd {}; pwd".format(self.local_dir))
+            sshcp.shell(f"cd {self.local_dir}; pwd")
         self.assertTrue("Bad hostname" in str(ctx.exception))
 
     @parameterized.expand(_PARAMS)
@@ -171,7 +171,7 @@ class TestSshcp(unittest.TestCase):
     def test_shell_error_bad_port(self, _, password):
         sshcp = Sshcp(host=self.host, port=6666, user=self.user, password=password)
         with self.assertRaises(SshcpError) as ctx:
-            sshcp.shell("cd {}; pwd".format(self.local_dir))
+            sshcp.shell(f"cd {self.local_dir}; pwd")
         self.assertTrue("Connection refused by server" in str(ctx.exception))
 
     @parameterized.expand(_PARAMS)

--- a/src/python/web/handler/auto_queue.py
+++ b/src/python/web/handler/auto_queue.py
@@ -34,11 +34,11 @@ class AutoQueueHandler(IHandler):
         aqp = AutoQueuePattern(pattern=pattern)
 
         if aqp in self.__auto_queue_persist.patterns:
-            return HTTPResponse(body="Auto-queue pattern '{}' already exists.".format(pattern), status=400)
+            return HTTPResponse(body=f"Auto-queue pattern '{pattern}' already exists.", status=400)
         else:
             try:
                 self.__auto_queue_persist.add_pattern(aqp)
-                return HTTPResponse(body="Added auto-queue pattern '{}'.".format(pattern))
+                return HTTPResponse(body=f"Added auto-queue pattern '{pattern}'.")
             except ValueError as e:
                 return HTTPResponse(body=str(e), status=400)
 
@@ -49,7 +49,7 @@ class AutoQueueHandler(IHandler):
         aqp = AutoQueuePattern(pattern=pattern)
 
         if aqp not in self.__auto_queue_persist.patterns:
-            return HTTPResponse(body="Auto-queue pattern '{}' doesn't exist.".format(pattern), status=400)
+            return HTTPResponse(body=f"Auto-queue pattern '{pattern}' doesn't exist.", status=400)
         else:
             self.__auto_queue_persist.remove_pattern(aqp)
-            return HTTPResponse(body="Removed auto-queue pattern '{}'.".format(pattern))
+            return HTTPResponse(body=f"Removed auto-queue pattern '{pattern}'.")

--- a/src/python/web/handler/config.py
+++ b/src/python/web/handler/config.py
@@ -32,10 +32,10 @@ class ConfigHandler(IHandler):
             value = ""
 
         if not self.__config.has_section(section):
-            return HTTPResponse(body="There is no section '{}' in config".format(section), status=400)
+            return HTTPResponse(body=f"There is no section '{section}' in config", status=400)
         inner_config = getattr(self.__config, section)
         if not inner_config.has_property(key):
-            return HTTPResponse(body="Section '{}' in config has no option '{}'".format(section, key), status=400)
+            return HTTPResponse(body=f"Section '{section}' in config has no option '{key}'", status=400)
         # Reject the redacted sentinel to prevent accidentally overwriting
         # real credentials with "********"
         if Config.is_sensitive(section, key) and value == Config.REDACTED_SENTINEL:
@@ -43,7 +43,7 @@ class ConfigHandler(IHandler):
         try:
             inner_config.set_property(key, value)
             if Config.is_sensitive(section, key):
-                return HTTPResponse(body="{}.{} updated".format(section, key))
-            return HTTPResponse(body="{}.{} set to {}".format(section, key, value))
+                return HTTPResponse(body=f"{section}.{key} updated")
+            return HTTPResponse(body=f"{section}.{key} set to {value}")
         except ConfigError as e:
             return HTTPResponse(body=str(e), status=400)

--- a/src/python/web/handler/logs.py
+++ b/src/python/web/handler/logs.py
@@ -75,7 +75,7 @@ class LogsHandler(IHandler):
         O(sum of all log file bytes).
         """
         assert self._logdir is not None
-        base_path = os.path.join(self._logdir, "{}.log".format(self._service_name))
+        base_path = os.path.join(self._logdir, f"{self._service_name}.log")
 
         # Gather log file paths in oldest -> newest order.
         # RotatingFileHandler convention: on rotation, the current .log is
@@ -85,7 +85,7 @@ class LogsHandler(IHandler):
         # the deque below naturally retains the *newest* `limit` entries.
         log_files: list[str] = []
         for i in range(Constants.LOG_BACKUP_COUNT, 0, -1):
-            rotated = "{}.{}".format(base_path, i)
+            rotated = f"{base_path}.{i}"
             if os.path.isfile(rotated):
                 log_files.append(rotated)
         if os.path.isfile(base_path):

--- a/src/python/web/security.py
+++ b/src/python/web/security.py
@@ -99,7 +99,7 @@ def install_csrf_protection(app: bottle.Bottle):
         # the Origin header (or wsgi url_scheme) and the Host header.
         request_scheme = origin_t[0]  # trust the origin's scheme
         raw_host = bottle.request.get_header("Host", "")
-        request_t = _origin_tuple("{}://{}".format(request_scheme, raw_host)) if raw_host else None
+        request_t = _origin_tuple(f"{request_scheme}://{raw_host}") if raw_host else None
 
         if not request_t or origin_t != request_t:
             raise bottle.HTTPError(403, "CSRF validation failed: origin mismatch")

--- a/src/python/web/web_app.py
+++ b/src/python/web/web_app.py
@@ -70,7 +70,7 @@ class WebApp(bottle.Bottle):
         self.__controller = controller
         self.__html_path = context.args.html_path
         self.__status = context.status
-        self.logger.info("Html path set to: {}".format(self.__html_path))
+        self.logger.info(f"Html path set to: {self.__html_path}")
         self._stop_event = threading.Event()
         self._streaming_handlers: list[tuple[type[IStreamHandler], dict[str, Any]]] = []
 


### PR DESCRIPTION
## Summary
Mechanical auto-fix: converts all 305 `"...".format()` calls to f-strings via `ruff check --select UP032 --fix`, then `ruff format` to clean up line breaks.

**40 files changed, net -65 lines.**

## What changed
Every `"{}".format(x)` → `f"{x}"` across the Python codebase. No logic changes. The diff is large but entirely mechanical.

## Coordination
This PR is independent of Phase 1 (#400) — both branch from develop. Whichever merges second will need a trivial `pyproject.toml` conflict resolution (both remove entries from the same ignore list).

## Test plan
- [x] `ruff check` — all checks passed
- [x] `ruff format --check` — 164 files already formatted
- [x] `pytest tests/unittests` (excluding SSH-dependent tests) — 152 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Modernized internal code patterns for improved maintainability and consistency.

* **Chores**
  * Updated linting configuration to enforce modern coding standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->