### PR TITLE
Add from-clause to 25 raise statements (#399 Phase 3)

### DIFF
--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -50,7 +50,9 @@ class Converters:
         try:
             val = int(value)
         except ValueError:
-            raise ConfigError("Bad config: {}.{} ({}) must be an integer value".format(cls.__name__, name, value))
+            raise ConfigError(
+                "Bad config: {}.{} ({}) must be an integer value".format(cls.__name__, name, value)
+            ) from None
         return val
 
     @staticmethod
@@ -60,7 +62,9 @@ class Converters:
         try:
             val = bool(_strtobool(value))
         except ValueError:
-            raise ConfigError("Bad config: {}.{} ({}) must be a boolean value".format(cls.__name__, name, value))
+            raise ConfigError(
+                "Bad config: {}.{} ({}) must be a boolean value".format(cls.__name__, name, value)
+            ) from None
         return val
 
 
@@ -441,7 +445,7 @@ class Config(Persist):
         try:
             config_parser.read_string(content)
         except (configparser.MissingSectionHeaderError, configparser.ParsingError) as e:
-            raise PersistError("Error parsing Config - {}: {}".format(type(e).__name__, str(e)))
+            raise PersistError("Error parsing Config - {}: {}".format(type(e).__name__, str(e))) from e
         config_dict: OuterConfigType = {}
         for section in config_parser.sections():
             config_dict[section] = {}

--- a/src/python/controller/auto_queue.py
+++ b/src/python/controller/auto_queue.py
@@ -103,7 +103,7 @@ class AutoQueuePersist(Persist):
                 persist.add_pattern(AutoQueuePattern.from_str(pattern))
             return persist
         except (json.decoder.JSONDecodeError, KeyError) as e:
-            raise PersistError("Error parsing AutoQueuePersist - {}: {}".format(type(e).__name__, str(e)))
+            raise PersistError("Error parsing AutoQueuePersist - {}: {}".format(type(e).__name__, str(e))) from e
 
     @overrides(Persist)
     def to_str(self) -> str:

--- a/src/python/controller/controller_persist.py
+++ b/src/python/controller/controller_persist.py
@@ -68,7 +68,7 @@ class ControllerPersist(Persist):
             persist.corrupt_file_names = ControllerPersist._migrate_legacy_keys(persist.corrupt_file_names)
             return persist
         except (json.decoder.JSONDecodeError, KeyError) as e:
-            raise PersistError("Error parsing ControllerPersist - {}: {}".format(type(e).__name__, str(e)))
+            raise PersistError("Error parsing ControllerPersist - {}: {}".format(type(e).__name__, str(e))) from e
 
     @overrides(Persist)
     def to_str(self) -> str:

--- a/src/python/controller/extract/extract.py
+++ b/src/python/controller/extract/extract.py
@@ -68,8 +68,8 @@ class Extract:
             raise ExtractError(
                 f"Archive verification timed out after {Extract._7Z_TIMEOUT_SECS}s: {archive_path}"
             ) from None
-        except FileNotFoundError:
-            raise ExtractError("7z binary not found; cannot verify archive") from None
+        except FileNotFoundError as e:
+            raise ExtractError("7z binary not found; cannot verify archive") from e
 
         if result.returncode != 0:
             raise ExtractError(Extract._format_7z_error(result, "Archive verification failed"))
@@ -176,8 +176,8 @@ class Extract:
             )
         except subprocess.TimeoutExpired:
             raise ExtractError(f"7z timed out after {Extract._7Z_TIMEOUT_SECS}s: {archive_path}") from None
-        except FileNotFoundError:
-            raise ExtractError("7z binary not found; cannot extract archive") from None
+        except FileNotFoundError as e:
+            raise ExtractError("7z binary not found; cannot extract archive") from e
 
         if result.returncode != 0:
             raise ExtractError(Extract._format_7z_error(result, "7z failed"))

--- a/src/python/controller/extract/extract.py
+++ b/src/python/controller/extract/extract.py
@@ -67,9 +67,9 @@ class Extract:
         except subprocess.TimeoutExpired:
             raise ExtractError(
                 "Archive verification timed out after {}s: {}".format(Extract._7Z_TIMEOUT_SECS, archive_path)
-            )
+            ) from None
         except FileNotFoundError:
-            raise ExtractError("7z binary not found; cannot verify archive")
+            raise ExtractError("7z binary not found; cannot verify archive") from None
 
         if result.returncode != 0:
             raise ExtractError(Extract._format_7z_error(result, "Archive verification failed"))
@@ -177,9 +177,9 @@ class Extract:
                 timeout=Extract._7Z_TIMEOUT_SECS,
             )
         except subprocess.TimeoutExpired:
-            raise ExtractError("7z timed out after {}s: {}".format(Extract._7Z_TIMEOUT_SECS, archive_path))
+            raise ExtractError("7z timed out after {}s: {}".format(Extract._7Z_TIMEOUT_SECS, archive_path)) from None
         except FileNotFoundError:
-            raise ExtractError("7z binary not found; cannot extract archive")
+            raise ExtractError("7z binary not found; cannot extract archive") from None
 
         if result.returncode != 0:
             raise ExtractError(Extract._format_7z_error(result, "7z failed"))

--- a/src/python/controller/scan/local_scanner.py
+++ b/src/python/controller/scan/local_scanner.py
@@ -36,5 +36,5 @@ class LocalScanner(IScanner):
             result = self.__scanner.scan()
         except SystemScannerError:
             self.logger.exception("Caught SystemScannerError")
-            raise ScannerError(Localization.Error.LOCAL_SERVER_SCAN, recoverable=False)
+            raise ScannerError(Localization.Error.LOCAL_SERVER_SCAN, recoverable=False) from None
         return result

--- a/src/python/controller/scan/remote_scanner.py
+++ b/src/python/controller/scan/remote_scanner.py
@@ -69,7 +69,7 @@ class RemoteScanner(IScanner):
             self.logger.error("JSON parse error: {}\n{}".format(str(err), out[:500]))
             raise ScannerError(
                 Localization.Error.REMOTE_SERVER_SCAN.format("Invalid JSON data from scanner"), recoverable=False
-            )
+            ) from err
 
         self.__first_run = False
         return remote_files
@@ -112,18 +112,18 @@ class RemoteScanner(IScanner):
                         "outside your sync tree (e.g. '~' or '~/.local') and remove the "
                         "conflicting directory from the remote server.".format(self.__remote_path_to_scan_script),
                         recoverable=False,
-                    )
+                    ) from e
 
                 if "SystemScannerError" in error_str:
                     raise ScannerError(
                         Localization.Error.REMOTE_SERVER_SCAN.format(error_str.strip()), recoverable=False
-                    )
+                    ) from e
 
                 # Config errors on first run are non-recoverable
                 if self.__first_run and not self._is_transient_error(error_str):
                     raise ScannerError(
                         Localization.Error.REMOTE_SERVER_SCAN.format(error_str.strip()), recoverable=False
-                    )
+                    ) from e
 
                 # Retry transient errors
                 if attempt < self._SCAN_MAX_RETRIES:
@@ -148,7 +148,9 @@ class RemoteScanner(IScanner):
         except SshcpError as e:
             self.logger.exception("Shell detection failed")
             recoverable = self._is_transient_error(str(e))
-            raise ScannerError(Localization.Error.REMOTE_SERVER_INSTALL.format(str(e).strip()), recoverable=recoverable)
+            raise ScannerError(
+                Localization.Error.REMOTE_SERVER_INSTALL.format(str(e).strip()), recoverable=recoverable
+            ) from e
 
         # Resolve tilde in the script path to an absolute path.
         # SCP expands ~ natively, but the path is shell-quoted for md5sum
@@ -184,7 +186,9 @@ class RemoteScanner(IScanner):
         except SshcpError as e:
             self.logger.exception("Caught SSH exception during md5sum check")
             recoverable = self._is_transient_error(str(e))
-            raise ScannerError(Localization.Error.REMOTE_SERVER_INSTALL.format(str(e).strip()), recoverable=recoverable)
+            raise ScannerError(
+                Localization.Error.REMOTE_SERVER_INSTALL.format(str(e).strip()), recoverable=recoverable
+            ) from e
 
         # Guard: if the target path is already a directory on the remote, the
         # copy would succeed (scp deposits the file inside the dir) but
@@ -234,7 +238,7 @@ class RemoteScanner(IScanner):
                 recoverable = self._is_transient_error(str(e))
                 raise ScannerError(
                     Localization.Error.REMOTE_SERVER_INSTALL.format(str(e).strip()), recoverable=recoverable
-                )
+                ) from e
 
     def _install_scanfs_with_home_fallback(self, original_error: str):
         """
@@ -297,4 +301,4 @@ class RemoteScanner(IScanner):
                     )
                 ),
                 recoverable=False,
-            )
+            ) from fallback_e

--- a/src/python/lftp/job_status_parser.py
+++ b/src/python/lftp/job_status_parser.py
@@ -115,7 +115,7 @@ class LftpJobStatusParser:
         except ValueError as e:
             self.logger.error("LftpJobStateParser error: {}".format(str(e)))
             self.logger.error("Status:\n{}".format(output))
-            raise LftpJobStatusParserError("Error parsing lftp job status")
+            raise LftpJobStatusParserError("Error parsing lftp job status") from e
         return statuses
 
     def __parse_jobs(self, lines: list[str]) -> list[LftpJobStatus]:

--- a/src/python/lftp/lftp.py
+++ b/src/python/lftp/lftp.py
@@ -154,7 +154,7 @@ class Lftp:
                 try:
                     inst.__restart_process()
                 except Exception:
-                    raise LftpError("lftp process is not running and restart failed")
+                    raise LftpError("lftp process is not running and restart failed") from None
             return method(inst, *args, **kwargs)
 
         return wrapper

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -43,7 +43,6 @@ ignore = [
     "E741",  # ambiguous variable name — single-letter vars in context
     "UP032", # f-string — too much churn for auto-fix PR, defer to PR 2
     "UP046", # non-pep695-generic-class — requires Python 3.12+ syntax migration
-    "B904",  # raise-without-from — defer to PR 2
     "B905",  # zip-without-explicit-strict — defer to PR 2
     "B024",  # abstract-base-class-without-abstract-method — existing pattern
     "UP031", # printf-string-formatting — defer to PR 2

--- a/src/python/ssh/sshcp.py
+++ b/src/python/ssh/sshcp.py
@@ -106,14 +106,14 @@ class Sshcp:
                     "Available shells on the remote server: {}. "
                     "Fix by running on the remote server: "
                     "sudo chsh -s {} {}".format(shells_str, available_shells[0], self.__user)
-                )
+                ) from e
             else:
                 raise SshcpError(
                     "Remote user's login shell not found and no common shells "
                     "could be detected. Fix by running on the remote server: "
                     "sudo chsh -s /bin/sh {} OR "
                     "sudo ln -s /usr/bin/bash /bin/bash".format(self.__user)
-                )
+                ) from e
 
     def _run_shell_command(self, command: str) -> bytes:
         """
@@ -242,7 +242,7 @@ class Sshcp:
 
         except pexpect.exceptions.TIMEOUT:
             sp.close()
-            raise SshcpError("SFTP timed out")
+            raise SshcpError("SFTP timed out") from None
 
     def __run_command(self, command: str, flags: str, args: str) -> bytes:
 
@@ -359,7 +359,7 @@ class Sshcp:
                 "Timed out after {:.0f}s (limit: {}s). Command: {}".format(elapsed, self.__TIMEOUT_SECS, command)
             )
             self.logger.error("Command output before timeout: {}".format(sp.before if sp.before else b"(none)"))
-            raise SshcpError("Timed out after {:.0f}s".format(elapsed))
+            raise SshcpError("Timed out after {:.0f}s".format(elapsed)) from None
         finally:
             sp.close()
 

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -18,4 +18,4 @@ def pytest_configure(config):
             raise RuntimeError(
                 f"Cannot set multiprocessing start method to 'spawn'; "
                 f"current method is '{current}'. Tests require spawn."
-            )
+            ) from None


### PR DESCRIPTION
## Summary
Adds `from err` or `from None` to all 25 `raise` statements inside `except` blocks, resolving B904 (raise-without-from-inside-except). Removes `B904` from the ignore list.

## Approach
- **`from None`** (12 fixes) — Used when the raise creates a new domain-specific error that intentionally replaces the original (e.g., `except ValueError: raise ConfigError(...) from None`)
- **`from err`/`from e`/`from fallback_e`** (13 fixes) — Used when the original exception context aids debugging (e.g., `except KeyError as e: raise PersistError(...) from e`)

## Files changed (11)
- `common/config.py` (3)
- `controller/auto_queue.py` (1)
- `controller/controller_persist.py` (1)
- `controller/extract/extract.py` (4)
- `controller/scan/local_scanner.py` (1)
- `controller/scan/remote_scanner.py` (5)
- `lftp/job_status_parser.py` (1)
- `lftp/lftp.py` (1)
- `ssh/sshcp.py` (4)
- `tests/conftest.py` (1)
- `pyproject.toml` (ignore list update)

## Coordination
Independent of Phase 1 (#400) and Phase 2 (#401) — all three branch from develop. Whichever merges last resolves a trivial `pyproject.toml` conflict.

## Test plan
- [x] `ruff check` — all checks passed
- [x] `ruff format --check` — all files formatted
- [x] `pytest tests/unittests` (excluding SSH-dependent) — 152 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved exception handling and error tracing throughout the codebase for better debugging diagnostics.

* **Chores**
  * Updated code quality configuration to enforce stricter exception handling standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->