### PR TITLE
Enable ruff C901 complexity enforcement (max=12)

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -704,7 +704,7 @@ class Controller:
             out_dir_path_fallback=out_dir_path_fallback,
         )
 
-    def __update_model(self):
+    def __update_model(self):  # noqa: C901 — will be decomposed in #394
         # Grab the latest extract results (shared)
         latest_extract_statuses = self.__extract_process.pop_latest_statuses()
         latest_extracted_results = self.__extract_process.pop_completed()
@@ -979,7 +979,7 @@ class Controller:
                 if current is None or pc._latest_local_scan.timestamp > current:  # type: ignore[reportPrivateUsage]
                     self.__context.status.controller.latest_local_scan_time = pc._latest_local_scan.timestamp  # type: ignore[reportPrivateUsage]
 
-    def _update_pair_model_state(
+    def _update_pair_model_state(  # noqa: C901 — will be decomposed in #394
         self,
         pc: _PairContext,
         latest_extract_statuses: ExtractStatusResult | None,
@@ -1052,7 +1052,7 @@ class Controller:
             pair_validate_statuses = [s for s in latest_validate_statuses.statuses if s.pair_id == pc.pair_id]
             pc.model_builder.set_validate_statuses(pair_validate_statuses)
 
-    def _sync_persist_to_all_builders(self):
+    def _sync_persist_to_all_builders(self):  # noqa: C901 — will be decomposed in #394
         """Push current persist state to all pair model builders, filtered by pair_id."""
         namespaced_prefixes = tuple(
             f"{other_pc.pair_id}{sep}"
@@ -1111,7 +1111,7 @@ class Controller:
             pc.model_builder.set_validated_files(validated)
             pc.model_builder.set_corrupt_files(corrupt)
 
-    def __process_commands(self):
+    def __process_commands(self):  # noqa: C901 — will be decomposed in #394
         def _notify_failure(_command: Controller.Command, _msg: str):
             self.logger.warning(f"Command failed. {_msg}")
             for _callback in _command.callbacks:

--- a/src/python/controller/model_builder.py
+++ b/src/python/controller/model_builder.py
@@ -152,7 +152,7 @@ class ModelBuilder:
         """
         return self.__cached_model is None
 
-    def build_model(self) -> Model:
+    def build_model(self) -> Model:  # noqa: C901 — complexity 58, needs decomposition
         if self.__cached_model is not None:
             return self.__cached_model
 
@@ -188,7 +188,7 @@ class ModelBuilder:
             ):
                 raise ModelError("Mismatch in is_dir between sources")
 
-            def __fill_model_file(
+            def __fill_model_file(  # noqa: C901 — complexity 16, nested helper
                 _model_file: ModelFile,
                 _remote: SystemFile | None,
                 _local: SystemFile | None,

--- a/src/python/lftp/job_status_parser.py
+++ b/src/python/lftp/job_status_parser.py
@@ -118,7 +118,7 @@ class LftpJobStatusParser:
             raise LftpJobStatusParserError("Error parsing lftp job status") from e
         return statuses
 
-    def __parse_jobs(self, lines: list[str]) -> list[LftpJobStatus]:
+    def __parse_jobs(self, lines: list[str]) -> list[LftpJobStatus]:  # noqa: C901 — complexity 48, lftp output parser
         jobs: list[LftpJobStatus] = []
 
         # Header patterns
@@ -532,7 +532,7 @@ class LftpJobStatusParser:
         return jobs
 
     @staticmethod
-    def __parse_queue(lines: list[str]) -> list[LftpJobStatus]:
+    def __parse_queue(lines: list[str]) -> list[LftpJobStatus]:  # noqa: C901 — complexity 19, lftp output parser
         queue: list[LftpJobStatus] = []
 
         queue_done_m = re.compile(LftpJobStatusParser.__QUEUE_DONE_REGEX)

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -40,6 +40,7 @@ select = [
     "RET",  # flake8-return
     "PERF", # perflint
     "RUF",  # ruff-specific
+    "C",    # mccabe complexity
 ]
 ignore = [
     "UP046",  # non-pep695-generic-class — requires Python 3.12+ syntax migration
@@ -55,10 +56,13 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "I001"]  # re-exports, import order is load-order sensitive
-"tests/**" = ["W291", "SIM117", "RUF059"]  # trailing whitespace in test data; nested with; structural unpacking
+"tests/**" = ["W291", "SIM117", "RUF059", "C901"]  # trailing whitespace; nested with; structural unpacking; test complexity
 "tests/**/test_job_status_parser.py" = ["E501"]  # long lines are lftp output test data
 "model/file.py" = ["E721"]  # intentional type() comparisons for enum-style state checks
 "scan_fs.py" = ["UP006", "UP032", "UP035", "UP045"]  # must use typing/format() for Python 3.5 compat on remote
+
+[tool.ruff.lint.mccabe]
+max-complexity = 12
 
 [tool.ruff.lint.isort]
 known-first-party = ["common", "controller", "model", "lftp", "ssh", "web", "system"]

--- a/src/python/ssh/sshcp.py
+++ b/src/python/ssh/sshcp.py
@@ -243,7 +243,7 @@ class Sshcp:
             sp.close()
             raise SshcpError("SFTP timed out") from None
 
-    def __run_command(self, command: str, flags: str, args: str) -> bytes:
+    def __run_command(self, command: str, flags: str, args: str) -> bytes:  # noqa: C901 — complexity 19, pexpect state machine
 
         command_args = [command, flags]
 

--- a/src/python/web/handler/logs.py
+++ b/src/python/web/handler/logs.py
@@ -61,7 +61,7 @@ class LogsHandler(IHandler):
 
         return HTTPResponse(body=json.dumps(entries), content_type="application/json")
 
-    def _read_logs(self, search: str, min_level: int, limit: int, before: int) -> list[dict[str, str]]:
+    def _read_logs(self, search: str, min_level: int, limit: int, before: int) -> list[dict[str, str]]:  # noqa: C901
         """
         Read log entries from rotated log files without loading any file fully into memory.
 


### PR DESCRIPTION
Closes #395

## Summary
Enables mccabe cyclomatic complexity checking (`C901`) with `max-complexity = 12`. Any new function exceeding this threshold will fail CI.

## Existing violations (10 functions, annotated with `# noqa: C901`)

| Function | File | Complexity | Tracked in |
|----------|------|----------:|------------|
| `__update_model` | controller.py | 51 | #394 |
| `__process_commands` | controller.py | 31 | #394 |
| `_sync_persist_to_all_builders` | controller.py | 22 | #394 |
| `_update_pair_model_state` | controller.py | 14 | #394 |
| `build_model` | model_builder.py | 58 | — |
| `__fill_model_file` | model_builder.py | 16 | — |
| `__parse_jobs` | job_status_parser.py | 48 | — |
| `__parse_queue` | job_status_parser.py | 19 | — |
| `__run_command` | sshcp.py | 19 | — |
| `_read_logs` | logs.py | 16 | — |

Tests exempted via `per-file-ignores` — test complexity reflects scenario count, not logic complexity.

## Test plan
- [x] `ruff check` — all checks passed
- [x] `ruff format --check` — all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to enable cyclomatic complexity checks across the codebase with a maximum allowed complexity threshold of 12.
  * Added linting suppression annotations to specific existing methods marked for future refactoring to allow continued development while enforcing complexity limits on new code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->