### PR TITLE
Redact all sensitive config fields, harden auto_queue responses

### DIFF
--- a/src/python/common/context.py
+++ b/src/python/common/context.py
@@ -68,10 +68,12 @@ class Context:
         # Print the config
         self.logger.debug("Config:")
         config_dict = self.config.as_dict()
+        sensitive = Config.sensitive_property_names()
         for section in config_dict:
+            sensitive_options = sensitive.get(section, set())
             for option in config_dict[section]:
                 value = config_dict[section][option]
-                if option == "remote_password":
+                if option in sensitive_options:
                     value = "********" if value else ""
                 self.logger.debug(f"  {section}.{option}: {value}")
 

--- a/src/python/web/handler/auto_queue.py
+++ b/src/python/web/handler/auto_queue.py
@@ -21,6 +21,8 @@ class AutoQueueHandler(IHandler):
         web_app.add_handler("/server/autoqueue/add/<pattern>", self.__handle_add_autoqueue)
         web_app.add_handler("/server/autoqueue/remove/<pattern>", self.__handle_remove_autoqueue)
 
+    _TEXT_HEADERS = {"X-Content-Type-Options": "nosniff"}
+
     def __handle_get_autoqueue(self):
         patterns = list(self.__auto_queue_persist.patterns)
         patterns.sort(key=lambda p: p.pattern)
@@ -34,12 +36,26 @@ class AutoQueueHandler(IHandler):
         aqp = AutoQueuePattern(pattern=pattern)
 
         if aqp in self.__auto_queue_persist.patterns:
-            return HTTPResponse(body=f"Auto-queue pattern '{pattern}' already exists.", status=400)
+            return HTTPResponse(
+                body=f"Auto-queue pattern '{pattern}' already exists.",
+                status=400,
+                content_type="text/plain",
+                headers=self._TEXT_HEADERS,
+            )
         try:
             self.__auto_queue_persist.add_pattern(aqp)
-            return HTTPResponse(body=f"Added auto-queue pattern '{pattern}'.")
+            return HTTPResponse(
+                body=f"Added auto-queue pattern '{pattern}'.",
+                content_type="text/plain",
+                headers=self._TEXT_HEADERS,
+            )
         except ValueError as e:
-            return HTTPResponse(body=str(e), status=400)
+            return HTTPResponse(
+                body=str(e),
+                status=400,
+                content_type="text/plain",
+                headers=self._TEXT_HEADERS,
+            )
 
     def __handle_remove_autoqueue(self, pattern: str):
         # value is double encoded
@@ -48,6 +64,15 @@ class AutoQueueHandler(IHandler):
         aqp = AutoQueuePattern(pattern=pattern)
 
         if aqp not in self.__auto_queue_persist.patterns:
-            return HTTPResponse(body=f"Auto-queue pattern '{pattern}' doesn't exist.", status=400)
+            return HTTPResponse(
+                body=f"Auto-queue pattern '{pattern}' doesn't exist.",
+                status=400,
+                content_type="text/plain",
+                headers=self._TEXT_HEADERS,
+            )
         self.__auto_queue_persist.remove_pattern(aqp)
-        return HTTPResponse(body=f"Removed auto-queue pattern '{pattern}'.")
+        return HTTPResponse(
+            body=f"Removed auto-queue pattern '{pattern}'.",
+            content_type="text/plain",
+            headers=self._TEXT_HEADERS,
+        )

--- a/src/python/web/handler/auto_queue.py
+++ b/src/python/web/handler/auto_queue.py
@@ -12,6 +12,8 @@ from ..web_app import IHandler, WebApp
 
 
 class AutoQueueHandler(IHandler):
+    _NOSNIFF_HEADERS = {"X-Content-Type-Options": "nosniff"}
+
     def __init__(self, auto_queue_persist: AutoQueuePersist):
         self.__auto_queue_persist = auto_queue_persist
 
@@ -21,13 +23,11 @@ class AutoQueueHandler(IHandler):
         web_app.add_handler("/server/autoqueue/add/<pattern>", self.__handle_add_autoqueue)
         web_app.add_handler("/server/autoqueue/remove/<pattern>", self.__handle_remove_autoqueue)
 
-    _TEXT_HEADERS = {"X-Content-Type-Options": "nosniff"}
-
     def __handle_get_autoqueue(self):
         patterns = list(self.__auto_queue_persist.patterns)
         patterns.sort(key=lambda p: p.pattern)
         out_json = SerializeAutoQueue.patterns(patterns)
-        return HTTPResponse(body=out_json)
+        return HTTPResponse(body=out_json, content_type="application/json", headers=self._NOSNIFF_HEADERS)
 
     def __handle_add_autoqueue(self, pattern: str):
         # value is double encoded
@@ -40,21 +40,21 @@ class AutoQueueHandler(IHandler):
                 body=f"Auto-queue pattern '{pattern}' already exists.",
                 status=400,
                 content_type="text/plain",
-                headers=self._TEXT_HEADERS,
+                headers=self._NOSNIFF_HEADERS,
             )
         try:
             self.__auto_queue_persist.add_pattern(aqp)
             return HTTPResponse(
                 body=f"Added auto-queue pattern '{pattern}'.",
                 content_type="text/plain",
-                headers=self._TEXT_HEADERS,
+                headers=self._NOSNIFF_HEADERS,
             )
         except ValueError as e:
             return HTTPResponse(
                 body=str(e),
                 status=400,
                 content_type="text/plain",
-                headers=self._TEXT_HEADERS,
+                headers=self._NOSNIFF_HEADERS,
             )
 
     def __handle_remove_autoqueue(self, pattern: str):
@@ -68,11 +68,11 @@ class AutoQueueHandler(IHandler):
                 body=f"Auto-queue pattern '{pattern}' doesn't exist.",
                 status=400,
                 content_type="text/plain",
-                headers=self._TEXT_HEADERS,
+                headers=self._NOSNIFF_HEADERS,
             )
         self.__auto_queue_persist.remove_pattern(aqp)
         return HTTPResponse(
             body=f"Removed auto-queue pattern '{pattern}'.",
             content_type="text/plain",
-            headers=self._TEXT_HEADERS,
+            headers=self._NOSNIFF_HEADERS,
         )


### PR DESCRIPTION
Closes #404
Closes #405

## Summary
Two small security hardening fixes.

### #405 — Redact all sensitive config in debug log
The startup debug log only masked `remote_password`. Now uses `Config.sensitive_property_names()` to redact all sensitive fields: `remote_password`, `api_key`, `sonarr_api_key`, `radarr_api_key`.

### #404 — Content-Type/nosniff on auto_queue responses
The auto_queue handler returned user-provided pattern strings with Bottle's default `text/html` Content-Type. A pattern like `<script>` could be interpreted as HTML. Now all responses set `content_type="text/plain"` and `X-Content-Type-Options: nosniff`.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `pytest tests/unittests/test_common/` — 78 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for configuration logging by dynamically masking sensitive values.
  * Improved security headers for autoqueue operation responses with explicit content-type specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->