### PR TITLE
Extract ModelRegistry from controller.py (#394 Phase 2D)

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import copy
 import logging
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from enum import Enum
 from queue import Queue
-from threading import Lock
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -17,7 +15,7 @@ if TYPE_CHECKING:
 
 from common import AppError, AppOneShotProcess, Constants, Context, MultiprocessingLogger
 from lftp import Lftp, LftpError, LftpJobStatus
-from model import IModelListener, Model, ModelDiff, ModelDiffUtil, ModelError, ModelFile
+from model import IModelListener, Model, ModelDiff, ModelError, ModelFile
 
 from .controller_persist import ControllerPersist
 from .delete import DeleteLocalProcess, DeleteRemoteProcess
@@ -26,6 +24,7 @@ from .delete import DeleteLocalProcess, DeleteRemoteProcess
 from .exclude_patterns import filter_excluded_files, parse_exclude_patterns
 from .extract import ExtractProcess, ExtractRequest, ExtractStatus, ExtractStatusResult
 from .model_builder import ModelBuilder
+from .model_registry import ModelRegistry
 from .move import MoveProcess
 from .pair_context import ControllerError, PairContext, configure_lftp, validate_config
 from .persist_keys import KEY_SEP, persist_key, strip_persist_key
@@ -101,15 +100,10 @@ class Controller:
         # The command queue
         self.__command_queue: Queue[Controller.Command] = Queue()
 
-        # The model (shared across all pairs)
-        self.__model = Model()
-        self.__model.set_base_logger(self.logger)
-        # Lock for the model
-        # Note: While the scanners are in a separate process, the rest of the application
-        #       is threaded in a single process. (The webserver is bottle+wsgiref which is
-        #       multi-threaded). Therefore it is safe to use a threading Lock for the model
-        #       (the scanner processes never try to access the model)
-        self.__model_lock = Lock()
+        # The model registry (shared across all pairs, thread-safe)
+        _model = Model()
+        _model.set_base_logger(self.logger)
+        self.__registry = ModelRegistry(_model)
 
         # Setup multiprocess logging (shared)
         self.__mp_logger = MultiprocessingLogger(self.logger)
@@ -367,51 +361,19 @@ class Controller:
             self.logger.info("Exited controller")
 
     def get_model_files(self) -> list[ModelFile]:
-        """
-        Returns a copy of all the model files
-        :return:
-        """
-        with self.__model_lock:
-            model_files = self.__get_model_files()
-        return model_files
+        return self.__registry.get_files()
 
     def add_model_listener(self, listener: IModelListener):
-        """
-        Adds a listener to the controller's model
-        :param listener:
-        :return:
-        """
-        with self.__model_lock:
-            self.__model.add_listener(listener)
+        self.__registry.add_listener(listener)
 
     def remove_model_listener(self, listener: IModelListener):
-        """
-        Removes a listener from the controller's model
-        :param listener:
-        :return:
-        """
-        with self.__model_lock:
-            self.__model.remove_listener(listener)
+        self.__registry.remove_listener(listener)
 
     def get_model_files_and_add_listener(self, listener: IModelListener):
-        """
-        Adds a listener and returns the current state of model files in one atomic operation
-        :param listener:
-        :return:
-        """
-        with self.__model_lock:
-            self.__model.add_listener(listener)
-            model_files = self.__get_model_files()
-        return model_files
+        return self.__registry.get_files_and_add_listener(listener)
 
     def queue_command(self, command: Command):
         self.__command_queue.put(command)
-
-    def __get_model_files(self) -> list[ModelFile]:
-        model_files: list[ModelFile] = []
-        for file in self.__model.get_all_files():
-            model_files.append(copy.deepcopy(file))
-        return model_files
 
     def _get_pair_context_for_command(self, command: Command) -> PairContext | None:
         """Find the pair context for a command based on pair_id."""
@@ -541,164 +503,147 @@ class Controller:
                     new_model.add_file(file)
                     seen_names_by_path[norm_path].add(file.name)
 
-            with self.__model_lock:
-                model_diff = ModelDiffUtil.diff_models(self.__model, new_model)
+            model_diff = self.__registry.apply_diff(new_model)
 
-                for diff in model_diff:
-                    if diff.change == ModelDiff.Change.ADDED:
-                        assert diff.new_file is not None
-                        self.__model.add_file(diff.new_file)
-                    elif diff.change == ModelDiff.Change.REMOVED:
-                        assert diff.old_file is not None
-                        self.__model.remove_file(diff.old_file.name, pair_id=diff.old_file.pair_id)
-                    elif diff.change == ModelDiff.Change.UPDATED:
-                        assert diff.new_file is not None
-                        self.__model.update_file(diff.new_file)
+            for diff in model_diff:
+                diff_file = diff.new_file or diff.old_file
+                assert diff_file is not None
+                pc = self._get_pair_context_for_file(diff_file)
 
-                    diff_file = diff.new_file or diff.old_file
-                    assert diff_file is not None
-                    pc = self._get_pair_context_for_file(diff_file)
+                if diff.new_file is not None and diff.new_file.state in (
+                    ModelFile.State.QUEUED,
+                    ModelFile.State.DOWNLOADING,
+                ):
+                    pkey = persist_key(diff.new_file.pair_id, diff.new_file.name)
+                    self.__moved_file_keys.discard(pkey)
+                    self.__persist.downloaded_file_names.discard(pkey)
+                    self.__persist.extracted_file_names.discard(pkey)
+                    self.__persist.extract_failed_file_names.discard(pkey)
+                    self.__persist.validated_file_names.discard(pkey)
+                    self.__persist.corrupt_file_names.discard(pkey)
+                    self._sync_persist_to_all_builders()
 
-                    if diff.new_file is not None and diff.new_file.state in (
-                        ModelFile.State.QUEUED,
-                        ModelFile.State.DOWNLOADING,
-                    ):
-                        pkey = persist_key(diff.new_file.pair_id, diff.new_file.name)
-                        self.__moved_file_keys.discard(pkey)
-                        self.__persist.downloaded_file_names.discard(pkey)
-                        self.__persist.extracted_file_names.discard(pkey)
-                        self.__persist.extract_failed_file_names.discard(pkey)
-                        self.__persist.validated_file_names.discard(pkey)
-                        self.__persist.corrupt_file_names.discard(pkey)
-                        self._sync_persist_to_all_builders()
+                downloaded = False
+                if (
+                    diff.change == ModelDiff.Change.ADDED
+                    and diff.new_file is not None
+                    and diff.new_file.state == ModelFile.State.DOWNLOADED
+                ) or (
+                    diff.change == ModelDiff.Change.UPDATED
+                    and diff.new_file is not None
+                    and diff.new_file.state == ModelFile.State.DOWNLOADED
+                    and diff.old_file is not None
+                    and diff.old_file.state != ModelFile.State.DOWNLOADED
+                ):
+                    downloaded = True
+                if downloaded:
+                    assert diff.new_file is not None
+                    assert pc is not None
+                    pkey = persist_key(diff.new_file.pair_id, diff.new_file.name)
+                    self.__persist.downloaded_file_names.add(pkey)
+                    self._sync_persist_to_all_builders()
 
-                    downloaded = False
+                    # Auto-validate if enabled
                     if (
-                        diff.change == ModelDiff.Change.ADDED
-                        and diff.new_file is not None
-                        and diff.new_file.state == ModelFile.State.DOWNLOADED
-                    ) or (
-                        diff.change == ModelDiff.Change.UPDATED
-                        and diff.new_file is not None
-                        and diff.new_file.state == ModelFile.State.DOWNLOADED
-                        and diff.old_file is not None
-                        and diff.old_file.state != ModelFile.State.DOWNLOADED
+                        self.__context.config.validate.enabled
+                        and self.__context.config.validate.auto_validate
+                        and diff.new_file.remote_size is not None
                     ):
-                        downloaded = True
-                    if downloaded:
-                        assert diff.new_file is not None
-                        assert pc is not None
-                        pkey = persist_key(diff.new_file.pair_id, diff.new_file.name)
-                        self.__persist.downloaded_file_names.add(pkey)
-                        self._sync_persist_to_all_builders()
+                        req = ValidateRequest(
+                            name=diff.new_file.name,
+                            is_dir=diff.new_file.is_dir,
+                            pair_id=pc.pair_id,
+                            local_path=pc.effective_local_path,
+                            remote_path=pc.remote_path,
+                            algorithm=self.__context.config.validate.algorithm,  # type: ignore[arg-type]
+                            remote_address=self.__context.config.lftp.remote_address,  # type: ignore[arg-type]
+                            remote_username=self.__context.config.lftp.remote_username,  # type: ignore[arg-type]
+                            remote_password=self.__password,
+                            remote_port=self.__context.config.lftp.remote_port,  # type: ignore[arg-type]
+                        )
+                        self.__validate_process.validate(req)
+                        self.__pending_validation_keys.add(persist_key(pc.pair_id, diff.new_file.name))
+                        self.logger.info(f"Auto-queued validation for '{diff.new_file.name}'")
 
-                        # Auto-validate if enabled
-                        if (
+                    if self.__context.config.controller.use_staging and self.__context.config.controller.staging_path:
+                        will_auto_extract = (
+                            self.__context.config.autoqueue.auto_extract and diff.new_file.is_extractable
+                        )
+                        will_auto_validate = (
                             self.__context.config.validate.enabled
                             and self.__context.config.validate.auto_validate
                             and diff.new_file.remote_size is not None
-                        ):
-                            req = ValidateRequest(
-                                name=diff.new_file.name,
-                                is_dir=diff.new_file.is_dir,
-                                pair_id=pc.pair_id,
-                                local_path=pc.effective_local_path,
-                                remote_path=pc.remote_path,
-                                algorithm=self.__context.config.validate.algorithm,  # type: ignore[arg-type]
-                                remote_address=self.__context.config.lftp.remote_address,  # type: ignore[arg-type]
-                                remote_username=self.__context.config.lftp.remote_username,  # type: ignore[arg-type]
-                                remote_password=self.__password,
-                                remote_port=self.__context.config.lftp.remote_port,  # type: ignore[arg-type]
-                            )
-                            self.__validate_process.validate(req)
-                            self.__pending_validation_keys.add(persist_key(pc.pair_id, diff.new_file.name))
-                            self.logger.info(f"Auto-queued validation for '{diff.new_file.name}'")
-
-                        if (
-                            self.__context.config.controller.use_staging
-                            and self.__context.config.controller.staging_path
-                        ):
-                            will_auto_extract = (
-                                self.__context.config.autoqueue.auto_extract and diff.new_file.is_extractable
-                            )
-                            will_auto_validate = (
-                                self.__context.config.validate.enabled
-                                and self.__context.config.validate.auto_validate
-                                and diff.new_file.remote_size is not None
-                            )
-                            if not will_auto_extract and not will_auto_validate:
-                                self.__spawn_move_process(diff.new_file.name, pc)
-
-                    if diff.new_file is not None and pc is not None and diff.new_file.name in pc.pending_completion:
-                        use_staging = (
-                            self.__context.config.controller.use_staging
-                            and self.__context.config.controller.staging_path
                         )
-                        # A file with no local presence and DEFAULT state means
-                        # it was deleted locally (e.g. stopped download whose files
-                        # were removed). Nothing left to track.
-                        if diff.new_file.state == ModelFile.State.DEFAULT and diff.new_file.local_size is None:
+                        if not will_auto_extract and not will_auto_validate:
+                            self.__spawn_move_process(diff.new_file.name, pc)
+
+                if diff.new_file is not None and pc is not None and diff.new_file.name in pc.pending_completion:
+                    use_staging = (
+                        self.__context.config.controller.use_staging and self.__context.config.controller.staging_path
+                    )
+                    # A file with no local presence and DEFAULT state means
+                    # it was deleted locally (e.g. stopped download whose files
+                    # were removed). Nothing left to track.
+                    if diff.new_file.state == ModelFile.State.DEFAULT and diff.new_file.local_size is None:
+                        pc.pending_completion.discard(diff.new_file.name)
+                    elif use_staging:
+                        move_key = persist_key(diff.new_file.pair_id, diff.new_file.name)
+                        if move_key in self.__moved_file_keys or diff.new_file.state in (
+                            ModelFile.State.DELETED,
+                            ModelFile.State.EXTRACTED,
+                            ModelFile.State.EXTRACT_FAILED,
+                            ModelFile.State.VALIDATED,
+                            ModelFile.State.CORRUPT,
+                        ):
                             pc.pending_completion.discard(diff.new_file.name)
-                        elif use_staging:
-                            move_key = persist_key(diff.new_file.pair_id, diff.new_file.name)
-                            if move_key in self.__moved_file_keys or diff.new_file.state in (
-                                ModelFile.State.DELETED,
-                                ModelFile.State.EXTRACTED,
-                                ModelFile.State.EXTRACT_FAILED,
-                                ModelFile.State.VALIDATED,
-                                ModelFile.State.CORRUPT,
-                            ):
-                                pc.pending_completion.discard(diff.new_file.name)
-                        else:
-                            if diff.new_file.state in (
-                                ModelFile.State.DOWNLOADED,
-                                ModelFile.State.EXTRACTED,
-                                ModelFile.State.EXTRACT_FAILED,
-                                ModelFile.State.VALIDATED,
-                                ModelFile.State.CORRUPT,
-                                ModelFile.State.DELETED,
-                            ):
-                                pc.pending_completion.discard(diff.new_file.name)
+                    else:
+                        if diff.new_file.state in (
+                            ModelFile.State.DOWNLOADED,
+                            ModelFile.State.EXTRACTED,
+                            ModelFile.State.EXTRACT_FAILED,
+                            ModelFile.State.VALIDATED,
+                            ModelFile.State.CORRUPT,
+                            ModelFile.State.DELETED,
+                        ):
+                            pc.pending_completion.discard(diff.new_file.name)
 
-                # Prune the extracted files list of any files that were deleted locally
-                remove_extracted_keys: set[str] = set()
-                for pkey in self.__persist.extracted_file_names:
-                    # Find the file in the model by checking each pair
-                    for _pc in self.__pair_contexts:
-                        bare_name = strip_persist_key(pkey, _pc.pair_id)
-                        if bare_name != pkey or _pc.pair_id is None:
-                            try:
-                                file = self.__model.get_file(bare_name, pair_id=_pc.pair_id)
-                                if file.state == ModelFile.State.DELETED:
-                                    remove_extracted_keys.add(pkey)
-                            except ModelError:
-                                pass
-                if remove_extracted_keys:
-                    self.logger.info(f"Removing from extracted list: {remove_extracted_keys}")
-                    self.__persist.extracted_file_names.difference_update(remove_extracted_keys)
-                    self._sync_persist_to_all_builders()
+        # Prune the extracted files list of any files that were deleted locally
+        remove_extracted_keys: set[str] = set()
+        for pkey in self.__persist.extracted_file_names:
+            # Find the file in the model by checking each pair
+            for _pc in self.__pair_contexts:
+                bare_name = strip_persist_key(pkey, _pc.pair_id)
+                if bare_name != pkey or _pc.pair_id is None:
+                    try:
+                        file = self.__registry.get_file(bare_name, pair_id=_pc.pair_id)
+                        if file.state == ModelFile.State.DELETED:
+                            remove_extracted_keys.add(pkey)
+                    except ModelError:
+                        pass
+        if remove_extracted_keys:
+            self.logger.info(f"Removing from extracted list: {remove_extracted_keys}")
+            self.__persist.extracted_file_names.difference_update(remove_extracted_keys)
+            self._sync_persist_to_all_builders()
 
-                # Persist cleanup: remove entries for files absent from all sources
-                all_scans_received = all(
-                    _pc.remote_scan_received and _pc.local_scan_received for _pc in self.__pair_contexts
-                )
-                if all_scans_received:
-                    # Build a set of all composite keys present in the model
-                    model_keys: set[str] = set()
-                    for f in self.__model.get_all_files():
-                        model_keys.add(persist_key(f.pair_id, f.name))
-                    absent_keys: set[str] = set()
-                    for pkey in self.__persist.downloaded_file_names:
-                        if pkey not in model_keys and pkey not in self.__moved_file_keys:
-                            absent_keys.add(pkey)
-                    if absent_keys:
-                        self.logger.info(f"Persist cleanup (both absent): {absent_keys}")
-                        self.__persist.downloaded_file_names.difference_update(absent_keys)
-                        self.__persist.extracted_file_names.difference_update(absent_keys)
-                        self.__persist.extract_failed_file_names.difference_update(absent_keys)
-                        self.__persist.validated_file_names.difference_update(absent_keys)
-                        self.__persist.corrupt_file_names.difference_update(absent_keys)
-                        self._sync_persist_to_all_builders()
+        # Persist cleanup: remove entries for files absent from all sources
+        all_scans_received = all(_pc.remote_scan_received and _pc.local_scan_received for _pc in self.__pair_contexts)
+        if all_scans_received:
+            # Build a set of all composite keys present in the model
+            model_keys: set[str] = set()
+            for f in self.__registry.get_all_files():
+                model_keys.add(persist_key(f.pair_id, f.name))
+            absent_keys: set[str] = set()
+            for pkey in self.__persist.downloaded_file_names:
+                if pkey not in model_keys and pkey not in self.__moved_file_keys:
+                    absent_keys.add(pkey)
+            if absent_keys:
+                self.logger.info(f"Persist cleanup (both absent): {absent_keys}")
+                self.__persist.downloaded_file_names.difference_update(absent_keys)
+                self.__persist.extracted_file_names.difference_update(absent_keys)
+                self.__persist.extract_failed_file_names.difference_update(absent_keys)
+                self.__persist.validated_file_names.difference_update(absent_keys)
+                self.__persist.corrupt_file_names.difference_update(absent_keys)
+                self._sync_persist_to_all_builders()
 
         # Process extraction failures — mark as failed immediately
         for result in latest_failed_extractions:
@@ -902,7 +847,7 @@ class Controller:
                 continue
 
             try:
-                file = self.__model.get_file(command.filename, pair_id=pc.pair_id)
+                file = self.__registry.get_file(command.filename, pair_id=pc.pair_id)
             except ModelError:
                 _notify_failure(command, f"File '{command.filename}' not found")
                 continue

--- a/src/python/controller/model_registry.py
+++ b/src/python/controller/model_registry.py
@@ -1,0 +1,87 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+"""Thread-safe model and listener registry.
+
+Encapsulates the Model, its lock, and listener management. Extracted from
+controller.py as part of the controller decomposition (#394 Phase 2D).
+"""
+
+from __future__ import annotations
+
+import copy
+from threading import Lock
+
+from model import IModelListener, Model, ModelDiff, ModelDiffUtil, ModelFile
+
+
+class ModelRegistry:
+    """Owns the Model instance and its lock.
+
+    Public API methods (get_files, add_listener, etc.) are thread-safe.
+    The ``apply_diff`` method is also thread-safe and returns the diffs
+    so the caller can process side effects outside the lock.
+
+    Direct model access (``get_file``, ``get_all_files``) is provided for
+    the controller thread which doesn't need locking (single-threaded access).
+    """
+
+    def __init__(self, model: Model):
+        self._model = model
+        self._lock = Lock()
+
+    # --- Thread-safe public API (used by external callers) ---
+
+    def get_files(self) -> list[ModelFile]:
+        """Return a deep copy of all model files (thread-safe)."""
+        with self._lock:
+            return [copy.deepcopy(f) for f in self._model.get_all_files()]
+
+    def add_listener(self, listener: IModelListener) -> None:
+        """Add a model listener (thread-safe)."""
+        with self._lock:
+            self._model.add_listener(listener)
+
+    def remove_listener(self, listener: IModelListener) -> None:
+        """Remove a model listener (thread-safe)."""
+        with self._lock:
+            self._model.remove_listener(listener)
+
+    def get_files_and_add_listener(self, listener: IModelListener) -> list[ModelFile]:
+        """Add a listener and return current files atomically (thread-safe)."""
+        with self._lock:
+            self._model.add_listener(listener)
+            return [copy.deepcopy(f) for f in self._model.get_all_files()]
+
+    # --- Mutation API (thread-safe, called from controller thread) ---
+
+    def apply_diff(self, new_model: Model) -> list[ModelDiff]:
+        """Diff the current model against new_model, apply changes, and return the diffs.
+
+        The diff computation and model mutation happen atomically under the lock.
+        Listeners are notified during mutation (inside the lock).
+        The returned diffs can be used by the caller for side-effect processing
+        outside the lock.
+        """
+        with self._lock:
+            diffs = ModelDiffUtil.diff_models(self._model, new_model)
+            for diff in diffs:
+                if diff.change == ModelDiff.Change.ADDED:
+                    assert diff.new_file is not None
+                    self._model.add_file(diff.new_file)
+                elif diff.change == ModelDiff.Change.REMOVED:
+                    assert diff.old_file is not None
+                    self._model.remove_file(diff.old_file.name, pair_id=diff.old_file.pair_id)
+                elif diff.change == ModelDiff.Change.UPDATED:
+                    assert diff.new_file is not None
+                    self._model.update_file(diff.new_file)
+            return diffs
+
+    # --- Direct access (controller thread only, no lock needed) ---
+
+    def get_file(self, name: str, pair_id: str | None = None) -> ModelFile:
+        """Get a single file by name. Not thread-safe — controller thread only."""
+        return self._model.get_file(name, pair_id=pair_id)
+
+    def get_all_files(self) -> list[ModelFile]:
+        """Get all files (no copy). Not thread-safe — controller thread only."""
+        return self._model.get_all_files()

--- a/src/python/controller/model_registry.py
+++ b/src/python/controller/model_registry.py
@@ -9,7 +9,7 @@ controller.py as part of the controller decomposition (#394 Phase 2D).
 from __future__ import annotations
 
 import copy
-from threading import Lock
+from threading import RLock
 
 from model import IModelListener, Model, ModelDiff, ModelDiffUtil, ModelFile
 
@@ -27,7 +27,7 @@ class ModelRegistry:
 
     def __init__(self, model: Model):
         self._model = model
-        self._lock = Lock()
+        self._lock = RLock()
 
     # --- Thread-safe public API (used by external callers) ---
 

--- a/src/python/tests/unittests/test_controller/test_controller_lock.py
+++ b/src/python/tests/unittests/test_controller/test_controller_lock.py
@@ -1,31 +1,28 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
-"""Tests for Controller's __model_lock exception-safety.
+"""Tests for ModelRegistry lock exception-safety.
 
 Regression test for https://github.com/nitrobass24/seedsync/issues/373
 
-Previously the short model-lock regions used raw acquire()/release() pairs
-with no try/finally.  An exception raised inside the locked body would leak
-the lock forever and every subsequent caller would deadlock.  After
-converting those regions to `with self.__model_lock:` blocks, the lock is
-guaranteed to release on exception.
+The ModelRegistry owns the model lock. These tests verify that exceptions
+raised inside locked methods still release the lock (otherwise the next
+caller would deadlock).
 """
 
 import unittest
-from threading import Lock
 from unittest.mock import MagicMock
 
 import timeout_decorator
 
-from controller import Controller
-from model import IModelListener
+from controller.model_registry import ModelRegistry
+from model import IModelListener, Model
 
 
 class _BoomError(Exception):
     """Custom exception used to prove the lock was released on raise."""
 
 
-class TestControllerModelLockExceptionSafety(unittest.TestCase):
+class TestModelRegistryLockExceptionSafety(unittest.TestCase):
     """Verify that exceptions raised inside a model-lock region still
     release the lock (otherwise the next caller would deadlock).
 
@@ -35,17 +32,12 @@ class TestControllerModelLockExceptionSafety(unittest.TestCase):
     """
 
     def setUp(self):
-        # Build a Controller instance without running __init__ — we only need
-        # the private attributes the methods under test actually touch.
-        self.controller = Controller.__new__(Controller)
-        # Name-mangled private attributes:
-        self.controller._Controller__model_lock = Lock()
-        self.controller._Controller__model = MagicMock()
+        self.mock_model = MagicMock(spec=Model)
+        self.mock_model.get_all_files.return_value = []
+        self.registry = ModelRegistry(self.mock_model)
 
     @timeout_decorator.timeout(5)
-    def test_get_model_files_releases_lock_on_exception(self):
-        # Replace the private helper with one that raises on first call, then
-        # returns normally.
+    def test_get_files_releases_lock_on_exception(self):
         calls = {"n": 0}
 
         def flaky():
@@ -54,25 +46,21 @@ class TestControllerModelLockExceptionSafety(unittest.TestCase):
                 raise _BoomError("boom")
             return []
 
-        # Patch the name-mangled method.
-        self.controller._Controller__get_model_files = flaky  # type: ignore[attr-defined]
+        self.mock_model.get_all_files.side_effect = flaky
 
-        # First call raises — this is the scenario that previously leaked
-        # the lock (acquire, raise, release never called).
         with self.assertRaises(_BoomError):
-            self.controller.get_model_files()
+            self.registry.get_files()
 
-        # Second call must complete.  Before the fix this deadlocked
-        # forever because the lock was still held.
-        result = self.controller.get_model_files()
+        # Recovery call: must not deadlock.
+        result = self.registry.get_files()
         self.assertEqual(result, [])
 
         # Sanity: lock must currently be free.
-        self.assertTrue(self.controller._Controller__model_lock.acquire(blocking=False))
-        self.controller._Controller__model_lock.release()
+        self.assertTrue(self.registry._lock.acquire(blocking=False))
+        self.registry._lock.release()
 
     @timeout_decorator.timeout(5)
-    def test_add_model_listener_releases_lock_on_exception(self):
+    def test_add_listener_releases_lock_on_exception(self):
         listener = MagicMock(spec=IModelListener)
         calls = {"n": 0}
 
@@ -81,19 +69,19 @@ class TestControllerModelLockExceptionSafety(unittest.TestCase):
             if calls["n"] == 1:
                 raise _BoomError("boom")
 
-        self.controller._Controller__model.add_listener.side_effect = flaky_add
+        self.mock_model.add_listener.side_effect = flaky_add
 
         with self.assertRaises(_BoomError):
-            self.controller.add_model_listener(listener)
+            self.registry.add_listener(listener)
 
         # Recovery call: must not deadlock.
-        self.controller.add_model_listener(listener)
+        self.registry.add_listener(listener)
 
-        self.assertTrue(self.controller._Controller__model_lock.acquire(blocking=False))
-        self.controller._Controller__model_lock.release()
+        self.assertTrue(self.registry._lock.acquire(blocking=False))
+        self.registry._lock.release()
 
     @timeout_decorator.timeout(5)
-    def test_remove_model_listener_releases_lock_on_exception(self):
+    def test_remove_listener_releases_lock_on_exception(self):
         listener = MagicMock(spec=IModelListener)
         calls = {"n": 0}
 
@@ -102,18 +90,18 @@ class TestControllerModelLockExceptionSafety(unittest.TestCase):
             if calls["n"] == 1:
                 raise _BoomError("boom")
 
-        self.controller._Controller__model.remove_listener.side_effect = flaky_remove
+        self.mock_model.remove_listener.side_effect = flaky_remove
 
         with self.assertRaises(_BoomError):
-            self.controller.remove_model_listener(listener)
+            self.registry.remove_listener(listener)
 
-        self.controller.remove_model_listener(listener)
+        self.registry.remove_listener(listener)
 
-        self.assertTrue(self.controller._Controller__model_lock.acquire(blocking=False))
-        self.controller._Controller__model_lock.release()
+        self.assertTrue(self.registry._lock.acquire(blocking=False))
+        self.registry._lock.release()
 
     @timeout_decorator.timeout(5)
-    def test_get_model_files_and_add_listener_releases_lock_on_exception(self):
+    def test_get_files_and_add_listener_releases_lock_on_exception(self):
         listener = MagicMock(spec=IModelListener)
         calls = {"n": 0}
 
@@ -122,18 +110,16 @@ class TestControllerModelLockExceptionSafety(unittest.TestCase):
             if calls["n"] == 1:
                 raise _BoomError("boom")
 
-        self.controller._Controller__model.add_listener.side_effect = flaky_add
-        # __get_model_files must exist — provide a trivial stub.
-        self.controller._Controller__get_model_files = lambda: []  # type: ignore[attr-defined]
+        self.mock_model.add_listener.side_effect = flaky_add
 
         with self.assertRaises(_BoomError):
-            self.controller.get_model_files_and_add_listener(listener)
+            self.registry.get_files_and_add_listener(listener)
 
-        result = self.controller.get_model_files_and_add_listener(listener)
+        result = self.registry.get_files_and_add_listener(listener)
         self.assertEqual(result, [])
 
-        self.assertTrue(self.controller._Controller__model_lock.acquire(blocking=False))
-        self.controller._Controller__model_lock.release()
+        self.assertTrue(self.registry._lock.acquire(blocking=False))
+        self.registry._lock.release()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part of #394

## Summary
New `ModelRegistry` class encapsulates the `Model`, its `Lock`, and listener management. Controller's 4 public model API methods become one-line delegates.

| Method | Thread-safe | Purpose |
|--------|:-----------:|---------|
| `get_files()` | Yes | Deep copy of all model files |
| `add_listener()` | Yes | Add model listener |
| `remove_listener()` | Yes | Remove model listener |
| `get_files_and_add_listener()` | Yes | Atomic add + get |
| `apply_diff(new_model)` | Yes | Diff, mutate, notify — returns diffs for side effects |
| `get_file()` | No | Direct read (controller thread only) |
| `get_all_files()` | No | Direct read (controller thread only) |

## Key design decision
`apply_diff` keeps the diff computation and model mutation atomic under the lock, but returns the diffs so the controller can process side effects (persist updates, move spawning, etc.) outside the lock. This keeps the lock hold time minimal while preserving correctness.

## What changed
- Removed `__model`, `__model_lock`, `__get_model_files` from Controller
- Removed `copy`, `Lock`, `ModelDiffUtil` imports from controller.py
- Lock safety tests (`test_controller_lock.py`) now test `ModelRegistry` directly

## Stats (cumulative from 1433)
- `controller.py`: 1180 → 1125 lines (**-308 total**)
- New file: `controller/model_registry.py` (87 lines)

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] 375 tests pass (including 4 lock safety tests rewritten for ModelRegistry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal model state management to use a centralized registry pattern, improving thread-safety and simplifying model access APIs while maintaining existing functionality.

* **Tests**
  * Updated tests to validate the new thread-safety mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->