### PR TITLE
Extract ModelUpdater from controller.py (#394 Phase 3F)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ When you see these, open an issue for the extraction rather than working around 
 ### Enforcement
 
 - **Qualitative checks**: code review. Reviewers should push back on "this file is getting unwieldy" even without a hard rule.
-- **Mechanical checks** (Python): ruff's `C901` (cyclomatic complexity) with `max-complexity = 12`. Tracked for rollout in a follow-up issue — not yet enabled globally.
+- **Mechanical checks** (Python): ruff's `C901` (cyclomatic complexity) with `max-complexity = 12`. Enforced in CI; existing outliers are annotated with `# noqa: C901`.
 - **Ratchet pattern**: when a bound exists but the codebase has outliers, set the threshold just above the worst and drop it over time (same pattern we use for `--max-warnings` in `ng lint`).
 
 ## GitHub Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ When you see these, open an issue for the extraction rather than working around 
 ### Enforcement
 
 - **Qualitative checks**: code review. Reviewers should push back on "this file is getting unwieldy" even without a hard rule.
-- **Mechanical checks** (Python): ruff's `C901` (cyclomatic complexity) with `max-complexity = 12`. Enforced in CI; existing outliers are annotated with `# noqa: C901`.
+- **Mechanical checks** (Python): ruff's `C901` (cyclomatic complexity) with `max-complexity = 12`. Enforced in CI; existing outliers are annotated with `# noqa: C901`. Test files (`tests/**`) are excluded via `per-file-ignores` in `pyproject.toml`.
 - **Ratchet pattern**: when a bound exists but the codebase has outliers, set the threshold just above the worst and drop it over time (same pattern we use for `--max-warnings` in `ng lint`).
 
 ## GitHub Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ These are guidelines, not hard caps. Their real job is to slow you down and ask 
 | File | ≤ 500 lines | At 400, ask "one concern or several?" |
 | Class | ≤ 300 lines | If state covers > 2 concerns, extract |
 | Function / method | ≤ 40 lines | Longer is OK when linear; deep nesting is not |
-| Cyclomatic complexity (per function) | ≤ 12 | Hard limit once `C901` is enabled in CI |
+| Cyclomatic complexity (per function) | ≤ 12 | Enforced in CI via ruff `C901` (`max-complexity = 12`) |
 
 Cyclomatic complexity is the one number that actually predicts pain — a 200-line linear function is fine; a 40-line function with 5 nested conditionals is dangerous. Use `ruff check --select C901` locally to measure.
 

--- a/src/python/controller/command_pipeline.py
+++ b/src/python/controller/command_pipeline.py
@@ -62,7 +62,7 @@ class CommandPipeline:
         self._extract_process = extract_process
         self._validate_process = validate_process
         self._logger = logger
-        self._sync_persist_callback = sync_persist_callback
+        self.sync_persist_callback = sync_persist_callback
 
         # The command queue
         self.command_queue: Queue[Controller.Command] = Queue()
@@ -150,7 +150,7 @@ class CommandPipeline:
                     continue
                 pkey = persist_key(pc.pair_id, file.name)
                 self._persist.extract_failed_file_names.discard(pkey)
-                self._sync_persist_callback()
+                self.sync_persist_callback()
                 req = self._build_extract_request(file, pc)
                 self._extract_process.extract(req)
 
@@ -262,7 +262,7 @@ class CommandPipeline:
                 pkey = persist_key(pc.pair_id, file.name)
                 self._persist.validated_file_names.discard(pkey)
                 self._persist.corrupt_file_names.discard(pkey)
-                self._sync_persist_callback()
+                self.sync_persist_callback()
                 req = ValidateRequest(
                     name=file.name,
                     is_dir=file.is_dir,

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -269,7 +269,7 @@ class Controller:
         # Model builder
         model_builder = ModelBuilder(pair_id=pair_id)
         model_builder.set_base_logger(pair_logger)
-        # Persist state is filtered per-pair by _sync_persist_to_all_builders()
+        # Persist state is filtered per-pair by ModelUpdater.sync_persist_to_all_builders()
         # called after all pair contexts are built. Initialize with empty sets.
         model_builder.set_downloaded_files(set())
         model_builder.set_extracted_files(set())

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -13,21 +12,20 @@ if TYPE_CHECKING:
     pass
 
 from common import AppOneShotProcess, Constants, Context, MultiprocessingLogger
-from lftp import Lftp, LftpError, LftpJobStatus
-from model import IModelListener, Model, ModelDiff, ModelError, ModelFile
+from lftp import Lftp
+from model import IModelListener, Model, ModelFile
 
 from .command_pipeline import CommandPipeline
 from .controller_persist import ControllerPersist
 
 # my libs
-from .exclude_patterns import filter_excluded_files
-from .extract import ExtractProcess, ExtractStatus, ExtractStatusResult
+from .extract import ExtractProcess
 from .model_builder import ModelBuilder
 from .model_registry import ModelRegistry
+from .model_updater import ModelUpdater
 from .pair_context import ControllerError, PairContext, configure_lftp, validate_config
-from .persist_keys import KEY_SEP, persist_key, strip_persist_key
 from .scan import ActiveScanner, LocalScanner, RemoteScanner, ScannerProcess
-from .validate import ValidateProcess, ValidateRequest, ValidateStatusResult
+from .validate import ValidateProcess
 
 
 class Controller:
@@ -103,9 +101,8 @@ class Controller:
         # Setup multiprocess logging (shared)
         self.__mp_logger = MultiprocessingLogger(self.logger)
 
-        # Build pair contexts, then seed each builder with filtered persist state
+        # Build pair contexts (persist state is seeded after updater creation below)
         self.__pair_contexts: list[PairContext] = self._build_pair_contexts()
-        self._sync_persist_to_all_builders()
 
         # Setup extract process (global -- extraction is local-only)
         self.__extract_process = ExtractProcess()
@@ -115,7 +112,9 @@ class Controller:
         self.__validate_process = ValidateProcess()
         self.__validate_process.set_mp_log_queue(self.__mp_logger.queue, self.__mp_logger.log_level)
 
-        # Command pipeline owns the queue, active processes, and move state
+        # Command pipeline owns the queue, active processes, and move state.
+        # Use a lambda placeholder for sync_persist_callback; it will be
+        # replaced once the ModelUpdater is created (chicken-and-egg).
         self.__pipeline = CommandPipeline(
             pair_contexts=self.__pair_contexts,
             registry=self.__registry,
@@ -126,8 +125,26 @@ class Controller:
             extract_process=self.__extract_process,
             validate_process=self.__validate_process,
             logger=self.logger,
-            sync_persist_callback=self._sync_persist_to_all_builders,
+            sync_persist_callback=lambda: None,
         )
+
+        # Model updater owns the per-cycle update loop
+        self.__updater = ModelUpdater(
+            pair_contexts=self.__pair_contexts,
+            persist=self.__persist,
+            pipeline=self.__pipeline,
+            registry=self.__registry,
+            extract_process=self.__extract_process,
+            validate_process=self.__validate_process,
+            context=self.__context,
+            password=self.__password,
+            logger=self.logger,
+        )
+        # Now wire the real callback into the pipeline
+        self.__pipeline._sync_persist_callback = self.__updater.sync_persist_to_all_builders
+
+        # Seed each builder with filtered persist state
+        self.__updater.sync_persist_to_all_builders()
 
         self.__started = False
 
@@ -308,7 +325,7 @@ class Controller:
         self.__pipeline.propagate_exceptions()
         self.__pipeline.cleanup()
         self.__pipeline.step()
-        self.__update_model()
+        self.__updater.update()
 
     def exit(self):
         self.logger.debug("Exiting controller")
@@ -370,395 +387,3 @@ class Controller:
 
     def queue_command(self, command: Command):
         self.__pipeline.queue(command)
-
-    def __update_model(self):  # noqa: C901 — will be decomposed in #394
-        # Grab the latest extract results (shared)
-        latest_extract_statuses = self.__extract_process.pop_latest_statuses()
-        latest_extracted_results = self.__extract_process.pop_completed()
-        latest_failed_extractions = self.__extract_process.pop_failed()
-
-        # Grab the latest validate results (shared)
-        latest_validate_statuses = self.__validate_process.pop_latest_statuses()
-        latest_validated_results = self.__validate_process.pop_completed()
-        latest_failed_validations = self.__validate_process.pop_failed()
-
-        # Process each pair context's scan results and LFTP status
-        for pc in self.__pair_contexts:
-            self._update_pair_model_state(pc, latest_extract_statuses, latest_validate_statuses)
-
-        # Process extraction completions once (shared across all pairs)
-        if latest_extracted_results:
-            for result in latest_extracted_results:
-                owner_pc = self.__pipeline.find_pair_by_id(result.pair_id)
-                if owner_pc is None:
-                    self.logger.warning(
-                        f"Ignoring extract completion for '{result.name}': pair '{result.pair_id}' no longer exists"
-                    )
-                    continue
-                pkey = persist_key(result.pair_id, result.name)
-                self.__persist.extracted_file_names.add(pkey)
-                if self.__context.config.controller.use_staging and self.__context.config.controller.staging_path:
-                    if pkey not in self.__pipeline.pending_validation_keys:
-                        self.__pipeline.spawn_move_process(result.name, owner_pc)
-            self._sync_persist_to_all_builders()
-
-        # Build an aggregate new model from all pairs
-        any_pair_has_changes = any(pc.model_builder.has_changes() for pc in self.__pair_contexts)
-
-        if any_pair_has_changes:
-            new_model = Model()
-            _dummy = logging.getLogger("dummy")
-            _dummy.propagate = False
-            new_model.set_base_logger(_dummy)  # silence logs for temp model
-
-            # When multiple pairs share the same local directory, a file that
-            # exists only locally (no remote counterpart) would appear in every
-            # pair's model.  Deduplicate by scoping per normalized local path:
-            #   1) adding all "managed" files first (have a remote, or non-DEFAULT state),
-            #   2) then adding local-only files only if no other pair with the
-            #      same local directory already claims a file with that name.
-            seen_names_by_path: dict[str, set[str]] = {}
-            deferred_local_only: list[tuple[ModelFile, str]] = []
-            for pc in self.__pair_contexts:
-                norm_path = os.path.normpath(os.path.abspath(pc.local_path))
-                if norm_path not in seen_names_by_path:
-                    seen_names_by_path[norm_path] = set()
-                pair_model = pc.model_builder.build_model()
-                for file in pair_model.get_all_files():
-                    is_local_only = file.remote_size is None and file.state == ModelFile.State.DEFAULT
-                    if is_local_only:
-                        deferred_local_only.append((file, norm_path))
-                    else:
-                        new_model.add_file(file)
-                        seen_names_by_path[norm_path].add(file.name)
-
-            for file, norm_path in deferred_local_only:
-                if file.name not in seen_names_by_path[norm_path]:
-                    new_model.add_file(file)
-                    seen_names_by_path[norm_path].add(file.name)
-
-            model_diff = self.__registry.apply_diff(new_model)
-
-            for diff in model_diff:
-                diff_file = diff.new_file or diff.old_file
-                assert diff_file is not None
-                pc = self.__pipeline.get_pair_context_for_file(diff_file)
-
-                if diff.new_file is not None and diff.new_file.state in (
-                    ModelFile.State.QUEUED,
-                    ModelFile.State.DOWNLOADING,
-                ):
-                    pkey = persist_key(diff.new_file.pair_id, diff.new_file.name)
-                    self.__pipeline.moved_file_keys.discard(pkey)
-                    self.__persist.downloaded_file_names.discard(pkey)
-                    self.__persist.extracted_file_names.discard(pkey)
-                    self.__persist.extract_failed_file_names.discard(pkey)
-                    self.__persist.validated_file_names.discard(pkey)
-                    self.__persist.corrupt_file_names.discard(pkey)
-                    self._sync_persist_to_all_builders()
-
-                downloaded = False
-                if (
-                    diff.change == ModelDiff.Change.ADDED
-                    and diff.new_file is not None
-                    and diff.new_file.state == ModelFile.State.DOWNLOADED
-                ) or (
-                    diff.change == ModelDiff.Change.UPDATED
-                    and diff.new_file is not None
-                    and diff.new_file.state == ModelFile.State.DOWNLOADED
-                    and diff.old_file is not None
-                    and diff.old_file.state != ModelFile.State.DOWNLOADED
-                ):
-                    downloaded = True
-                if downloaded:
-                    assert diff.new_file is not None
-                    assert pc is not None
-                    pkey = persist_key(diff.new_file.pair_id, diff.new_file.name)
-                    self.__persist.downloaded_file_names.add(pkey)
-                    self._sync_persist_to_all_builders()
-
-                    # Auto-validate if enabled
-                    if (
-                        self.__context.config.validate.enabled
-                        and self.__context.config.validate.auto_validate
-                        and diff.new_file.remote_size is not None
-                    ):
-                        req = ValidateRequest(
-                            name=diff.new_file.name,
-                            is_dir=diff.new_file.is_dir,
-                            pair_id=pc.pair_id,
-                            local_path=pc.effective_local_path,
-                            remote_path=pc.remote_path,
-                            algorithm=self.__context.config.validate.algorithm,  # type: ignore[arg-type]
-                            remote_address=self.__context.config.lftp.remote_address,  # type: ignore[arg-type]
-                            remote_username=self.__context.config.lftp.remote_username,  # type: ignore[arg-type]
-                            remote_password=self.__password,
-                            remote_port=self.__context.config.lftp.remote_port,  # type: ignore[arg-type]
-                        )
-                        self.__validate_process.validate(req)
-                        self.__pipeline.pending_validation_keys.add(persist_key(pc.pair_id, diff.new_file.name))
-                        self.logger.info(f"Auto-queued validation for '{diff.new_file.name}'")
-
-                    if self.__context.config.controller.use_staging and self.__context.config.controller.staging_path:
-                        will_auto_extract = (
-                            self.__context.config.autoqueue.auto_extract and diff.new_file.is_extractable
-                        )
-                        will_auto_validate = (
-                            self.__context.config.validate.enabled
-                            and self.__context.config.validate.auto_validate
-                            and diff.new_file.remote_size is not None
-                        )
-                        if not will_auto_extract and not will_auto_validate:
-                            self.__pipeline.spawn_move_process(diff.new_file.name, pc)
-
-                if diff.new_file is not None and pc is not None and diff.new_file.name in pc.pending_completion:
-                    use_staging = (
-                        self.__context.config.controller.use_staging and self.__context.config.controller.staging_path
-                    )
-                    # A file with no local presence and DEFAULT state means
-                    # it was deleted locally (e.g. stopped download whose files
-                    # were removed). Nothing left to track.
-                    if diff.new_file.state == ModelFile.State.DEFAULT and diff.new_file.local_size is None:
-                        pc.pending_completion.discard(diff.new_file.name)
-                    elif use_staging:
-                        move_key = persist_key(diff.new_file.pair_id, diff.new_file.name)
-                        if move_key in self.__pipeline.moved_file_keys or diff.new_file.state in (
-                            ModelFile.State.DELETED,
-                            ModelFile.State.EXTRACTED,
-                            ModelFile.State.EXTRACT_FAILED,
-                            ModelFile.State.VALIDATED,
-                            ModelFile.State.CORRUPT,
-                        ):
-                            pc.pending_completion.discard(diff.new_file.name)
-                    else:
-                        if diff.new_file.state in (
-                            ModelFile.State.DOWNLOADED,
-                            ModelFile.State.EXTRACTED,
-                            ModelFile.State.EXTRACT_FAILED,
-                            ModelFile.State.VALIDATED,
-                            ModelFile.State.CORRUPT,
-                            ModelFile.State.DELETED,
-                        ):
-                            pc.pending_completion.discard(diff.new_file.name)
-
-        # Prune the extracted files list of any files that were deleted locally
-        remove_extracted_keys: set[str] = set()
-        for pkey in self.__persist.extracted_file_names:
-            # Find the file in the model by checking each pair
-            for _pc in self.__pair_contexts:
-                bare_name = strip_persist_key(pkey, _pc.pair_id)
-                if bare_name != pkey or _pc.pair_id is None:
-                    try:
-                        file = self.__registry.get_file(bare_name, pair_id=_pc.pair_id)
-                        if file.state == ModelFile.State.DELETED:
-                            remove_extracted_keys.add(pkey)
-                    except ModelError:
-                        pass
-        if remove_extracted_keys:
-            self.logger.info(f"Removing from extracted list: {remove_extracted_keys}")
-            self.__persist.extracted_file_names.difference_update(remove_extracted_keys)
-            self._sync_persist_to_all_builders()
-
-        # Persist cleanup: remove entries for files absent from all sources
-        all_scans_received = all(_pc.remote_scan_received and _pc.local_scan_received for _pc in self.__pair_contexts)
-        if all_scans_received:
-            # Build a set of all composite keys present in the model
-            model_keys: set[str] = set()
-            for f in self.__registry.get_all_files():
-                model_keys.add(persist_key(f.pair_id, f.name))
-            absent_keys: set[str] = set()
-            for pkey in self.__persist.downloaded_file_names:
-                if pkey not in model_keys and pkey not in self.__pipeline.moved_file_keys:
-                    absent_keys.add(pkey)
-            if absent_keys:
-                self.logger.info(f"Persist cleanup (both absent): {absent_keys}")
-                self.__persist.downloaded_file_names.difference_update(absent_keys)
-                self.__persist.extracted_file_names.difference_update(absent_keys)
-                self.__persist.extract_failed_file_names.difference_update(absent_keys)
-                self.__persist.validated_file_names.difference_update(absent_keys)
-                self.__persist.corrupt_file_names.difference_update(absent_keys)
-                self._sync_persist_to_all_builders()
-
-        # Process extraction failures — mark as failed immediately
-        for result in latest_failed_extractions:
-            self.logger.error(f"Extraction failed for '{result.name}'")
-            fail_key = persist_key(result.pair_id, result.name)
-            self.__persist.extract_failed_file_names.add(fail_key)
-            self._sync_persist_to_all_builders()
-
-        # Process validation completions — mark as validated
-        for result in latest_validated_results:
-            self.logger.info(f"Validation passed for '{result.name}'")
-            pkey = persist_key(result.pair_id, result.name)
-            self.__pipeline.pending_validation_keys.discard(pkey)
-            self.__persist.validated_file_names.add(pkey)
-            self.__persist.corrupt_file_names.discard(pkey)
-            self._sync_persist_to_all_builders()
-            # If staging is active, spawn the move process now that validation finished
-            self.__pipeline.spawn_deferred_move(result.pair_id, result.name)
-
-        # Process validation failures
-        for result in latest_failed_validations:
-            self.logger.error(f"Validation failed for '{result.name}': {result.error_message}")
-            pkey = persist_key(result.pair_id, result.name)
-            self.__pipeline.pending_validation_keys.discard(pkey)
-            if result.is_checksum_mismatch:
-                # Checksum mismatch — mark as corrupt
-                self.__persist.corrupt_file_names.add(pkey)
-                self.__persist.validated_file_names.discard(pkey)
-                self._sync_persist_to_all_builders()
-            else:
-                # Non-mismatch failure (SSH error, etc.) — don't mark corrupt,
-                # just log so the user can retry
-                self.logger.warning(
-                    f"Validation error for '{result.name}' (not marking corrupt): {result.error_message}"
-                )
-            # Spawn deferred move regardless of failure type — validation is done
-            self.__pipeline.spawn_deferred_move(result.pair_id, result.name)
-
-        # Update the controller status (use most recent across all pairs)
-        for pc in self.__pair_contexts:
-            if pc._latest_remote_scan is not None:  # type: ignore[reportPrivateUsage]
-                current = self.__context.status.controller.latest_remote_scan_time
-                if current is None or pc._latest_remote_scan.timestamp > current:  # type: ignore[reportPrivateUsage]
-                    self.__context.status.controller.latest_remote_scan_time = pc._latest_remote_scan.timestamp  # type: ignore[reportPrivateUsage]
-                    self.__context.status.controller.latest_remote_scan_failed = pc._latest_remote_scan.failed  # type: ignore[reportPrivateUsage]
-                    self.__context.status.controller.latest_remote_scan_error = pc._latest_remote_scan.error_message  # type: ignore[reportPrivateUsage]
-            if pc._latest_local_scan is not None:  # type: ignore[reportPrivateUsage]
-                current = self.__context.status.controller.latest_local_scan_time
-                if current is None or pc._latest_local_scan.timestamp > current:  # type: ignore[reportPrivateUsage]
-                    self.__context.status.controller.latest_local_scan_time = pc._latest_local_scan.timestamp  # type: ignore[reportPrivateUsage]
-
-    def _update_pair_model_state(  # noqa: C901 — will be decomposed in #394
-        self,
-        pc: PairContext,
-        latest_extract_statuses: ExtractStatusResult | None,
-        latest_validate_statuses: ValidateStatusResult | None,
-    ) -> None:
-        """
-        Update a single pair context's scan results, LFTP status, and model builder state.
-        """
-        latest_remote_scan = pc.remote_scan_process.pop_latest_result()
-        latest_local_scan = pc.local_scan_process.pop_latest_result()
-        latest_active_scan = pc.active_scan_process.pop_latest_result()
-
-        pc._latest_remote_scan = latest_remote_scan  # type: ignore[reportPrivateUsage]
-        pc._latest_local_scan = latest_local_scan  # type: ignore[reportPrivateUsage]
-
-        lftp_statuses = None
-        try:
-            lftp_statuses = pc.lftp.status()
-        except LftpError as e:
-            self.logger.warning(f"Caught lftp error (pair {pc.name}): {e!s}")
-
-        if latest_remote_scan is not None:
-            pc.remote_scan_received = True
-        if latest_local_scan is not None:
-            pc.local_scan_received = True
-
-        if lftp_statuses is not None:
-            current_downloading = {s.name for s in lftp_statuses if s.state == LftpJobStatus.State.RUNNING}
-            just_completed = pc.prev_downloading_file_names - current_downloading
-            if just_completed:
-                for name in just_completed:
-                    self.logger.info(f"Download completed (LFTP job finished): {name}")
-                self.__persist.downloaded_file_names.update(persist_key(pc.pair_id, n) for n in just_completed)
-                self._sync_persist_to_all_builders()
-                pc.pending_completion.update(just_completed)
-                pc.local_scan_process.force_scan()
-
-            pc.active_downloading_file_names = list(current_downloading)
-            pc.prev_downloading_file_names = current_downloading
-
-        if latest_extract_statuses is not None:
-            # Only include extract statuses for files that belong to this pair
-            pc.active_extracting_file_names = [
-                s.name
-                for s in latest_extract_statuses.statuses
-                if s.pair_id == pc.pair_id
-                and s.state == ExtractStatus.State.EXTRACTING
-                and persist_key(pc.pair_id, s.name) in self.__persist.downloaded_file_names
-            ]
-
-        active_files = pc.active_downloading_file_names + pc.active_extracting_file_names
-        active_files += list(pc.pending_completion)
-        pc.active_scanner.set_active_files(active_files)
-
-        pc.model_builder.set_auto_delete_remote(bool(self.__context.config.autoqueue.auto_delete_remote))
-
-        if latest_remote_scan is not None:
-            remote_files = filter_excluded_files(
-                latest_remote_scan.files, self.__context.config.general.exclude_patterns
-            )
-            pc.model_builder.set_remote_files(remote_files)
-        if latest_local_scan is not None:
-            pc.model_builder.set_local_files(latest_local_scan.files)
-        if latest_active_scan is not None:
-            pc.model_builder.set_active_files(latest_active_scan.files)
-        if lftp_statuses is not None:
-            pc.model_builder.set_lftp_statuses(lftp_statuses)
-        if latest_extract_statuses is not None:
-            pair_statuses = [s for s in latest_extract_statuses.statuses if s.pair_id == pc.pair_id]
-            pc.model_builder.set_extract_statuses(pair_statuses)
-        if latest_validate_statuses is not None:
-            pair_validate_statuses = [s for s in latest_validate_statuses.statuses if s.pair_id == pc.pair_id]
-            pc.model_builder.set_validate_statuses(pair_validate_statuses)
-
-    def _sync_persist_to_all_builders(self):  # noqa: C901 — will be decomposed in #394
-        """Push current persist state to all pair model builders, filtered by pair_id."""
-        namespaced_prefixes = tuple(
-            f"{other_pc.pair_id}{sep}"
-            for other_pc in self.__pair_contexts
-            if other_pc.pair_id
-            for sep in (KEY_SEP, ":")
-        )
-        for pc in self.__pair_contexts:
-            prefix = f"{pc.pair_id}{KEY_SEP}" if pc.pair_id else ""
-            # Defense-in-depth: from_str() migrates colon keys at load time,
-            # but we check both separators here in case of incomplete migration.
-            legacy_prefix = f"{pc.pair_id}:" if pc.pair_id else ""
-            downloaded: set[str] = set()
-            extracted: set[str] = set()
-            extract_failed: set[str] = set()
-            validated: set[str] = set()
-            corrupt: set[str] = set()
-            for key in self.__persist.downloaded_file_names:
-                if prefix and key.startswith(prefix):
-                    downloaded.add(key[len(prefix) :])
-                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
-                    downloaded.add(key[len(legacy_prefix) :])
-                elif not prefix and not key.startswith(namespaced_prefixes):
-                    downloaded.add(key)
-            for key in self.__persist.extracted_file_names:
-                if prefix and key.startswith(prefix):
-                    extracted.add(key[len(prefix) :])
-                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
-                    extracted.add(key[len(legacy_prefix) :])
-                elif not prefix and not key.startswith(namespaced_prefixes):
-                    extracted.add(key)
-            for key in self.__persist.extract_failed_file_names:
-                if prefix and key.startswith(prefix):
-                    extract_failed.add(key[len(prefix) :])
-                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
-                    extract_failed.add(key[len(legacy_prefix) :])
-                elif not prefix and not key.startswith(namespaced_prefixes):
-                    extract_failed.add(key)
-            for key in self.__persist.validated_file_names:
-                if prefix and key.startswith(prefix):
-                    validated.add(key[len(prefix) :])
-                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
-                    validated.add(key[len(legacy_prefix) :])
-                elif not prefix and not key.startswith(namespaced_prefixes):
-                    validated.add(key)
-            for key in self.__persist.corrupt_file_names:
-                if prefix and key.startswith(prefix):
-                    corrupt.add(key[len(prefix) :])
-                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
-                    corrupt.add(key[len(legacy_prefix) :])
-                elif not prefix and not key.startswith(namespaced_prefixes):
-                    corrupt.add(key)
-            pc.model_builder.set_downloaded_files(downloaded)
-            pc.model_builder.set_extracted_files(extracted)
-            pc.model_builder.set_extract_failed_files(extract_failed)
-            pc.model_builder.set_validated_files(validated)
-            pc.model_builder.set_corrupt_files(corrupt)

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -141,7 +141,7 @@ class Controller:
             logger=self.logger,
         )
         # Now wire the real callback into the pipeline
-        self.__pipeline._sync_persist_callback = self.__updater.sync_persist_to_all_builders
+        self.__pipeline.sync_persist_callback = self.__updater.sync_persist_to_all_builders
 
         # Seed each builder with filtered persist state
         self.__updater.sync_persist_to_all_builders()

--- a/src/python/controller/model_updater.py
+++ b/src/python/controller/model_updater.py
@@ -1,0 +1,443 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+"""Model update logic: scan processing, diff application, and persist sync.
+
+Owns the per-cycle model-update loop that was formerly Controller.__update_model.
+Extracted from controller.py as part of the controller decomposition
+(#394 Phase F).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from common import Context
+from lftp import LftpError, LftpJobStatus
+from model import Model, ModelDiff, ModelError, ModelFile
+
+from .command_pipeline import CommandPipeline
+from .controller_persist import ControllerPersist
+from .exclude_patterns import filter_excluded_files
+from .extract import ExtractProcess, ExtractStatus, ExtractStatusResult
+from .model_registry import ModelRegistry
+from .pair_context import PairContext
+from .persist_keys import KEY_SEP, persist_key, strip_persist_key
+from .validate import ValidateProcess, ValidateRequest, ValidateStatusResult
+
+
+class ModelUpdater:
+    """Runs the per-cycle model-update loop.
+
+    All methods preserve the exact logic from their original Controller
+    counterparts — this is a structural extraction, not a refactor.
+    """
+
+    def __init__(
+        self,
+        pair_contexts: list[PairContext],
+        persist: ControllerPersist,
+        pipeline: CommandPipeline,
+        registry: ModelRegistry,
+        extract_process: ExtractProcess,
+        validate_process: ValidateProcess,
+        context: Context,
+        password: str | None,
+        logger: logging.Logger,
+    ):
+        self._pair_contexts = pair_contexts
+        self._persist = persist
+        self._pipeline = pipeline
+        self._registry = registry
+        self._extract_process = extract_process
+        self._validate_process = validate_process
+        self._context = context
+        self._password = password
+        self._logger = logger
+
+    def update(self):  # noqa: C901 — will be decomposed in #394
+        # Grab the latest extract results (shared)
+        latest_extract_statuses = self._extract_process.pop_latest_statuses()
+        latest_extracted_results = self._extract_process.pop_completed()
+        latest_failed_extractions = self._extract_process.pop_failed()
+
+        # Grab the latest validate results (shared)
+        latest_validate_statuses = self._validate_process.pop_latest_statuses()
+        latest_validated_results = self._validate_process.pop_completed()
+        latest_failed_validations = self._validate_process.pop_failed()
+
+        # Process each pair context's scan results and LFTP status
+        for pc in self._pair_contexts:
+            self._update_pair_model_state(pc, latest_extract_statuses, latest_validate_statuses)
+
+        # Process extraction completions once (shared across all pairs)
+        if latest_extracted_results:
+            for result in latest_extracted_results:
+                owner_pc = self._pipeline.find_pair_by_id(result.pair_id)
+                if owner_pc is None:
+                    self._logger.warning(
+                        f"Ignoring extract completion for '{result.name}': pair '{result.pair_id}' no longer exists"
+                    )
+                    continue
+                pkey = persist_key(result.pair_id, result.name)
+                self._persist.extracted_file_names.add(pkey)
+                if self._context.config.controller.use_staging and self._context.config.controller.staging_path:
+                    if pkey not in self._pipeline.pending_validation_keys:
+                        self._pipeline.spawn_move_process(result.name, owner_pc)
+            self.sync_persist_to_all_builders()
+
+        # Build an aggregate new model from all pairs
+        any_pair_has_changes = any(pc.model_builder.has_changes() for pc in self._pair_contexts)
+
+        if any_pair_has_changes:
+            new_model = Model()
+            _dummy = logging.getLogger("dummy")
+            _dummy.propagate = False
+            new_model.set_base_logger(_dummy)  # silence logs for temp model
+
+            # When multiple pairs share the same local directory, a file that
+            # exists only locally (no remote counterpart) would appear in every
+            # pair's model.  Deduplicate by scoping per normalized local path:
+            #   1) adding all "managed" files first (have a remote, or non-DEFAULT state),
+            #   2) then adding local-only files only if no other pair with the
+            #      same local directory already claims a file with that name.
+            seen_names_by_path: dict[str, set[str]] = {}
+            deferred_local_only: list[tuple[ModelFile, str]] = []
+            for pc in self._pair_contexts:
+                norm_path = os.path.normpath(os.path.abspath(pc.local_path))
+                if norm_path not in seen_names_by_path:
+                    seen_names_by_path[norm_path] = set()
+                pair_model = pc.model_builder.build_model()
+                for file in pair_model.get_all_files():
+                    is_local_only = file.remote_size is None and file.state == ModelFile.State.DEFAULT
+                    if is_local_only:
+                        deferred_local_only.append((file, norm_path))
+                    else:
+                        new_model.add_file(file)
+                        seen_names_by_path[norm_path].add(file.name)
+
+            for file, norm_path in deferred_local_only:
+                if file.name not in seen_names_by_path[norm_path]:
+                    new_model.add_file(file)
+                    seen_names_by_path[norm_path].add(file.name)
+
+            model_diff = self._registry.apply_diff(new_model)
+
+            for diff in model_diff:
+                diff_file = diff.new_file or diff.old_file
+                assert diff_file is not None
+                pc = self._pipeline.get_pair_context_for_file(diff_file)
+
+                if diff.new_file is not None and diff.new_file.state in (
+                    ModelFile.State.QUEUED,
+                    ModelFile.State.DOWNLOADING,
+                ):
+                    pkey = persist_key(diff.new_file.pair_id, diff.new_file.name)
+                    self._pipeline.moved_file_keys.discard(pkey)
+                    self._persist.downloaded_file_names.discard(pkey)
+                    self._persist.extracted_file_names.discard(pkey)
+                    self._persist.extract_failed_file_names.discard(pkey)
+                    self._persist.validated_file_names.discard(pkey)
+                    self._persist.corrupt_file_names.discard(pkey)
+                    self.sync_persist_to_all_builders()
+
+                downloaded = False
+                if (
+                    diff.change == ModelDiff.Change.ADDED
+                    and diff.new_file is not None
+                    and diff.new_file.state == ModelFile.State.DOWNLOADED
+                ) or (
+                    diff.change == ModelDiff.Change.UPDATED
+                    and diff.new_file is not None
+                    and diff.new_file.state == ModelFile.State.DOWNLOADED
+                    and diff.old_file is not None
+                    and diff.old_file.state != ModelFile.State.DOWNLOADED
+                ):
+                    downloaded = True
+                if downloaded:
+                    assert diff.new_file is not None
+                    assert pc is not None
+                    pkey = persist_key(diff.new_file.pair_id, diff.new_file.name)
+                    self._persist.downloaded_file_names.add(pkey)
+                    self.sync_persist_to_all_builders()
+
+                    # Auto-validate if enabled
+                    if (
+                        self._context.config.validate.enabled
+                        and self._context.config.validate.auto_validate
+                        and diff.new_file.remote_size is not None
+                    ):
+                        req = ValidateRequest(
+                            name=diff.new_file.name,
+                            is_dir=diff.new_file.is_dir,
+                            pair_id=pc.pair_id,
+                            local_path=pc.effective_local_path,
+                            remote_path=pc.remote_path,
+                            algorithm=self._context.config.validate.algorithm,  # type: ignore[arg-type]
+                            remote_address=self._context.config.lftp.remote_address,  # type: ignore[arg-type]
+                            remote_username=self._context.config.lftp.remote_username,  # type: ignore[arg-type]
+                            remote_password=self._password,
+                            remote_port=self._context.config.lftp.remote_port,  # type: ignore[arg-type]
+                        )
+                        self._validate_process.validate(req)
+                        self._pipeline.pending_validation_keys.add(persist_key(pc.pair_id, diff.new_file.name))
+                        self._logger.info(f"Auto-queued validation for '{diff.new_file.name}'")
+
+                    if self._context.config.controller.use_staging and self._context.config.controller.staging_path:
+                        will_auto_extract = self._context.config.autoqueue.auto_extract and diff.new_file.is_extractable
+                        will_auto_validate = (
+                            self._context.config.validate.enabled
+                            and self._context.config.validate.auto_validate
+                            and diff.new_file.remote_size is not None
+                        )
+                        if not will_auto_extract and not will_auto_validate:
+                            self._pipeline.spawn_move_process(diff.new_file.name, pc)
+
+                if diff.new_file is not None and pc is not None and diff.new_file.name in pc.pending_completion:
+                    use_staging = (
+                        self._context.config.controller.use_staging and self._context.config.controller.staging_path
+                    )
+                    # A file with no local presence and DEFAULT state means
+                    # it was deleted locally (e.g. stopped download whose files
+                    # were removed). Nothing left to track.
+                    if diff.new_file.state == ModelFile.State.DEFAULT and diff.new_file.local_size is None:
+                        pc.pending_completion.discard(diff.new_file.name)
+                    elif use_staging:
+                        move_key = persist_key(diff.new_file.pair_id, diff.new_file.name)
+                        if move_key in self._pipeline.moved_file_keys or diff.new_file.state in (
+                            ModelFile.State.DELETED,
+                            ModelFile.State.EXTRACTED,
+                            ModelFile.State.EXTRACT_FAILED,
+                            ModelFile.State.VALIDATED,
+                            ModelFile.State.CORRUPT,
+                        ):
+                            pc.pending_completion.discard(diff.new_file.name)
+                    else:
+                        if diff.new_file.state in (
+                            ModelFile.State.DOWNLOADED,
+                            ModelFile.State.EXTRACTED,
+                            ModelFile.State.EXTRACT_FAILED,
+                            ModelFile.State.VALIDATED,
+                            ModelFile.State.CORRUPT,
+                            ModelFile.State.DELETED,
+                        ):
+                            pc.pending_completion.discard(diff.new_file.name)
+
+        # Prune the extracted files list of any files that were deleted locally
+        remove_extracted_keys: set[str] = set()
+        for pkey in self._persist.extracted_file_names:
+            # Find the file in the model by checking each pair
+            for _pc in self._pair_contexts:
+                bare_name = strip_persist_key(pkey, _pc.pair_id)
+                if bare_name != pkey or _pc.pair_id is None:
+                    try:
+                        file = self._registry.get_file(bare_name, pair_id=_pc.pair_id)
+                        if file.state == ModelFile.State.DELETED:
+                            remove_extracted_keys.add(pkey)
+                    except ModelError:
+                        pass
+        if remove_extracted_keys:
+            self._logger.info(f"Removing from extracted list: {remove_extracted_keys}")
+            self._persist.extracted_file_names.difference_update(remove_extracted_keys)
+            self.sync_persist_to_all_builders()
+
+        # Persist cleanup: remove entries for files absent from all sources
+        all_scans_received = all(_pc.remote_scan_received and _pc.local_scan_received for _pc in self._pair_contexts)
+        if all_scans_received:
+            # Build a set of all composite keys present in the model
+            model_keys: set[str] = set()
+            for f in self._registry.get_all_files():
+                model_keys.add(persist_key(f.pair_id, f.name))
+            absent_keys: set[str] = set()
+            for pkey in self._persist.downloaded_file_names:
+                if pkey not in model_keys and pkey not in self._pipeline.moved_file_keys:
+                    absent_keys.add(pkey)
+            if absent_keys:
+                self._logger.info(f"Persist cleanup (both absent): {absent_keys}")
+                self._persist.downloaded_file_names.difference_update(absent_keys)
+                self._persist.extracted_file_names.difference_update(absent_keys)
+                self._persist.extract_failed_file_names.difference_update(absent_keys)
+                self._persist.validated_file_names.difference_update(absent_keys)
+                self._persist.corrupt_file_names.difference_update(absent_keys)
+                self.sync_persist_to_all_builders()
+
+        # Process extraction failures — mark as failed immediately
+        for result in latest_failed_extractions:
+            self._logger.error(f"Extraction failed for '{result.name}'")
+            fail_key = persist_key(result.pair_id, result.name)
+            self._persist.extract_failed_file_names.add(fail_key)
+            self.sync_persist_to_all_builders()
+
+        # Process validation completions — mark as validated
+        for result in latest_validated_results:
+            self._logger.info(f"Validation passed for '{result.name}'")
+            pkey = persist_key(result.pair_id, result.name)
+            self._pipeline.pending_validation_keys.discard(pkey)
+            self._persist.validated_file_names.add(pkey)
+            self._persist.corrupt_file_names.discard(pkey)
+            self.sync_persist_to_all_builders()
+            # If staging is active, spawn the move process now that validation finished
+            self._pipeline.spawn_deferred_move(result.pair_id, result.name)
+
+        # Process validation failures
+        for result in latest_failed_validations:
+            self._logger.error(f"Validation failed for '{result.name}': {result.error_message}")
+            pkey = persist_key(result.pair_id, result.name)
+            self._pipeline.pending_validation_keys.discard(pkey)
+            if result.is_checksum_mismatch:
+                # Checksum mismatch — mark as corrupt
+                self._persist.corrupt_file_names.add(pkey)
+                self._persist.validated_file_names.discard(pkey)
+                self.sync_persist_to_all_builders()
+            else:
+                # Non-mismatch failure (SSH error, etc.) — don't mark corrupt,
+                # just log so the user can retry
+                self._logger.warning(
+                    f"Validation error for '{result.name}' (not marking corrupt): {result.error_message}"
+                )
+            # Spawn deferred move regardless of failure type — validation is done
+            self._pipeline.spawn_deferred_move(result.pair_id, result.name)
+
+        # Update the controller status (use most recent across all pairs)
+        for pc in self._pair_contexts:
+            if pc._latest_remote_scan is not None:  # type: ignore[reportPrivateUsage]
+                current = self._context.status.controller.latest_remote_scan_time
+                if current is None or pc._latest_remote_scan.timestamp > current:  # type: ignore[reportPrivateUsage]
+                    self._context.status.controller.latest_remote_scan_time = pc._latest_remote_scan.timestamp  # type: ignore[reportPrivateUsage]
+                    self._context.status.controller.latest_remote_scan_failed = pc._latest_remote_scan.failed  # type: ignore[reportPrivateUsage]
+                    self._context.status.controller.latest_remote_scan_error = pc._latest_remote_scan.error_message  # type: ignore[reportPrivateUsage]
+            if pc._latest_local_scan is not None:  # type: ignore[reportPrivateUsage]
+                current = self._context.status.controller.latest_local_scan_time
+                if current is None or pc._latest_local_scan.timestamp > current:  # type: ignore[reportPrivateUsage]
+                    self._context.status.controller.latest_local_scan_time = pc._latest_local_scan.timestamp  # type: ignore[reportPrivateUsage]
+
+    def _update_pair_model_state(  # noqa: C901 — will be decomposed in #394
+        self,
+        pc: PairContext,
+        latest_extract_statuses: ExtractStatusResult | None,
+        latest_validate_statuses: ValidateStatusResult | None,
+    ) -> None:
+        """
+        Update a single pair context's scan results, LFTP status, and model builder state.
+        """
+        latest_remote_scan = pc.remote_scan_process.pop_latest_result()
+        latest_local_scan = pc.local_scan_process.pop_latest_result()
+        latest_active_scan = pc.active_scan_process.pop_latest_result()
+
+        pc._latest_remote_scan = latest_remote_scan  # type: ignore[reportPrivateUsage]
+        pc._latest_local_scan = latest_local_scan  # type: ignore[reportPrivateUsage]
+
+        lftp_statuses = None
+        try:
+            lftp_statuses = pc.lftp.status()
+        except LftpError as e:
+            self._logger.warning(f"Caught lftp error (pair {pc.name}): {e!s}")
+
+        if latest_remote_scan is not None:
+            pc.remote_scan_received = True
+        if latest_local_scan is not None:
+            pc.local_scan_received = True
+
+        if lftp_statuses is not None:
+            current_downloading = {s.name for s in lftp_statuses if s.state == LftpJobStatus.State.RUNNING}
+            just_completed = pc.prev_downloading_file_names - current_downloading
+            if just_completed:
+                for name in just_completed:
+                    self._logger.info(f"Download completed (LFTP job finished): {name}")
+                self._persist.downloaded_file_names.update(persist_key(pc.pair_id, n) for n in just_completed)
+                self.sync_persist_to_all_builders()
+                pc.pending_completion.update(just_completed)
+                pc.local_scan_process.force_scan()
+
+            pc.active_downloading_file_names = list(current_downloading)
+            pc.prev_downloading_file_names = current_downloading
+
+        if latest_extract_statuses is not None:
+            # Only include extract statuses for files that belong to this pair
+            pc.active_extracting_file_names = [
+                s.name
+                for s in latest_extract_statuses.statuses
+                if s.pair_id == pc.pair_id
+                and s.state == ExtractStatus.State.EXTRACTING
+                and persist_key(pc.pair_id, s.name) in self._persist.downloaded_file_names
+            ]
+
+        active_files = pc.active_downloading_file_names + pc.active_extracting_file_names
+        active_files += list(pc.pending_completion)
+        pc.active_scanner.set_active_files(active_files)
+
+        pc.model_builder.set_auto_delete_remote(bool(self._context.config.autoqueue.auto_delete_remote))
+
+        if latest_remote_scan is not None:
+            remote_files = filter_excluded_files(
+                latest_remote_scan.files, self._context.config.general.exclude_patterns
+            )
+            pc.model_builder.set_remote_files(remote_files)
+        if latest_local_scan is not None:
+            pc.model_builder.set_local_files(latest_local_scan.files)
+        if latest_active_scan is not None:
+            pc.model_builder.set_active_files(latest_active_scan.files)
+        if lftp_statuses is not None:
+            pc.model_builder.set_lftp_statuses(lftp_statuses)
+        if latest_extract_statuses is not None:
+            pair_statuses = [s for s in latest_extract_statuses.statuses if s.pair_id == pc.pair_id]
+            pc.model_builder.set_extract_statuses(pair_statuses)
+        if latest_validate_statuses is not None:
+            pair_validate_statuses = [s for s in latest_validate_statuses.statuses if s.pair_id == pc.pair_id]
+            pc.model_builder.set_validate_statuses(pair_validate_statuses)
+
+    def sync_persist_to_all_builders(self):  # noqa: C901 — will be decomposed in #394
+        """Push current persist state to all pair model builders, filtered by pair_id."""
+        namespaced_prefixes = tuple(
+            f"{other_pc.pair_id}{sep}" for other_pc in self._pair_contexts if other_pc.pair_id for sep in (KEY_SEP, ":")
+        )
+        for pc in self._pair_contexts:
+            prefix = f"{pc.pair_id}{KEY_SEP}" if pc.pair_id else ""
+            # Defense-in-depth: from_str() migrates colon keys at load time,
+            # but we check both separators here in case of incomplete migration.
+            legacy_prefix = f"{pc.pair_id}:" if pc.pair_id else ""
+            downloaded: set[str] = set()
+            extracted: set[str] = set()
+            extract_failed: set[str] = set()
+            validated: set[str] = set()
+            corrupt: set[str] = set()
+            for key in self._persist.downloaded_file_names:
+                if prefix and key.startswith(prefix):
+                    downloaded.add(key[len(prefix) :])
+                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
+                    downloaded.add(key[len(legacy_prefix) :])
+                elif not prefix and not key.startswith(namespaced_prefixes):
+                    downloaded.add(key)
+            for key in self._persist.extracted_file_names:
+                if prefix and key.startswith(prefix):
+                    extracted.add(key[len(prefix) :])
+                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
+                    extracted.add(key[len(legacy_prefix) :])
+                elif not prefix and not key.startswith(namespaced_prefixes):
+                    extracted.add(key)
+            for key in self._persist.extract_failed_file_names:
+                if prefix and key.startswith(prefix):
+                    extract_failed.add(key[len(prefix) :])
+                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
+                    extract_failed.add(key[len(legacy_prefix) :])
+                elif not prefix and not key.startswith(namespaced_prefixes):
+                    extract_failed.add(key)
+            for key in self._persist.validated_file_names:
+                if prefix and key.startswith(prefix):
+                    validated.add(key[len(prefix) :])
+                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
+                    validated.add(key[len(legacy_prefix) :])
+                elif not prefix and not key.startswith(namespaced_prefixes):
+                    validated.add(key)
+            for key in self._persist.corrupt_file_names:
+                if prefix and key.startswith(prefix):
+                    corrupt.add(key[len(prefix) :])
+                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
+                    corrupt.add(key[len(legacy_prefix) :])
+                elif not prefix and not key.startswith(namespaced_prefixes):
+                    corrupt.add(key)
+            pc.model_builder.set_downloaded_files(downloaded)
+            pc.model_builder.set_extracted_files(extracted)
+            pc.model_builder.set_extract_failed_files(extract_failed)
+            pc.model_builder.set_validated_files(validated)
+            pc.model_builder.set_corrupt_files(corrupt)

--- a/src/python/controller/model_updater.py
+++ b/src/python/controller/model_updater.py
@@ -4,7 +4,7 @@
 
 Owns the per-cycle model-update loop that was formerly Controller.__update_model.
 Extracted from controller.py as part of the controller decomposition
-(#394 Phase F).
+(#394 Phase 3F).
 """
 
 from __future__ import annotations
@@ -386,58 +386,47 @@ class ModelUpdater:
             pair_validate_statuses = [s for s in latest_validate_statuses.statuses if s.pair_id == pc.pair_id]
             pc.model_builder.set_validate_statuses(pair_validate_statuses)
 
-    def sync_persist_to_all_builders(self):  # noqa: C901 — will be decomposed in #394
+    def sync_persist_to_all_builders(self):
         """Push current persist state to all pair model builders, filtered by pair_id."""
         namespaced_prefixes = tuple(
             f"{other_pc.pair_id}{sep}" for other_pc in self._pair_contexts if other_pc.pair_id for sep in (KEY_SEP, ":")
         )
         for pc in self._pair_contexts:
-            prefix = f"{pc.pair_id}{KEY_SEP}" if pc.pair_id else ""
-            # Defense-in-depth: from_str() migrates colon keys at load time,
-            # but we check both separators here in case of incomplete migration.
-            legacy_prefix = f"{pc.pair_id}:" if pc.pair_id else ""
-            downloaded: set[str] = set()
-            extracted: set[str] = set()
-            extract_failed: set[str] = set()
-            validated: set[str] = set()
-            corrupt: set[str] = set()
-            for key in self._persist.downloaded_file_names:
-                if prefix and key.startswith(prefix):
-                    downloaded.add(key[len(prefix) :])
-                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
-                    downloaded.add(key[len(legacy_prefix) :])
-                elif not prefix and not key.startswith(namespaced_prefixes):
-                    downloaded.add(key)
-            for key in self._persist.extracted_file_names:
-                if prefix and key.startswith(prefix):
-                    extracted.add(key[len(prefix) :])
-                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
-                    extracted.add(key[len(legacy_prefix) :])
-                elif not prefix and not key.startswith(namespaced_prefixes):
-                    extracted.add(key)
-            for key in self._persist.extract_failed_file_names:
-                if prefix and key.startswith(prefix):
-                    extract_failed.add(key[len(prefix) :])
-                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
-                    extract_failed.add(key[len(legacy_prefix) :])
-                elif not prefix and not key.startswith(namespaced_prefixes):
-                    extract_failed.add(key)
-            for key in self._persist.validated_file_names:
-                if prefix and key.startswith(prefix):
-                    validated.add(key[len(prefix) :])
-                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
-                    validated.add(key[len(legacy_prefix) :])
-                elif not prefix and not key.startswith(namespaced_prefixes):
-                    validated.add(key)
-            for key in self._persist.corrupt_file_names:
-                if prefix and key.startswith(prefix):
-                    corrupt.add(key[len(prefix) :])
-                elif prefix and legacy_prefix and key.startswith(legacy_prefix):
-                    corrupt.add(key[len(legacy_prefix) :])
-                elif not prefix and not key.startswith(namespaced_prefixes):
-                    corrupt.add(key)
-            pc.model_builder.set_downloaded_files(downloaded)
-            pc.model_builder.set_extracted_files(extracted)
-            pc.model_builder.set_extract_failed_files(extract_failed)
-            pc.model_builder.set_validated_files(validated)
-            pc.model_builder.set_corrupt_files(corrupt)
+            pc.model_builder.set_downloaded_files(
+                self._filter_keys_for_pair(self._persist.downloaded_file_names, pc.pair_id, namespaced_prefixes)
+            )
+            pc.model_builder.set_extracted_files(
+                self._filter_keys_for_pair(self._persist.extracted_file_names, pc.pair_id, namespaced_prefixes)
+            )
+            pc.model_builder.set_extract_failed_files(
+                self._filter_keys_for_pair(self._persist.extract_failed_file_names, pc.pair_id, namespaced_prefixes)
+            )
+            pc.model_builder.set_validated_files(
+                self._filter_keys_for_pair(self._persist.validated_file_names, pc.pair_id, namespaced_prefixes)
+            )
+            pc.model_builder.set_corrupt_files(
+                self._filter_keys_for_pair(self._persist.corrupt_file_names, pc.pair_id, namespaced_prefixes)
+            )
+
+    @staticmethod
+    def _filter_keys_for_pair(keys: set[str], pair_id: str | None, namespaced_prefixes: tuple[str, ...]) -> set[str]:
+        """Filter and strip persist keys that belong to a specific pair.
+
+        For pairs with a pair_id, matches keys with the current separator or
+        legacy colon prefix. For the default pair (pair_id=None), matches keys
+        that don't start with any other pair's prefix.
+        """
+        result: set[str] = set()
+        if pair_id:
+            prefix = f"{pair_id}{KEY_SEP}"
+            legacy_prefix = f"{pair_id}:"
+            for key in keys:
+                if key.startswith(prefix):
+                    result.add(key[len(prefix) :])
+                elif key.startswith(legacy_prefix):
+                    result.add(key[len(legacy_prefix) :])
+        else:
+            for key in keys:
+                if not key.startswith(namespaced_prefixes):
+                    result.add(key)
+        return result

--- a/src/python/controller/model_updater.py
+++ b/src/python/controller/model_updater.py
@@ -299,17 +299,18 @@ class ModelUpdater:
             self._pipeline.spawn_deferred_move(result.pair_id, result.name)
 
         # Update the controller status (use most recent across all pairs)
+        # Note: remote scans set failed/error fields; local scans don't surface errors
         for pc in self._pair_contexts:
-            if pc._latest_remote_scan is not None:  # type: ignore[reportPrivateUsage]
+            if pc.latest_remote_scan is not None:
                 current = self._context.status.controller.latest_remote_scan_time
-                if current is None or pc._latest_remote_scan.timestamp > current:  # type: ignore[reportPrivateUsage]
-                    self._context.status.controller.latest_remote_scan_time = pc._latest_remote_scan.timestamp  # type: ignore[reportPrivateUsage]
-                    self._context.status.controller.latest_remote_scan_failed = pc._latest_remote_scan.failed  # type: ignore[reportPrivateUsage]
-                    self._context.status.controller.latest_remote_scan_error = pc._latest_remote_scan.error_message  # type: ignore[reportPrivateUsage]
-            if pc._latest_local_scan is not None:  # type: ignore[reportPrivateUsage]
+                if current is None or pc.latest_remote_scan.timestamp > current:
+                    self._context.status.controller.latest_remote_scan_time = pc.latest_remote_scan.timestamp
+                    self._context.status.controller.latest_remote_scan_failed = pc.latest_remote_scan.failed
+                    self._context.status.controller.latest_remote_scan_error = pc.latest_remote_scan.error_message
+            if pc.latest_local_scan is not None:
                 current = self._context.status.controller.latest_local_scan_time
-                if current is None or pc._latest_local_scan.timestamp > current:  # type: ignore[reportPrivateUsage]
-                    self._context.status.controller.latest_local_scan_time = pc._latest_local_scan.timestamp  # type: ignore[reportPrivateUsage]
+                if current is None or pc.latest_local_scan.timestamp > current:
+                    self._context.status.controller.latest_local_scan_time = pc.latest_local_scan.timestamp
 
     def _update_pair_model_state(  # noqa: C901 — will be decomposed in #394
         self,
@@ -324,8 +325,8 @@ class ModelUpdater:
         latest_local_scan = pc.local_scan_process.pop_latest_result()
         latest_active_scan = pc.active_scan_process.pop_latest_result()
 
-        pc._latest_remote_scan = latest_remote_scan  # type: ignore[reportPrivateUsage]
-        pc._latest_local_scan = latest_local_scan  # type: ignore[reportPrivateUsage]
+        pc.latest_remote_scan = latest_remote_scan
+        pc.latest_local_scan = latest_local_scan
 
         lftp_statuses = None
         try:

--- a/src/python/controller/pair_context.py
+++ b/src/python/controller/pair_context.py
@@ -67,9 +67,9 @@ class PairContext:
         self.remote_scan_received: bool = False
         self.local_scan_received: bool = False
 
-        # Temporary storage for latest scan results (set during _update_pair_model_state)
-        self._latest_remote_scan: ScannerResult | None = None
-        self._latest_local_scan: ScannerResult | None = None
+        # Temporary storage for latest scan results (set during ModelUpdater._update_pair_model_state)
+        self.latest_remote_scan: ScannerResult | None = None
+        self.latest_local_scan: ScannerResult | None = None
 
 
 def validate_config(context: Context) -> None:

--- a/src/python/tests/unittests/test_controller/test_command_pipeline.py
+++ b/src/python/tests/unittests/test_controller/test_command_pipeline.py
@@ -1,0 +1,134 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import os
+import unittest
+from unittest.mock import MagicMock
+
+from controller.command_pipeline import CommandPipeline
+from model import ModelFile
+
+
+class TestCommandPipelineHelpers(unittest.TestCase):
+    def _make_pipeline(self, pair_contexts=None):
+        """Create a CommandPipeline with mocked collaborators."""
+        if pair_contexts is None:
+            pair_contexts = []
+        registry = MagicMock()
+        persist = MagicMock()
+        context = MagicMock()
+        password = None
+        mp_logger = MagicMock()
+        extract_process = MagicMock()
+        validate_process = MagicMock()
+        logger = MagicMock()
+        sync_persist_callback = MagicMock()
+
+        pipeline = CommandPipeline(
+            pair_contexts=pair_contexts,
+            registry=registry,
+            persist=persist,
+            context=context,
+            password=password,
+            mp_logger=mp_logger,
+            extract_process=extract_process,
+            validate_process=validate_process,
+            logger=logger,
+            sync_persist_callback=sync_persist_callback,
+        )
+        return pipeline
+
+    def _make_pair_context(self, pair_id):
+        """Create a simple mock PairContext with the given pair_id."""
+        pc = MagicMock()
+        pc.pair_id = pair_id
+        return pc
+
+    # --- find_pair_by_id ---
+
+    def test_find_pair_by_id_none_returns_first_pair(self):
+        pc1 = self._make_pair_context(None)
+        pc2 = self._make_pair_context("second")
+        pipeline = self._make_pipeline([pc1, pc2])
+
+        result = pipeline.find_pair_by_id(None)
+        self.assertIs(pc1, result)
+
+    def test_find_pair_by_id_matching_id(self):
+        pc1 = self._make_pair_context(None)
+        pc2 = self._make_pair_context("abc")
+        pipeline = self._make_pipeline([pc1, pc2])
+
+        result = pipeline.find_pair_by_id("abc")
+        self.assertIs(pc2, result)
+
+    def test_find_pair_by_id_nonexistent_returns_none(self):
+        pc1 = self._make_pair_context(None)
+        pipeline = self._make_pipeline([pc1])
+
+        result = pipeline.find_pair_by_id("nonexistent")
+        self.assertIsNone(result)
+
+    def test_find_pair_by_id_none_empty_list_returns_none(self):
+        pipeline = self._make_pipeline([])
+
+        result = pipeline.find_pair_by_id(None)
+        self.assertIsNone(result)
+
+    # --- get_pair_context_for_file ---
+
+    def test_get_pair_context_for_file_matching(self):
+        pc1 = self._make_pair_context(None)
+        pc2 = self._make_pair_context("abc")
+        pipeline = self._make_pipeline([pc1, pc2])
+
+        file = ModelFile("test.txt", False, pair_id="abc")
+        result = pipeline.get_pair_context_for_file(file)
+        self.assertIs(pc2, result)
+
+    def test_get_pair_context_for_file_no_match(self):
+        pc1 = self._make_pair_context("xyz")
+        pipeline = self._make_pipeline([pc1])
+
+        file = ModelFile("test.txt", False, pair_id="abc")
+        result = pipeline.get_pair_context_for_file(file)
+        self.assertIsNone(result)
+
+    # --- _pair_staging_dir ---
+
+    def test_pair_staging_dir_staging_disabled(self):
+        pc = self._make_pair_context(None)
+        pipeline = self._make_pipeline([pc])
+        pipeline._context.config.controller.use_staging = False
+        pipeline._context.config.controller.staging_path = None
+
+        result = pipeline._pair_staging_dir(pc)
+        self.assertIsNone(result)
+
+    def test_pair_staging_dir_no_pair_id(self):
+        pc = self._make_pair_context(None)
+        pipeline = self._make_pipeline([pc])
+        pipeline._context.config.controller.use_staging = True
+        pipeline._context.config.controller.staging_path = "/tmp/staging"
+
+        result = pipeline._pair_staging_dir(pc)
+        self.assertEqual("/tmp/staging", result)
+
+    def test_pair_staging_dir_with_pair_id(self):
+        pc = self._make_pair_context("abc-123")
+        pipeline = self._make_pipeline([pc])
+        pipeline._context.config.controller.use_staging = True
+        pipeline._context.config.controller.staging_path = "/tmp/staging"
+
+        result = pipeline._pair_staging_dir(pc)
+        self.assertEqual(os.path.join("/tmp/staging", "abc-123"), result)
+
+    # --- queue ---
+
+    def test_queue_puts_command_on_queue(self):
+        pipeline = self._make_pipeline([])
+        command = MagicMock()
+
+        pipeline.queue(command)
+
+        self.assertFalse(pipeline.command_queue.empty())
+        self.assertIs(command, pipeline.command_queue.get())

--- a/src/python/tests/unittests/test_controller/test_model_registry.py
+++ b/src/python/tests/unittests/test_controller/test_model_registry.py
@@ -1,0 +1,161 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import logging
+import unittest
+
+from controller.model_registry import ModelRegistry
+from model import IModelListener, Model, ModelDiff, ModelFile
+
+
+class _TestListener(IModelListener):
+    """Simple listener that records events."""
+
+    def __init__(self):
+        self.added: list[ModelFile] = []
+        self.removed: list[ModelFile] = []
+        self.updated: list[tuple[ModelFile, ModelFile]] = []
+
+    def file_added(self, file: ModelFile):
+        self.added.append(file)
+
+    def file_removed(self, file: ModelFile):
+        self.removed.append(file)
+
+    def file_updated(self, old_file: ModelFile, new_file: ModelFile):
+        self.updated.append((old_file, new_file))
+
+
+class TestModelRegistry(unittest.TestCase):
+    def setUp(self):
+        self.model = Model()
+        logger = logging.getLogger("TestModelRegistry")
+        logger.addHandler(logging.NullHandler())
+        self.model.set_base_logger(logger)
+        self.registry = ModelRegistry(self.model)
+
+    def test_get_files_returns_deep_copies(self):
+        f = ModelFile("test.txt", False)
+        f.state = ModelFile.State.DEFAULT
+        self.model.add_file(f)
+
+        files = self.registry.get_files()
+        self.assertEqual(1, len(files))
+        self.assertEqual("test.txt", files[0].name)
+
+        # Modify the returned copy
+        files[0].state = ModelFile.State.DOWNLOADED
+
+        # Original should be unchanged
+        original = self.model.get_file("test.txt")
+        self.assertEqual(ModelFile.State.DEFAULT, original.state)
+
+    def test_get_files_returns_all_files(self):
+        f1 = ModelFile("a.txt", False)
+        f2 = ModelFile("b.txt", False)
+        f3 = ModelFile("c.txt", True)
+        self.model.add_file(f1)
+        self.model.add_file(f2)
+        self.model.add_file(f3)
+
+        files = self.registry.get_files()
+        names = {f.name for f in files}
+        self.assertEqual({"a.txt", "b.txt", "c.txt"}, names)
+
+    def test_get_file_returns_directly(self):
+        f = ModelFile("test.txt", False)
+        f.state = ModelFile.State.DEFAULT
+        self.model.add_file(f)
+
+        result = self.registry.get_file("test.txt")
+        # Should be the same object, not a copy
+        self.assertIs(f, result)
+
+    def test_add_and_remove_listener(self):
+        listener = _TestListener()
+        self.registry.add_listener(listener)
+
+        f = ModelFile("test.txt", False)
+        self.model.add_file(f)
+        self.assertEqual(1, len(listener.added))
+
+        self.registry.remove_listener(listener)
+
+        f2 = ModelFile("test2.txt", False)
+        self.model.add_file(f2)
+        # Should not have received the second add
+        self.assertEqual(1, len(listener.added))
+
+    def test_get_files_and_add_listener_is_atomic(self):
+        f1 = ModelFile("existing.txt", False)
+        self.model.add_file(f1)
+
+        listener = _TestListener()
+        files = self.registry.get_files_and_add_listener(listener)
+
+        # Should return existing files
+        self.assertEqual(1, len(files))
+        self.assertEqual("existing.txt", files[0].name)
+
+        # Listener should receive subsequent updates
+        f2 = ModelFile("new.txt", False)
+        self.model.add_file(f2)
+        self.assertEqual(1, len(listener.added))
+        self.assertEqual("new.txt", listener.added[0].name)
+
+    def test_apply_diff_add_file(self):
+        new_model = Model()
+        logger = logging.getLogger("TestModelRegistry.new")
+        logger.addHandler(logging.NullHandler())
+        new_model.set_base_logger(logger)
+
+        f = ModelFile("added.txt", False)
+        new_model.add_file(f)
+
+        diffs = self.registry.apply_diff(new_model)
+
+        self.assertEqual(1, len(diffs))
+        self.assertEqual(ModelDiff.Change.ADDED, diffs[0].change)
+        self.assertEqual("added.txt", diffs[0].new_file.name)
+
+        # Verify the model was updated
+        result = self.registry.get_file("added.txt")
+        self.assertEqual("added.txt", result.name)
+
+    def test_apply_diff_remove_file(self):
+        f = ModelFile("to_remove.txt", False)
+        self.model.add_file(f)
+
+        # New model is empty -- the file is removed
+        new_model = Model()
+        logger = logging.getLogger("TestModelRegistry.new")
+        logger.addHandler(logging.NullHandler())
+        new_model.set_base_logger(logger)
+
+        diffs = self.registry.apply_diff(new_model)
+
+        self.assertEqual(1, len(diffs))
+        self.assertEqual(ModelDiff.Change.REMOVED, diffs[0].change)
+        self.assertEqual("to_remove.txt", diffs[0].old_file.name)
+
+    def test_apply_diff_update_file(self):
+        f = ModelFile("update_me.txt", False)
+        f.state = ModelFile.State.DEFAULT
+        self.model.add_file(f)
+
+        new_model = Model()
+        logger = logging.getLogger("TestModelRegistry.new")
+        logger.addHandler(logging.NullHandler())
+        new_model.set_base_logger(logger)
+        f_updated = ModelFile("update_me.txt", False)
+        f_updated.state = ModelFile.State.DOWNLOADED
+        new_model.add_file(f_updated)
+
+        diffs = self.registry.apply_diff(new_model)
+
+        self.assertEqual(1, len(diffs))
+        self.assertEqual(ModelDiff.Change.UPDATED, diffs[0].change)
+        self.assertEqual(ModelFile.State.DOWNLOADED, diffs[0].new_file.state)
+
+        # Verify model is updated
+        result = self.registry.get_file("update_me.txt")
+        self.assertEqual(ModelFile.State.DOWNLOADED, result.state)

--- a/src/python/tests/unittests/test_controller/test_model_updater.py
+++ b/src/python/tests/unittests/test_controller/test_model_updater.py
@@ -1,0 +1,120 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import unittest
+from unittest.mock import MagicMock
+
+from controller.model_updater import ModelUpdater
+from controller.persist_keys import KEY_SEP
+
+
+class TestSyncPersistToAllBuilders(unittest.TestCase):
+    def _make_pair_context(self, pair_id):
+        """Create a mock PairContext with a model_builder that records calls."""
+        pc = MagicMock()
+        pc.pair_id = pair_id
+        return pc
+
+    def _make_updater(self, pair_contexts, persist):
+        """Create a ModelUpdater with mocked collaborators."""
+        pipeline = MagicMock()
+        registry = MagicMock()
+        extract_process = MagicMock()
+        validate_process = MagicMock()
+        context = MagicMock()
+        logger = MagicMock()
+
+        updater = ModelUpdater(
+            pair_contexts=pair_contexts,
+            persist=persist,
+            pipeline=pipeline,
+            registry=registry,
+            extract_process=extract_process,
+            validate_process=validate_process,
+            context=context,
+            password=None,
+            logger=logger,
+        )
+        return updater
+
+    def _make_persist(self, downloaded=None, extracted=None, extract_failed=None,
+                      validated=None, corrupt=None):
+        """Create a mock persist object with the given file name sets."""
+        persist = MagicMock()
+        persist.downloaded_file_names = downloaded or set()
+        persist.extracted_file_names = extracted or set()
+        persist.extract_failed_file_names = extract_failed or set()
+        persist.validated_file_names = validated or set()
+        persist.corrupt_file_names = corrupt or set()
+        return persist
+
+    def test_filters_downloaded_keys_by_pair_id_prefix(self):
+        pc_abc = self._make_pair_context("abc")
+        pc_xyz = self._make_pair_context("xyz")
+
+        persist = self._make_persist(
+            downloaded={f"abc{KEY_SEP}movie.mkv", f"xyz{KEY_SEP}show.avi"},
+            extracted={f"abc{KEY_SEP}movie.mkv"},
+        )
+
+        updater = self._make_updater([pc_abc, pc_xyz], persist)
+        updater.sync_persist_to_all_builders()
+
+        # pc_abc should get only movie.mkv
+        pc_abc.model_builder.set_downloaded_files.assert_called_once_with({"movie.mkv"})
+        pc_abc.model_builder.set_extracted_files.assert_called_once_with({"movie.mkv"})
+
+        # pc_xyz should get only show.avi
+        pc_xyz.model_builder.set_downloaded_files.assert_called_once_with({"show.avi"})
+        pc_xyz.model_builder.set_extracted_files.assert_called_once_with(set())
+
+    def test_none_pair_id_gets_unprefixed_keys(self):
+        pc_default = self._make_pair_context(None)
+        pc_abc = self._make_pair_context("abc")
+
+        persist = self._make_persist(
+            downloaded={"plain_file.txt", f"abc{KEY_SEP}namespaced.mkv"},
+        )
+
+        updater = self._make_updater([pc_default, pc_abc], persist)
+        updater.sync_persist_to_all_builders()
+
+        # Default pair (None pair_id) should get plain_file.txt (no prefix)
+        pc_default.model_builder.set_downloaded_files.assert_called_once_with({"plain_file.txt"})
+
+        # abc pair should get namespaced.mkv
+        pc_abc.model_builder.set_downloaded_files.assert_called_once_with({"namespaced.mkv"})
+
+    def test_handles_legacy_colon_separator_keys(self):
+        pc_abc = self._make_pair_context("abc")
+
+        persist = self._make_persist(
+            downloaded={"abc:legacy_file.mkv"},
+            extracted={"abc:legacy_file.mkv"},
+        )
+
+        updater = self._make_updater([pc_abc], persist)
+        updater.sync_persist_to_all_builders()
+
+        # Should strip the legacy colon prefix and deliver the bare name
+        pc_abc.model_builder.set_downloaded_files.assert_called_once_with({"legacy_file.mkv"})
+        pc_abc.model_builder.set_extracted_files.assert_called_once_with({"legacy_file.mkv"})
+
+    def test_all_persist_categories_are_distributed(self):
+        pc_abc = self._make_pair_context("abc")
+
+        persist = self._make_persist(
+            downloaded={f"abc{KEY_SEP}file.mkv"},
+            extracted={f"abc{KEY_SEP}file.mkv"},
+            extract_failed={f"abc{KEY_SEP}bad.zip"},
+            validated={f"abc{KEY_SEP}good.mkv"},
+            corrupt={f"abc{KEY_SEP}corrupt.mkv"},
+        )
+
+        updater = self._make_updater([pc_abc], persist)
+        updater.sync_persist_to_all_builders()
+
+        pc_abc.model_builder.set_downloaded_files.assert_called_once_with({"file.mkv"})
+        pc_abc.model_builder.set_extracted_files.assert_called_once_with({"file.mkv"})
+        pc_abc.model_builder.set_extract_failed_files.assert_called_once_with({"bad.zip"})
+        pc_abc.model_builder.set_validated_files.assert_called_once_with({"good.mkv"})
+        pc_abc.model_builder.set_corrupt_files.assert_called_once_with({"corrupt.mkv"})

--- a/src/python/tests/unittests/test_controller/test_model_updater.py
+++ b/src/python/tests/unittests/test_controller/test_model_updater.py
@@ -98,6 +98,22 @@ class TestSyncPersistToAllBuilders(unittest.TestCase):
         pc_abc.model_builder.set_downloaded_files.assert_called_once_with({"legacy_file.mkv"})
         pc_abc.model_builder.set_extracted_files.assert_called_once_with({"legacy_file.mkv"})
 
+    def test_default_pair_excludes_legacy_colon_keys(self):
+        pc_default = self._make_pair_context(None)
+        pc_abc = self._make_pair_context("abc")
+
+        persist = self._make_persist(
+            downloaded={"abc:legacy.mkv", "plain.txt"},
+        )
+
+        updater = self._make_updater([pc_default, pc_abc], persist)
+        updater.sync_persist_to_all_builders()
+
+        # Default pair should NOT get the legacy-colon-prefixed key
+        pc_default.model_builder.set_downloaded_files.assert_called_once_with({"plain.txt"})
+        # abc pair should get it stripped
+        pc_abc.model_builder.set_downloaded_files.assert_called_once_with({"legacy.mkv"})
+
     def test_all_persist_categories_are_distributed(self):
         pc_abc = self._make_pair_context("abc")
 

--- a/src/python/tests/unittests/test_controller/test_model_updater.py
+++ b/src/python/tests/unittests/test_controller/test_model_updater.py
@@ -36,8 +36,7 @@ class TestSyncPersistToAllBuilders(unittest.TestCase):
         )
         return updater
 
-    def _make_persist(self, downloaded=None, extracted=None, extract_failed=None,
-                      validated=None, corrupt=None):
+    def _make_persist(self, downloaded=None, extracted=None, extract_failed=None, validated=None, corrupt=None):
         """Create a mock persist object with the given file name sets."""
         persist = MagicMock()
         persist.downloaded_file_names = downloaded or set()

--- a/src/python/tests/unittests/test_controller/test_persist_keys.py
+++ b/src/python/tests/unittests/test_controller/test_persist_keys.py
@@ -1,0 +1,38 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import unittest
+
+from controller.persist_keys import KEY_SEP, persist_key, strip_persist_key
+
+
+class TestPersistKey(unittest.TestCase):
+    def test_key_sep_is_unit_separator(self):
+        self.assertEqual("\x1f", KEY_SEP)
+
+    def test_persist_key_no_pair_id(self):
+        result = persist_key(None, "file.txt")
+        self.assertEqual("file.txt", result)
+
+    def test_persist_key_with_pair_id(self):
+        result = persist_key("abc-123", "file.txt")
+        self.assertEqual("abc-123\x1ffile.txt", result)
+
+    def test_strip_persist_key_no_pair_id(self):
+        result = strip_persist_key("file.txt", None)
+        self.assertEqual("file.txt", result)
+
+    def test_strip_persist_key_current_separator(self):
+        result = strip_persist_key("abc-123\x1ffile.txt", "abc-123")
+        self.assertEqual("file.txt", result)
+
+    def test_strip_persist_key_legacy_colon_separator(self):
+        result = strip_persist_key("abc-123:file.txt", "abc-123")
+        self.assertEqual("file.txt", result)
+
+    def test_strip_persist_key_wrong_pair_id_returns_key_unchanged(self):
+        result = strip_persist_key("abc-123\x1ffile.txt", "other-id")
+        self.assertEqual("abc-123\x1ffile.txt", result)
+
+    def test_strip_persist_key_no_prefix_match_returns_key_unchanged(self):
+        result = strip_persist_key("no-prefix-file.txt", "abc-123")
+        self.assertEqual("no-prefix-file.txt", result)

--- a/src/python/tests/unittests/test_controller/test_validate_config.py
+++ b/src/python/tests/unittests/test_controller/test_validate_config.py
@@ -8,6 +8,7 @@ from common import Args, Config, Context, Status
 from common.path_pairs_config import PathPairsConfig
 from controller import Controller, ControllerPersist
 from controller.controller import ControllerError
+from controller.model_updater import ModelUpdater
 
 # All required Lftp fields and their valid test values
 _LFTP_REQUIRED = {
@@ -99,7 +100,7 @@ class TestValidateConfig(unittest.TestCase):
     """Tests for Controller._validate_config()."""
 
     @patch.object(Controller, "_build_pair_contexts", return_value=[])
-    @patch.object(Controller, "_sync_persist_to_all_builders")
+    @patch.object(ModelUpdater, "sync_persist_to_all_builders")
     def test_valid_config_does_not_raise(self, _mock_sync, _mock_build):
         """A fully-populated config should not raise."""
         config = _make_config()
@@ -110,7 +111,7 @@ class TestValidateConfig(unittest.TestCase):
         Controller(context, persist)
 
     @patch.object(Controller, "_build_pair_contexts", return_value=[])
-    @patch.object(Controller, "_sync_persist_to_all_builders")
+    @patch.object(ModelUpdater, "sync_persist_to_all_builders")
     def test_missing_single_lftp_field_raises(self, _mock_sync, _mock_build):
         """A single missing Lftp field should raise with that field name."""
         config = _make_config(skip_lftp={"remote_address"})
@@ -122,7 +123,7 @@ class TestValidateConfig(unittest.TestCase):
         self.assertIn("Lftp.remote_address", str(cm.exception))
 
     @patch.object(Controller, "_build_pair_contexts", return_value=[])
-    @patch.object(Controller, "_sync_persist_to_all_builders")
+    @patch.object(ModelUpdater, "sync_persist_to_all_builders")
     def test_missing_multiple_fields_lists_all(self, _mock_sync, _mock_build):
         """Multiple missing fields should all appear in the error message."""
         config = _make_config(
@@ -142,7 +143,7 @@ class TestValidateConfig(unittest.TestCase):
         self.assertIn("General.verbose", msg)
 
     @patch.object(Controller, "_build_pair_contexts", return_value=[])
-    @patch.object(Controller, "_sync_persist_to_all_builders")
+    @patch.object(ModelUpdater, "sync_persist_to_all_builders")
     def test_missing_args_local_path_to_scanfs_raises(self, _mock_sync, _mock_build):
         """Missing Args.local_path_to_scanfs should raise."""
         config = _make_config()
@@ -154,7 +155,7 @@ class TestValidateConfig(unittest.TestCase):
         self.assertIn("Args.local_path_to_scanfs", str(cm.exception))
 
     @patch.object(Controller, "_build_pair_contexts", return_value=[])
-    @patch.object(Controller, "_sync_persist_to_all_builders")
+    @patch.object(ModelUpdater, "sync_persist_to_all_builders")
     def test_missing_autoqueue_field_raises(self, _mock_sync, _mock_build):
         """Missing AutoQueue.auto_delete_remote should raise."""
         config = _make_config(skip_autoqueue=True)
@@ -166,7 +167,7 @@ class TestValidateConfig(unittest.TestCase):
         self.assertIn("AutoQueue.auto_delete_remote", str(cm.exception))
 
     @patch.object(Controller, "_build_pair_contexts", return_value=[])
-    @patch.object(Controller, "_sync_persist_to_all_builders")
+    @patch.object(ModelUpdater, "sync_persist_to_all_builders")
     def test_missing_controller_field_raises(self, _mock_sync, _mock_build):
         """Missing Controller.interval_ms_local_scan should raise."""
         config = _make_config(skip_controller={"interval_ms_local_scan"})
@@ -182,7 +183,7 @@ class TestBackwardCompatValidation(unittest.TestCase):
     """Tests for backward-compat path pair validation in _build_pair_contexts."""
 
     @patch.object(Controller, "_validate_config")
-    @patch.object(Controller, "_sync_persist_to_all_builders")
+    @patch.object(ModelUpdater, "sync_persist_to_all_builders")
     def test_backward_compat_missing_remote_path_raises(self, _mock_sync, _mock_validate):
         """When no path pairs exist and remote_path is None, should raise."""
         # remote_path defaults to None in Config.Lftp.__init__
@@ -199,7 +200,7 @@ class TestBackwardCompatValidation(unittest.TestCase):
         self.assertIn("remote_path", str(cm.exception))
 
     @patch.object(Controller, "_build_pair_contexts", return_value=[])
-    @patch.object(Controller, "_sync_persist_to_all_builders")
+    @patch.object(ModelUpdater, "sync_persist_to_all_builders")
     def test_missing_extract_path_when_not_using_local(self, _mock_sync, _mock_build):
         """When use_local_path_as_extract_path is False and extract_path is None, should raise."""
         config = _make_config(skip_controller={"use_local_path_as_extract_path"})
@@ -213,7 +214,7 @@ class TestBackwardCompatValidation(unittest.TestCase):
         self.assertIn("Controller.extract_path", str(cm.exception))
 
     @patch.object(Controller, "_validate_config")
-    @patch.object(Controller, "_sync_persist_to_all_builders")
+    @patch.object(ModelUpdater, "sync_persist_to_all_builders")
     def test_backward_compat_missing_local_path_raises(self, _mock_sync, _mock_validate):
         """When no path pairs exist and local_path is None, should raise."""
         config = Config()


### PR DESCRIPTION
Closes #394

## Summary
Final phase of the controller decomposition. Extracts the model update logic into a new `ModelUpdater` class.

### Methods moved (3)

| New method | Was | LOC |
|------------|-----|----:|
| `update()` | `__update_model` | ~258 |
| `_update_pair_model_state()` | `_update_pair_model_state` | ~75 |
| `sync_persist_to_all_builders()` | `_sync_persist_to_all_builders` | ~57 |

### Controller.process() is now:
```python
self.__pipeline.propagate_exceptions()
self.__pipeline.cleanup()
self.__pipeline.step()
self.__updater.update()
```

## Final state

| Module | Lines | Responsibility |
|--------|------:|----------------|
| `controller.py` | 389 | Coordinator: init, start, exit, pair building, public API |
| `command_pipeline.py` | 439 | Command queue, process dispatch, move management |
| `model_updater.py` | 443 | Model diff, persist sync, scan/status processing |
| `model_registry.py` | 87 | Thread-safe model + listener management |
| `pair_context.py` | 165 | PairContext, config validation, LFTP configuration |
| `persist_keys.py` | 33 | Persist key construction/parsing |
| `exclude_patterns.py` | 91 | Exclude pattern filtering |

**controller.py: 1433 → 389 lines (-1044, 73% reduction)**

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] 297 controller tests pass (test patches updated to target ModelUpdater)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CI enforcement: cyclomatic complexity is actively enforced with max-complexity = 12 and guidance for existing violations and test exclusions.

* **New Features / Refactor**
  * Split controller’s model-update loop into a dedicated updater component and made pipeline persistence syncing available to that updater.

* **Tests**
  * Added extensive unit tests covering controller pipeline, model updater, model registry, persist-key utilities, and validation wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->