### PR TITLE
Discord and Telegram notification presets

### DIFF
--- a/src/angular/src/app/models/config.ts
+++ b/src/angular/src/app/models/config.ts
@@ -66,6 +66,9 @@ export interface Notifications {
   notify_on_extraction_complete: boolean | null;
   notify_on_extraction_failed: boolean | null;
   notify_on_delete_complete: boolean | null;
+  discord_webhook_url: string | null;
+  telegram_bot_token: string | null;
+  telegram_chat_id: string | null;
 }
 
 export interface Validate {
@@ -152,6 +155,9 @@ export const DEFAULT_NOTIFICATIONS: Notifications = {
   notify_on_extraction_complete: null,
   notify_on_extraction_failed: null,
   notify_on_delete_complete: null,
+  discord_webhook_url: null,
+  telegram_bot_token: null,
+  telegram_chat_id: null,
 };
 
 export const DEFAULT_VALIDATE: Validate = {

--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -366,6 +366,24 @@ export const OPTIONS_CONTEXT_NOTIFICATIONS: IOptionsContext = {
       valuePath: ['notifications', 'notify_on_delete_complete'],
       description: null,
     },
+    {
+      type: OptionType.Password,
+      label: 'Discord Webhook URL',
+      valuePath: ['notifications', 'discord_webhook_url'],
+      description: 'Discord channel webhook URL. Leave empty to disable.',
+    },
+    {
+      type: OptionType.Password,
+      label: 'Telegram Bot Token',
+      valuePath: ['notifications', 'telegram_bot_token'],
+      description: 'Token from @BotFather. Leave empty to disable.',
+    },
+    {
+      type: OptionType.Text,
+      label: 'Telegram Chat ID',
+      valuePath: ['notifications', 'telegram_chat_id'],
+      description: 'Numeric ID of the chat/channel to post to.',
+    },
   ],
 };
 

--- a/src/angular/src/app/pages/settings/settings-page.component.html
+++ b/src/angular/src/app/pages/settings/settings-page.component.html
@@ -71,9 +71,53 @@
         *ngTemplateOutlet="optionsList; context: OPTIONS_CONTEXT_OTHER">
       </ng-container>
 
-      <ng-container
-        *ngTemplateOutlet="optionsList; context: OPTIONS_CONTEXT_NOTIFICATIONS">
-      </ng-container>
+      <div class="card">
+        <h3 class="card-header">Notifications</h3>
+        <div class="card-body">
+          @for (option of OPTIONS_CONTEXT_NOTIFICATIONS.options; track option.label) {
+            <div>
+              <app-option
+                [type]="option.type"
+                [label]="option.label"
+                [description]="option.description"
+                [choices]="option.choices || []"
+                [value]="getOptionValue(config$ | async, option.valuePath)"
+                (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event)">
+              </app-option>
+            </div>
+          }
+          <div class="notification-test-buttons">
+            <div class="test-row">
+              <button type="button" class="btn btn-sm btn-outline-secondary"
+                      [disabled]="testingDiscord || !commandsEnabled"
+                      (click)="onTestDiscord()">
+                {{ testingDiscord ? 'Testing...' : 'Test Discord' }}
+              </button>
+              @if (discordResult) {
+                <span class="test-result" aria-live="polite" aria-atomic="true"
+                      [class.text-success]="discordResult.success"
+                      [class.text-danger]="!discordResult.success">
+                  {{ discordResult.message }}
+                </span>
+              }
+            </div>
+            <div class="test-row">
+              <button type="button" class="btn btn-sm btn-outline-secondary"
+                      [disabled]="testingTelegram || !commandsEnabled"
+                      (click)="onTestTelegram()">
+                {{ testingTelegram ? 'Testing...' : 'Test Telegram' }}
+              </button>
+              @if (telegramResult) {
+                <span class="test-result" aria-live="polite" aria-atomic="true"
+                      [class.text-success]="telegramResult.success"
+                      [class.text-danger]="!telegramResult.success">
+                  {{ telegramResult.message }}
+                </span>
+              }
+            </div>
+          </div>
+        </div>
+      </div>
 
       <div class="card">
         <app-integrations></app-integrations>

--- a/src/angular/src/app/pages/settings/settings-page.component.html
+++ b/src/angular/src/app/pages/settings/settings-page.component.html
@@ -80,6 +80,7 @@
                 [type]="option.type"
                 [label]="option.label"
                 [description]="option.description"
+                [disabled]="!!option.disabled"
                 [choices]="option.choices || []"
                 [value]="getOptionValue(config$ | async, option.valuePath)"
                 (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event)">

--- a/src/angular/src/app/pages/settings/settings-page.component.scss
+++ b/src/angular/src/app/pages/settings/settings-page.component.scss
@@ -98,6 +98,23 @@
     }
 }
 
+.notification-test-buttons {
+    margin-top: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--border-color, #dee2e6);
+}
+
+.test-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.test-result {
+    font-size: 0.85rem;
+}
+
 /* Medium and large screens */
 @media only screen and (min-width: $medium-min-width) {
     #settings {

--- a/src/angular/src/app/pages/settings/settings-page.component.ts
+++ b/src/angular/src/app/pages/settings/settings-page.component.ts
@@ -6,6 +6,7 @@ import { distinctUntilChanged, map } from 'rxjs';
 import { LoggerService } from '../../services/utils/logger.service';
 import { ConfigService } from '../../services/settings/config.service';
 import { NotificationService } from '../../services/utils/notification.service';
+import { NotificationsService, TestResult } from '../../services/settings/notifications.service';
 import { ServerCommandService } from '../../services/server/server-command.service';
 import { ConnectedService } from '../../services/utils/connected.service';
 import { PathPairsService } from '../../services/settings/path-pairs.service';
@@ -64,6 +65,7 @@ export class SettingsPageComponent implements OnInit {
   private readonly logger = inject(LoggerService);
   private readonly configService = inject(ConfigService);
   private readonly notifService = inject(NotificationService);
+  private readonly notificationsService = inject(NotificationsService);
   private readonly commandService = inject(ServerCommandService);
   private readonly connectedService = inject(ConnectedService);
   private readonly pathPairsService = inject(PathPairsService);
@@ -73,6 +75,10 @@ export class SettingsPageComponent implements OnInit {
   readonly config$ = this.configService.config$;
 
   commandsEnabled = false;
+  testingDiscord = false;
+  testingTelegram = false;
+  discordResult: TestResult | null = null;
+  telegramResult: TestResult | null = null;
 
   private configRestartNotif: Notification = createNotification(
     NotificationLevel.INFO,
@@ -204,6 +210,30 @@ export class SettingsPageComponent implements OnInit {
           this.logger.error(reaction.errorMessage);
         }
       },
+    });
+  }
+
+  onTestDiscord(): void {
+    this.testingDiscord = true;
+    this.discordResult = null;
+    this.notificationsService.testDiscord().pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((result) => {
+      this.testingDiscord = false;
+      this.discordResult = result;
+      this.cdr.markForCheck();
+    });
+  }
+
+  onTestTelegram(): void {
+    this.testingTelegram = true;
+    this.telegramResult = null;
+    this.notificationsService.testTelegram().pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((result) => {
+      this.testingTelegram = false;
+      this.telegramResult = result;
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -60,6 +60,9 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
       notify_on_extraction_complete: false,
       notify_on_extraction_failed: false,
       notify_on_delete_complete: false,
+      discord_webhook_url: null,
+      telegram_bot_token: null,
+      telegram_chat_id: null,
     },
     validate: {
       enabled: false,

--- a/src/angular/src/app/services/settings/notifications.service.spec.ts
+++ b/src/angular/src/app/services/settings/notifications.service.spec.ts
@@ -1,0 +1,98 @@
+import '@angular/compiler';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { NotificationsService, TestResult } from './notifications.service';
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        NotificationsService,
+      ],
+    });
+    service = TestBed.inject(NotificationsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('testDiscord() returns success on HTTP 200', () => {
+    let result: TestResult | undefined;
+    service.testDiscord().subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne('/server/notifications/test/discord');
+    expect(req.request.method).toBe('POST');
+    req.flush({});
+
+    expect(result!.success).toBe(true);
+    expect(result!.message).toBe('Notification sent successfully');
+  });
+
+  it('testDiscord() surfaces server-provided error message on failure', () => {
+    let result: TestResult | undefined;
+    service.testDiscord().subscribe((r) => (result = r));
+
+    httpMock.expectOne('/server/notifications/test/discord').flush(
+      { error: 'Discord webhook URL not configured' },
+      { status: 400, statusText: 'Bad Request' },
+    );
+
+    expect(result!.success).toBe(false);
+    expect(result!.message).toBe('Discord webhook URL not configured');
+  });
+
+  it('testDiscord() falls back to generic message when error body is unparsable', () => {
+    let result: TestResult | undefined;
+    service.testDiscord().subscribe((r) => (result = r));
+
+    httpMock.expectOne('/server/notifications/test/discord').error(new ProgressEvent('error'));
+
+    expect(result!.success).toBe(false);
+    expect(result!.message).toBe('Notification failed');
+  });
+
+  it('testTelegram() returns success on HTTP 200', () => {
+    let result: TestResult | undefined;
+    service.testTelegram().subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne('/server/notifications/test/telegram');
+    expect(req.request.method).toBe('POST');
+    req.flush({});
+
+    expect(result!.success).toBe(true);
+    expect(result!.message).toBe('Notification sent successfully');
+  });
+
+  it('testTelegram() surfaces server-provided error message on failure', () => {
+    let result: TestResult | undefined;
+    service.testTelegram().subscribe((r) => (result = r));
+
+    httpMock.expectOne('/server/notifications/test/telegram').flush(
+      { error: 'Telegram bot token not configured' },
+      { status: 400, statusText: 'Bad Request' },
+    );
+
+    expect(result!.success).toBe(false);
+    expect(result!.message).toBe('Telegram bot token not configured');
+  });
+
+  it('testTelegram() falls back to generic message when error body is unparsable', () => {
+    let result: TestResult | undefined;
+    service.testTelegram().subscribe((r) => (result = r));
+
+    httpMock.expectOne('/server/notifications/test/telegram').error(new ProgressEvent('error'));
+
+    expect(result!.success).toBe(false);
+    expect(result!.message).toBe('Notification failed');
+  });
+});

--- a/src/angular/src/app/services/settings/notifications.service.ts
+++ b/src/angular/src/app/services/settings/notifications.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+export interface TestResult {
+  readonly success: boolean;
+  readonly message: string;
+}
+
+const BASE_URL = '/server/notifications/test';
+
+@Injectable({ providedIn: 'root' })
+export class NotificationsService {
+  private readonly http = inject(HttpClient);
+
+  testDiscord(): Observable<TestResult> {
+    return this.http.post(`${BASE_URL}/discord`, {}).pipe(
+      map(() => ({ success: true, message: 'Notification sent successfully' })),
+      catchError((err: HttpErrorResponse) => {
+        let message: string;
+        try {
+          const body = typeof err.error === 'string' ? JSON.parse(err.error) : err.error;
+          message = body?.error || 'Notification failed';
+        } catch {
+          message = 'Notification failed';
+        }
+        return of({ success: false, message });
+      }),
+    );
+  }
+
+  testTelegram(): Observable<TestResult> {
+    return this.http.post(`${BASE_URL}/telegram`, {}).pipe(
+      map(() => ({ success: true, message: 'Notification sent successfully' })),
+      catchError((err: HttpErrorResponse) => {
+        let message: string;
+        try {
+          const body = typeof err.error === 'string' ? JSON.parse(err.error) : err.error;
+          message = body?.error || 'Notification failed';
+        } catch {
+          message = 'Notification failed';
+        }
+        return of({ success: false, message });
+      }),
+    );
+  }
+}

--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -370,6 +370,9 @@ class Config(Persist):
         notify_on_extraction_complete = PROP("notify_on_extraction_complete", Checkers.null, Converters.bool)
         notify_on_extraction_failed = PROP("notify_on_extraction_failed", Checkers.null, Converters.bool)
         notify_on_delete_complete = PROP("notify_on_delete_complete", Checkers.null, Converters.bool)
+        discord_webhook_url = PROP("discord_webhook_url", Checkers.string_allow_empty, Converters.null)
+        telegram_bot_token = PROP("telegram_bot_token", Checkers.string_allow_empty, Converters.null)
+        telegram_chat_id = PROP("telegram_chat_id", Checkers.string_allow_empty, Converters.null)
 
         def __init__(self):
             super().__init__()
@@ -378,6 +381,9 @@ class Config(Persist):
             self.notify_on_extraction_complete = True
             self.notify_on_extraction_failed = True
             self.notify_on_delete_complete = True
+            self.discord_webhook_url = ""
+            self.telegram_bot_token = ""
+            self.telegram_chat_id = ""
 
     class Validate(IC):
         enabled = PROP("enabled", Checkers.null, Converters.bool)
@@ -492,6 +498,7 @@ class Config(Persist):
         return {
             "Lftp": {"remote_password"},
             "Web": {"api_key"},
+            "Notifications": {"discord_webhook_url", "telegram_bot_token"},
         }
 
     @staticmethod

--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -498,7 +498,7 @@ class Config(Persist):
         return {
             "Lftp": {"remote_password"},
             "Web": {"api_key"},
-            "Notifications": {"discord_webhook_url", "telegram_bot_token"},
+            "Notifications": {"webhook_url", "discord_webhook_url", "telegram_bot_token"},
         }
 
     @staticmethod

--- a/src/python/controller/notification_formatters.py
+++ b/src/python/controller/notification_formatters.py
@@ -27,7 +27,10 @@ DISCORD_COLORS: dict[str, int] = {
 def format_discord(
     event_type: str,
     filename: str,
+    *,
     timestamp: str | None = None,
+    pair_id: str | None = None,
+    full_path: str | None = None,
 ) -> tuple[dict[str, str], bytes]:
     """Build a Discord webhook embed payload.
 
@@ -36,18 +39,32 @@ def format_discord(
     label = EVENT_LABELS.get(event_type, event_type)
     color = DISCORD_COLORS.get(event_type, 0x99AAB5)
     ts = timestamp or datetime.now(UTC).isoformat()
-    payload = {
-        "embeds": [
-            {
-                "title": f"SeedSync — {label}",
-                "description": f"`{filename}`",
-                "color": color,
-                "timestamp": ts,
-            }
-        ]
+    fields: list[dict[str, str | bool]] = []
+    if pair_id:
+        fields.append({"name": "Pair", "value": pair_id, "inline": True})
+    if full_path:
+        fields.append({"name": "Path", "value": f"`{full_path}`", "inline": False})
+    embed: dict[str, object] = {
+        "title": f"SeedSync — {label}",
+        "description": f"`{filename}`",
+        "color": color,
+        "timestamp": ts,
     }
+    if fields:
+        embed["fields"] = fields
+    payload = {"embeds": [embed]}
     headers = {"Content-Type": "application/json"}
     return headers, json.dumps(payload).encode("utf-8")
+
+
+def _escape_markdown(text: str) -> str:
+    """Escape characters that have meaning in Telegram Markdown v1.
+
+    Inside inline code (backtick-delimited) only backticks need escaping,
+    but since we use backticks to wrap user-provided text, we strip them
+    from the value to prevent premature closing of the code span.
+    """
+    return text.replace("`", "'")
 
 
 def format_telegram(
@@ -55,13 +72,22 @@ def format_telegram(
     chat_id: str,
     event_type: str,
     filename: str,
+    *,
+    pair_id: str | None = None,
+    full_path: str | None = None,
 ) -> tuple[str, dict[str, str], bytes]:
     """Build a Telegram sendMessage payload.
 
     Returns (api_url, headers, body_bytes).
     """
     label = EVENT_LABELS.get(event_type, event_type)
-    text = f"*SeedSync*\nEvent: `{label}`\nFile: `{filename}`"
+    safe_filename = _escape_markdown(filename)
+    lines = ["*SeedSync*", f"Event: `{label}`", f"File: `{safe_filename}`"]
+    if pair_id:
+        lines.append(f"Pair: `{_escape_markdown(pair_id)}`")
+    if full_path:
+        lines.append(f"Path: `{_escape_markdown(full_path)}`")
+    text = "\n".join(lines)
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
     payload = {
         "chat_id": chat_id,

--- a/src/python/controller/notification_formatters.py
+++ b/src/python/controller/notification_formatters.py
@@ -43,10 +43,10 @@ def format_discord(
     if pair_id:
         fields.append({"name": "Pair", "value": pair_id, "inline": True})
     if full_path:
-        fields.append({"name": "Path", "value": f"`{full_path}`", "inline": False})
+        fields.append({"name": "Path", "value": f"`{_escape_backticks(full_path)}`", "inline": False})
     embed: dict[str, object] = {
         "title": f"SeedSync — {label}",
-        "description": f"`{filename}`",
+        "description": f"`{_escape_backticks(filename)}`",
         "color": color,
         "timestamp": ts,
     }
@@ -57,12 +57,9 @@ def format_discord(
     return headers, json.dumps(payload).encode("utf-8")
 
 
-def _escape_markdown(text: str) -> str:
-    """Escape characters that have meaning in Telegram Markdown v1.
-
-    Inside inline code (backtick-delimited) only backticks need escaping,
-    but since we use backticks to wrap user-provided text, we strip them
-    from the value to prevent premature closing of the code span.
+def _escape_backticks(text: str) -> str:
+    """Replace backticks so user-provided text can be safely wrapped in
+    backtick-delimited inline code spans (Discord embeds, Telegram Markdown).
     """
     return text.replace("`", "'")
 
@@ -81,12 +78,12 @@ def format_telegram(
     Returns (api_url, headers, body_bytes).
     """
     label = EVENT_LABELS.get(event_type, event_type)
-    safe_filename = _escape_markdown(filename)
+    safe_filename = _escape_backticks(filename)
     lines = ["*SeedSync*", f"Event: `{label}`", f"File: `{safe_filename}`"]
     if pair_id:
-        lines.append(f"Pair: `{_escape_markdown(pair_id)}`")
+        lines.append(f"Pair: `{_escape_backticks(pair_id)}`")
     if full_path:
-        lines.append(f"Path: `{_escape_markdown(full_path)}`")
+        lines.append(f"Path: `{_escape_backticks(full_path)}`")
     text = "\n".join(lines)
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
     payload = {

--- a/src/python/controller/notification_formatters.py
+++ b/src/python/controller/notification_formatters.py
@@ -1,0 +1,72 @@
+"""Pure formatting functions for Discord and Telegram notification payloads.
+
+These functions do no I/O — they produce ready-to-POST (url, headers, body)
+triples that callers dispatch via fire-and-forget threads.
+"""
+
+import json
+from datetime import UTC, datetime
+
+EVENT_LABELS: dict[str, str] = {
+    "download_complete": "Download Complete",
+    "extraction_complete": "Extraction Complete",
+    "extraction_failed": "Extraction Failed",
+    "delete_complete": "Delete Complete",
+    "test": "Test Notification",
+}
+
+DISCORD_COLORS: dict[str, int] = {
+    "download_complete": 0x57F287,  # green
+    "extraction_complete": 0x5865F2,  # blurple
+    "extraction_failed": 0xED4245,  # red
+    "delete_complete": 0x99AAB5,  # grey
+    "test": 0x5865F2,  # blurple
+}
+
+
+def format_discord(
+    event_type: str,
+    filename: str,
+    timestamp: str | None = None,
+) -> tuple[dict[str, str], bytes]:
+    """Build a Discord webhook embed payload.
+
+    Returns (headers, body_bytes). The caller provides the webhook URL.
+    """
+    label = EVENT_LABELS.get(event_type, event_type)
+    color = DISCORD_COLORS.get(event_type, 0x99AAB5)
+    ts = timestamp or datetime.now(UTC).isoformat()
+    payload = {
+        "embeds": [
+            {
+                "title": f"SeedSync — {label}",
+                "description": f"`{filename}`",
+                "color": color,
+                "timestamp": ts,
+            }
+        ]
+    }
+    headers = {"Content-Type": "application/json"}
+    return headers, json.dumps(payload).encode("utf-8")
+
+
+def format_telegram(
+    bot_token: str,
+    chat_id: str,
+    event_type: str,
+    filename: str,
+) -> tuple[str, dict[str, str], bytes]:
+    """Build a Telegram sendMessage payload.
+
+    Returns (api_url, headers, body_bytes).
+    """
+    label = EVENT_LABELS.get(event_type, event_type)
+    text = f"*SeedSync*\nEvent: `{label}`\nFile: `{filename}`"
+    url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+    payload = {
+        "chat_id": chat_id,
+        "text": text,
+        "parse_mode": "Markdown",
+    }
+    headers = {"Content-Type": "application/json"}
+    return url, headers, json.dumps(payload).encode("utf-8")

--- a/src/python/controller/notifier.py
+++ b/src/python/controller/notifier.py
@@ -34,12 +34,16 @@ class WebhookNotifier(IModelListener):
         if not event_type:
             return
 
+        timestamp = datetime.now(UTC).isoformat()
+        pair_id = new_file.pair_id
+        full_path = new_file.full_path
+
         if self._config.notifications.webhook_url:
-            self._fire_webhook(event_type, new_file.name, pair_id=new_file.pair_id, full_path=new_file.full_path)
+            self._fire_webhook(event_type, new_file.name, timestamp, pair_id=pair_id, full_path=full_path)
         if self._config.notifications.discord_webhook_url:
-            self._fire_discord(event_type, new_file.name)
+            self._fire_discord(event_type, new_file.name, timestamp, pair_id=pair_id, full_path=full_path)
         if self._config.notifications.telegram_bot_token and self._config.notifications.telegram_chat_id:
-            self._fire_telegram(event_type, new_file.name)
+            self._fire_telegram(event_type, new_file.name, pair_id=pair_id, full_path=full_path)
 
     def _resolve_event_type(self, state: ModelFile.State) -> str | None:
         """Map a file state to an event type string, gated by config flags."""
@@ -82,13 +86,21 @@ class WebhookNotifier(IModelListener):
         else:
             self._logger.info("Webhook notifier shutdown: all threads completed")
 
-    def _fire_webhook(self, event_type: str, filename: str, pair_id: str | None = None, full_path: str | None = None):
+    def _fire_webhook(
+        self,
+        event_type: str,
+        filename: str,
+        timestamp: str,
+        *,
+        pair_id: str | None = None,
+        full_path: str | None = None,
+    ):
         """Fire-and-forget POST of raw webhook payload."""
         url = self._config.notifications.webhook_url
-        payload = {
+        payload: dict[str, str] = {
             "event_type": event_type,
             "filename": filename,
-            "timestamp": datetime.now(UTC).isoformat(),
+            "timestamp": timestamp,
         }
         if pair_id:
             payload["pair_id"] = pair_id
@@ -98,17 +110,32 @@ class WebhookNotifier(IModelListener):
         body = json.dumps(payload).encode("utf-8")
         self._fire_raw("webhook", url, headers, body)
 
-    def _fire_discord(self, event_type: str, filename: str):
+    def _fire_discord(
+        self,
+        event_type: str,
+        filename: str,
+        timestamp: str,
+        *,
+        pair_id: str | None = None,
+        full_path: str | None = None,
+    ):
         """Fire-and-forget POST of Discord embed."""
         url = self._config.notifications.discord_webhook_url
-        headers, body = format_discord(event_type, filename)
+        headers, body = format_discord(event_type, filename, timestamp=timestamp, pair_id=pair_id, full_path=full_path)
         self._fire_raw("Discord", url, headers, body)
 
-    def _fire_telegram(self, event_type: str, filename: str):
+    def _fire_telegram(
+        self,
+        event_type: str,
+        filename: str,
+        *,
+        pair_id: str | None = None,
+        full_path: str | None = None,
+    ):
         """Fire-and-forget POST of Telegram message."""
         token = self._config.notifications.telegram_bot_token
         chat_id = self._config.notifications.telegram_chat_id
-        url, headers, body = format_telegram(token, chat_id, event_type, filename)
+        url, headers, body = format_telegram(token, chat_id, event_type, filename, pair_id=pair_id, full_path=full_path)
         self._fire_raw("Telegram", url, headers, body)
 
     def _fire_raw(self, label: str, url: str, headers: dict[str, str], body: bytes):

--- a/src/python/controller/notifier.py
+++ b/src/python/controller/notifier.py
@@ -6,6 +6,7 @@ import urllib.request
 from datetime import UTC, datetime
 
 from common import Config
+from controller.notification_formatters import format_discord, format_telegram
 from model import IModelListener, ModelFile
 
 
@@ -29,29 +30,32 @@ class WebhookNotifier(IModelListener):
         if old_file.state == new_file.state:
             return
 
-        event_type = None
-        if new_file.state == ModelFile.State.DOWNLOADED:
-            if self._config.notifications.notify_on_download_complete:
-                event_type = "download_complete"
-        elif new_file.state == ModelFile.State.EXTRACTED:
-            if self._config.notifications.notify_on_extraction_complete:
-                event_type = "extraction_complete"
-        elif new_file.state == ModelFile.State.EXTRACT_FAILED:
-            if self._config.notifications.notify_on_extraction_failed:
-                event_type = "extraction_failed"
-        elif new_file.state == ModelFile.State.DELETED:
-            if self._config.notifications.notify_on_delete_complete:
-                event_type = "delete_complete"
+        event_type = self._resolve_event_type(new_file.state)
+        if not event_type:
+            return
 
-        if event_type and self._config.notifications.webhook_url:
+        if self._config.notifications.webhook_url:
             self._fire_webhook(event_type, new_file.name, pair_id=new_file.pair_id, full_path=new_file.full_path)
+        if self._config.notifications.discord_webhook_url:
+            self._fire_discord(event_type, new_file.name)
+        if self._config.notifications.telegram_bot_token and self._config.notifications.telegram_chat_id:
+            self._fire_telegram(event_type, new_file.name)
+
+    def _resolve_event_type(self, state: ModelFile.State) -> str | None:
+        """Map a file state to an event type string, gated by config flags."""
+        notif = self._config.notifications
+        if state == ModelFile.State.DOWNLOADED and notif.notify_on_download_complete:
+            return "download_complete"
+        if state == ModelFile.State.EXTRACTED and notif.notify_on_extraction_complete:
+            return "extraction_complete"
+        if state == ModelFile.State.EXTRACT_FAILED and notif.notify_on_extraction_failed:
+            return "extraction_failed"
+        if state == ModelFile.State.DELETED and notif.notify_on_delete_complete:
+            return "delete_complete"
+        return None
 
     def shutdown(self, timeout: float = 5):
-        """Drain in-flight webhook threads and prevent new ones from being queued.
-
-        Args:
-            timeout: Maximum total seconds to wait for all in-flight threads to complete.
-        """
+        """Drain in-flight webhook threads and prevent new ones from being queued."""
         with self._lock:
             self._shutdown_flag = True
             threads = list(self._active_threads)
@@ -79,7 +83,7 @@ class WebhookNotifier(IModelListener):
             self._logger.info("Webhook notifier shutdown: all threads completed")
 
     def _fire_webhook(self, event_type: str, filename: str, pair_id: str | None = None, full_path: str | None = None):
-        """Fire-and-forget POST in a daemon thread."""
+        """Fire-and-forget POST of raw webhook payload."""
         url = self._config.notifications.webhook_url
         payload = {
             "event_type": event_type,
@@ -90,31 +94,48 @@ class WebhookNotifier(IModelListener):
             payload["pair_id"] = pair_id
         if full_path:
             payload["path"] = full_path
-        thread = threading.Thread(target=self._thread_wrapper, args=(url, payload), daemon=True)
+        headers = {"Content-Type": "application/json"}
+        body = json.dumps(payload).encode("utf-8")
+        self._fire_raw("webhook", url, headers, body)
+
+    def _fire_discord(self, event_type: str, filename: str):
+        """Fire-and-forget POST of Discord embed."""
+        url = self._config.notifications.discord_webhook_url
+        headers, body = format_discord(event_type, filename)
+        self._fire_raw("Discord", url, headers, body)
+
+    def _fire_telegram(self, event_type: str, filename: str):
+        """Fire-and-forget POST of Telegram message."""
+        token = self._config.notifications.telegram_bot_token
+        chat_id = self._config.notifications.telegram_chat_id
+        url, headers, body = format_telegram(token, chat_id, event_type, filename)
+        self._fire_raw("Telegram", url, headers, body)
+
+    def _fire_raw(self, label: str, url: str, headers: dict[str, str], body: bytes):
+        """Fire-and-forget POST in a daemon thread."""
+        thread = threading.Thread(target=self._thread_wrapper, args=(label, url, headers, body), daemon=True)
         with self._lock:
             if self._shutdown_flag:
-                self._logger.debug("Webhook suppressed during shutdown: %s %s", event_type, filename)
+                self._logger.debug("%s notification suppressed during shutdown", label)
                 return
             self._active_threads.add(thread)
         thread.start()
 
-    def _thread_wrapper(self, url: str, payload: dict[str, str]) -> None:
-        """Wraps _send_post to track thread lifecycle."""
+    def _thread_wrapper(self, label: str, url: str, headers: dict[str, str], body: bytes) -> None:
         try:
-            self._send_post(url, payload)
+            self._send_post(label, url, headers, body)
         finally:
             with self._lock:
                 self._active_threads.discard(threading.current_thread())
 
-    def _send_post(self, url: str, payload: dict[str, str]) -> None:
+    def _send_post(self, label: str, url: str, headers: dict[str, str], body: bytes) -> None:
         if not url.startswith(("http://", "https://")):
-            self._logger.warning("Webhook URL rejected: scheme is not http/https")
+            self._logger.warning("%s URL rejected: scheme is not http/https", label)
             return
         try:
-            data = json.dumps(payload).encode("utf-8")
-            req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"}, method="POST")
+            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=5):
                 pass
-            self._logger.debug("Webhook sent: %s %s", payload["event_type"], payload["filename"])
+            self._logger.debug("%s notification sent", label)
         except Exception as e:
-            self._logger.warning("Webhook failed: %s", str(e))
+            self._logger.warning("%s notification failed: %s", label, str(e))

--- a/src/python/controller/notifier.py
+++ b/src/python/controller/notifier.py
@@ -146,7 +146,12 @@ class WebhookNotifier(IModelListener):
                 self._logger.debug("%s notification suppressed during shutdown", label)
                 return
             self._active_threads.add(thread)
-        thread.start()
+        try:
+            thread.start()
+        except RuntimeError:
+            with self._lock:
+                self._active_threads.discard(thread)
+            self._logger.exception("%s notification thread failed to start", label)
 
     def _thread_wrapper(self, label: str, url: str, headers: dict[str, str], body: bytes) -> None:
         try:

--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -390,6 +390,9 @@ class Seedsync:
         config.notifications.notify_on_extraction_complete = True
         config.notifications.notify_on_extraction_failed = True
         config.notifications.notify_on_delete_complete = True
+        config.notifications.discord_webhook_url = ""
+        config.notifications.telegram_bot_token = ""
+        config.notifications.telegram_chat_id = ""
 
         config.lftp.net_limit_rate = ""
         config.lftp.net_socket_buffer = "8M"

--- a/src/python/tests/integration/test_web/test_handler/test_notifications.py
+++ b/src/python/tests/integration/test_web/test_handler/test_notifications.py
@@ -1,0 +1,110 @@
+import json
+import unittest
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+from common import overrides
+from tests.integration.test_web.test_web_app import BaseTestWebApp
+
+
+class TestNotificationsHandler(BaseTestWebApp):
+    """Integration tests for the Discord/Telegram test notification endpoints."""
+
+    @overrides(BaseTestWebApp)
+    def setUp(self):
+        super().setUp()
+        from webtest import TestApp
+
+        from web import WebAppBuilder
+
+        self.web_app_builder = WebAppBuilder(self.context, self.controller, self.auto_queue_persist)
+        self.web_app = self.web_app_builder.build()
+        self.test_app = TestApp(self.web_app, extra_environ={"REMOTE_ADDR": "127.0.0.1"})
+
+    def _post(self, url, expect_errors=False):
+        return self.test_app.post(
+            url,
+            params=json.dumps({}),
+            content_type="application/json",
+            expect_errors=expect_errors,
+        )
+
+    # ------------------------------------------------------------------
+    # Discord
+    # ------------------------------------------------------------------
+    def test_discord_not_configured(self):
+        self.context.config.notifications.discord_webhook_url = ""
+        resp = self._post("/server/notifications/test/discord", expect_errors=True)
+        self.assertEqual(400, resp.status_int)
+        body = json.loads(resp.text)
+        self.assertIn("not configured", body["error"].lower())
+
+    @patch("web.handler.notifications.urllib.request.urlopen")
+    def test_discord_success(self, mock_urlopen):
+        self.context.config.notifications.discord_webhook_url = "https://discord.com/api/webhooks/123/TOKEN"
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        resp = self._post("/server/notifications/test/discord")
+        self.assertEqual(200, resp.status_int)
+        body = json.loads(resp.text)
+        self.assertTrue(body["success"])
+
+    @patch("web.handler.notifications.urllib.request.urlopen")
+    def test_discord_failure_returns_502(self, mock_urlopen):
+        self.context.config.notifications.discord_webhook_url = "https://discord.com/api/webhooks/123/TOKEN"
+        mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+        resp = self._post("/server/notifications/test/discord", expect_errors=True)
+        self.assertEqual(502, resp.status_int)
+        body = json.loads(resp.text)
+        self.assertIn("failed", body["error"].lower())
+        self.assertNotIn("URLError", resp.text)
+
+    # ------------------------------------------------------------------
+    # Telegram
+    # ------------------------------------------------------------------
+    def test_telegram_token_not_configured(self):
+        self.context.config.notifications.telegram_bot_token = ""
+        self.context.config.notifications.telegram_chat_id = "123"
+        resp = self._post("/server/notifications/test/telegram", expect_errors=True)
+        self.assertEqual(400, resp.status_int)
+        body = json.loads(resp.text)
+        self.assertIn("bot token", body["error"].lower())
+
+    def test_telegram_chat_id_not_configured(self):
+        self.context.config.notifications.telegram_bot_token = "tok"
+        self.context.config.notifications.telegram_chat_id = ""
+        resp = self._post("/server/notifications/test/telegram", expect_errors=True)
+        self.assertEqual(400, resp.status_int)
+        body = json.loads(resp.text)
+        self.assertIn("chat id", body["error"].lower())
+
+    @patch("web.handler.notifications.urllib.request.urlopen")
+    def test_telegram_success(self, mock_urlopen):
+        self.context.config.notifications.telegram_bot_token = "tok"
+        self.context.config.notifications.telegram_chat_id = "123"
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        resp = self._post("/server/notifications/test/telegram")
+        self.assertEqual(200, resp.status_int)
+        body = json.loads(resp.text)
+        self.assertTrue(body["success"])
+
+    @patch("web.handler.notifications.urllib.request.urlopen")
+    def test_telegram_failure_returns_502(self, mock_urlopen):
+        self.context.config.notifications.telegram_bot_token = "tok"
+        self.context.config.notifications.telegram_chat_id = "123"
+        mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+        resp = self._post("/server/notifications/test/telegram", expect_errors=True)
+        self.assertEqual(502, resp.status_int)
+        body = json.loads(resp.text)
+        self.assertIn("failed", body["error"].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/python/tests/unittests/test_common/test_config.py
+++ b/src/python/tests/unittests/test_common/test_config.py
@@ -669,6 +669,9 @@ class TestConfig(unittest.TestCase):
         notify_on_extraction_complete = True
         notify_on_extraction_failed = True
         notify_on_delete_complete = True
+        discord_webhook_url =
+        telegram_bot_token =
+        telegram_chat_id =
 
         [Validate]
         enabled = False

--- a/src/python/tests/unittests/test_controller/test_notification_formatters.py
+++ b/src/python/tests/unittests/test_controller/test_notification_formatters.py
@@ -1,0 +1,83 @@
+import json
+import unittest
+
+from controller.notification_formatters import (
+    DISCORD_COLORS,
+    EVENT_LABELS,
+    format_discord,
+    format_telegram,
+)
+
+
+class TestFormatDiscord(unittest.TestCase):
+    def test_returns_json_content_type(self):
+        headers, _ = format_discord("download_complete", "file.mkv")
+        self.assertEqual("application/json", headers["Content-Type"])
+
+    def test_body_is_valid_json(self):
+        _, body = format_discord("download_complete", "file.mkv")
+        payload = json.loads(body)
+        self.assertIn("embeds", payload)
+        self.assertEqual(1, len(payload["embeds"]))
+
+    def test_embed_title_contains_event_label(self):
+        for event_type, label in EVENT_LABELS.items():
+            _, body = format_discord(event_type, "file.mkv")
+            embed = json.loads(body)["embeds"][0]
+            self.assertIn(label, embed["title"], msg=event_type)
+
+    def test_embed_description_contains_filename(self):
+        _, body = format_discord("download_complete", "Movie.2024.mkv")
+        embed = json.loads(body)["embeds"][0]
+        self.assertIn("Movie.2024.mkv", embed["description"])
+
+    def test_embed_color_matches_event_type(self):
+        for event_type, color in DISCORD_COLORS.items():
+            _, body = format_discord(event_type, "f")
+            embed = json.loads(body)["embeds"][0]
+            self.assertEqual(color, embed["color"], msg=event_type)
+
+    def test_embed_has_timestamp(self):
+        _, body = format_discord("test", "f", timestamp="2026-01-01T00:00:00+00:00")
+        embed = json.loads(body)["embeds"][0]
+        self.assertEqual("2026-01-01T00:00:00+00:00", embed["timestamp"])
+
+    def test_unknown_event_type_uses_raw_string(self):
+        _, body = format_discord("custom_event", "f")
+        embed = json.loads(body)["embeds"][0]
+        self.assertIn("custom_event", embed["title"])
+
+
+class TestFormatTelegram(unittest.TestCase):
+    def test_url_contains_bot_token(self):
+        url, _, _ = format_telegram("TOKEN123", "CHAT456", "download_complete", "file.mkv")
+        self.assertEqual("https://api.telegram.org/botTOKEN123/sendMessage", url)
+
+    def test_body_contains_chat_id(self):
+        _, _, body = format_telegram("tok", "12345", "download_complete", "file.mkv")
+        payload = json.loads(body)
+        self.assertEqual("12345", payload["chat_id"])
+
+    def test_body_uses_markdown_parse_mode(self):
+        _, _, body = format_telegram("tok", "id", "download_complete", "file.mkv")
+        payload = json.loads(body)
+        self.assertEqual("Markdown", payload["parse_mode"])
+
+    def test_text_contains_filename(self):
+        _, _, body = format_telegram("tok", "id", "download_complete", "Movie.2024.mkv")
+        payload = json.loads(body)
+        self.assertIn("Movie.2024.mkv", payload["text"])
+
+    def test_text_contains_event_label(self):
+        for event_type, label in EVENT_LABELS.items():
+            _, _, body = format_telegram("tok", "id", event_type, "f")
+            payload = json.loads(body)
+            self.assertIn(label, payload["text"], msg=event_type)
+
+    def test_returns_json_content_type(self):
+        _, headers, _ = format_telegram("tok", "id", "test", "f")
+        self.assertEqual("application/json", headers["Content-Type"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/python/tests/unittests/test_controller/test_notifier.py
+++ b/src/python/tests/unittests/test_controller/test_notifier.py
@@ -48,7 +48,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
         notifier.shutdown(timeout=1)
 
         with patch.object(notifier, "_send_post") as mock_send:
-            notifier._fire_webhook("download_complete", "test.txt")
+            notifier._fire_webhook("download_complete", "test.txt", "2026-01-01T00:00:00+00:00")
             mock_send.assert_not_called()
 
     def test_shutdown_waits_for_inflight_threads(self):
@@ -61,7 +61,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
             barrier.wait(timeout=5)
 
         with patch.object(notifier, "_send_post", side_effect=slow_send):
-            notifier._fire_webhook("download_complete", "test.txt")
+            notifier._fire_webhook("download_complete", "test.txt", "2026-01-01T00:00:00+00:00")
             started.wait(timeout=5)
 
             with notifier._lock:
@@ -83,7 +83,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
             barrier.wait(timeout=10)
 
         with patch.object(notifier, "_send_post", side_effect=stuck_send):
-            notifier._fire_webhook("download_complete", "test.txt")
+            notifier._fire_webhook("download_complete", "test.txt", "2026-01-01T00:00:00+00:00")
             started.wait(timeout=5)
 
             start = time.monotonic()
@@ -103,7 +103,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
             raise RuntimeError("webhook failed")
 
         with patch.object(notifier, "_send_post", side_effect=failing_send):
-            notifier._fire_webhook("download_complete", "test.txt")
+            notifier._fire_webhook("download_complete", "test.txt", "2026-01-01T00:00:00+00:00")
             started.wait(timeout=5)
             notifier.shutdown(timeout=2)
 
@@ -116,7 +116,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
 
         with patch.object(notifier, "_send_post") as mock_send:
             for i in range(10):
-                notifier._fire_webhook("download_complete", f"file{i}.txt")
+                notifier._fire_webhook("download_complete", f"file{i}.txt", "2026-01-01T00:00:00+00:00")
 
             mock_send.assert_not_called()
             with notifier._lock:
@@ -141,7 +141,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
 
         with patch.object(notifier, "_send_post", side_effect=slow_send):
             for i in range(5):
-                notifier._fire_webhook("download_complete", f"file{i}.txt")
+                notifier._fire_webhook("download_complete", f"file{i}.txt", "2026-01-01T00:00:00+00:00")
             all_started.wait(timeout=5)
 
             start = time.monotonic()

--- a/src/python/tests/unittests/test_controller/test_notifier.py
+++ b/src/python/tests/unittests/test_controller/test_notifier.py
@@ -5,18 +5,28 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from controller.notifier import WebhookNotifier
+from model.file import ModelFile
 
 
 class TestWebhookNotifierShutdown(unittest.TestCase):
     """Tests for WebhookNotifier shutdown drain behavior."""
 
-    def _make_config(self, webhook_url="http://example.com/hook"):
+    def _make_config(
+        self,
+        webhook_url="http://example.com/hook",
+        discord_webhook_url="",
+        telegram_bot_token="",
+        telegram_chat_id="",
+    ):
         config = MagicMock()
         config.notifications.webhook_url = webhook_url
         config.notifications.notify_on_download_complete = True
         config.notifications.notify_on_extraction_complete = True
         config.notifications.notify_on_extraction_failed = True
         config.notifications.notify_on_delete_complete = True
+        config.notifications.discord_webhook_url = discord_webhook_url
+        config.notifications.telegram_bot_token = telegram_bot_token
+        config.notifications.telegram_chat_id = telegram_chat_id
         return config
 
     def _make_notifier(self, **kwargs):
@@ -24,14 +34,16 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
         logger = logging.getLogger("test_notifier")
         return WebhookNotifier(config, logger)
 
+    def _make_file(self, name="test.txt", state=ModelFile.State.DEFAULT):
+        f = ModelFile(name, False)
+        f.state = state
+        return f
+
     def test_shutdown_no_threads(self):
-        """Shutdown with no in-flight threads completes immediately."""
         notifier = self._make_notifier()
         notifier.shutdown(timeout=1)
-        # Should not raise
 
     def test_shutdown_prevents_new_webhooks(self):
-        """After shutdown, _fire_webhook should not start new threads."""
         notifier = self._make_notifier()
         notifier.shutdown(timeout=1)
 
@@ -40,12 +52,11 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
             mock_send.assert_not_called()
 
     def test_shutdown_waits_for_inflight_threads(self):
-        """Shutdown joins in-flight threads."""
         notifier = self._make_notifier()
         barrier = threading.Event()
         started = threading.Event()
 
-        def slow_send(url, payload):
+        def slow_send(*_args):
             started.set()
             barrier.wait(timeout=5)
 
@@ -56,7 +67,6 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
             with notifier._lock:
                 self.assertEqual(len(notifier._active_threads), 1)
 
-            # Release the barrier so shutdown can complete
             barrier.set()
             notifier.shutdown(timeout=2)
 
@@ -64,12 +74,11 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
                 self.assertEqual(len(notifier._active_threads), 0)
 
     def test_shutdown_timeout_respected(self):
-        """Shutdown returns after timeout even if threads are stuck."""
         notifier = self._make_notifier()
         barrier = threading.Event()
         started = threading.Event()
 
-        def stuck_send(url, payload):
+        def stuck_send(*_args):
             started.set()
             barrier.wait(timeout=10)
 
@@ -81,41 +90,31 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
             notifier.shutdown(timeout=0.2)
             elapsed = time.monotonic() - start
 
-            # Should return in roughly the timeout period, not 10s
             self.assertLess(elapsed, 1.0)
 
-        # Clean up: release stuck thread
         barrier.set()
 
     def test_thread_removed_on_exception(self):
-        """Thread is removed from _active_threads even if _send_post raises."""
         notifier = self._make_notifier()
         started = threading.Event()
 
-        def failing_send(url, payload):
+        def failing_send(*_args):
             started.set()
             raise RuntimeError("webhook failed")
 
         with patch.object(notifier, "_send_post", side_effect=failing_send):
             notifier._fire_webhook("download_complete", "test.txt")
             started.wait(timeout=5)
-            # Give the thread a moment to complete the exception handling
             notifier.shutdown(timeout=2)
 
             with notifier._lock:
                 self.assertEqual(len(notifier._active_threads), 0)
 
     def test_shutdown_flag_and_registration_atomic(self):
-        """No race between shutdown flag check and thread registration.
-
-        After shutdown sets the flag, no new threads should appear in
-        _active_threads.
-        """
         notifier = self._make_notifier()
         notifier.shutdown(timeout=0)
 
         with patch.object(notifier, "_send_post") as mock_send:
-            # Try to fire multiple webhooks after shutdown
             for i in range(10):
                 notifier._fire_webhook("download_complete", f"file{i}.txt")
 
@@ -124,14 +123,13 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
                 self.assertEqual(len(notifier._active_threads), 0)
 
     def test_total_timeout_not_per_thread(self):
-        """Total shutdown time should be bounded by timeout, not timeout * N."""
         notifier = self._make_notifier()
-        barriers = []
+        barriers: list[threading.Event] = []
         all_started = threading.Event()
         started_count = 0
         started_lock = threading.Lock()
 
-        def slow_send(url, payload):
+        def slow_send(*_args):
             nonlocal started_count
             b = threading.Event()
             barriers.append(b)
@@ -142,7 +140,6 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
             b.wait(timeout=10)
 
         with patch.object(notifier, "_send_post", side_effect=slow_send):
-            # Fire 5 webhooks
             for i in range(5):
                 notifier._fire_webhook("download_complete", f"file{i}.txt")
             all_started.wait(timeout=5)
@@ -151,13 +148,114 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
             notifier.shutdown(timeout=0.3)
             elapsed = time.monotonic() - start
 
-            # With 5 threads and 0.3s total timeout, should finish well under 1.5s
-            # (would be 1.5s if timeout was per-thread)
             self.assertLess(elapsed, 1.0)
 
-        # Clean up
         for b in barriers:
             b.set()
+
+
+class TestWebhookNotifierDispatch(unittest.TestCase):
+    """Tests for event dispatch to webhook, Discord, and Telegram."""
+
+    def _make_config(
+        self,
+        webhook_url="",
+        discord_webhook_url="",
+        telegram_bot_token="",
+        telegram_chat_id="",
+    ):
+        config = MagicMock()
+        config.notifications.webhook_url = webhook_url
+        config.notifications.notify_on_download_complete = True
+        config.notifications.notify_on_extraction_complete = True
+        config.notifications.notify_on_extraction_failed = True
+        config.notifications.notify_on_delete_complete = True
+        config.notifications.discord_webhook_url = discord_webhook_url
+        config.notifications.telegram_bot_token = telegram_bot_token
+        config.notifications.telegram_chat_id = telegram_chat_id
+        return config
+
+    def _make_notifier(self, **kwargs):
+        config = self._make_config(**kwargs)
+        logger = logging.getLogger("test_notifier_dispatch")
+        return WebhookNotifier(config, logger)
+
+    def _trigger(self, notifier):
+        old = ModelFile("test.mkv", False)
+        old.state = ModelFile.State.DOWNLOADING
+        new = ModelFile("test.mkv", False)
+        new.state = ModelFile.State.DOWNLOADED
+        notifier.file_updated(old, new)
+
+    def test_webhook_fires_when_configured(self):
+        notifier = self._make_notifier(webhook_url="http://hook.test")
+        with patch.object(notifier, "_fire_raw") as mock:
+            self._trigger(notifier)
+            notifier.shutdown(timeout=1)
+            mock.assert_called_once()
+            self.assertEqual("webhook", mock.call_args[0][0])
+
+    def test_discord_fires_when_configured(self):
+        notifier = self._make_notifier(discord_webhook_url="https://discord.com/api/webhooks/123/TOKEN")
+        with patch.object(notifier, "_fire_raw") as mock:
+            self._trigger(notifier)
+            notifier.shutdown(timeout=1)
+            mock.assert_called_once()
+            self.assertEqual("Discord", mock.call_args[0][0])
+
+    def test_telegram_fires_when_both_token_and_chat_id_set(self):
+        notifier = self._make_notifier(telegram_bot_token="tok", telegram_chat_id="123")
+        with patch.object(notifier, "_fire_raw") as mock:
+            self._trigger(notifier)
+            notifier.shutdown(timeout=1)
+            mock.assert_called_once()
+            self.assertEqual("Telegram", mock.call_args[0][0])
+
+    def test_telegram_skipped_when_token_missing(self):
+        notifier = self._make_notifier(telegram_bot_token="", telegram_chat_id="123")
+        with patch.object(notifier, "_fire_raw") as mock:
+            self._trigger(notifier)
+            notifier.shutdown(timeout=1)
+            mock.assert_not_called()
+
+    def test_telegram_skipped_when_chat_id_missing(self):
+        notifier = self._make_notifier(telegram_bot_token="tok", telegram_chat_id="")
+        with patch.object(notifier, "_fire_raw") as mock:
+            self._trigger(notifier)
+            notifier.shutdown(timeout=1)
+            mock.assert_not_called()
+
+    def test_all_three_fire_simultaneously(self):
+        notifier = self._make_notifier(
+            webhook_url="http://hook.test",
+            discord_webhook_url="https://discord.com/api/webhooks/123/TOKEN",
+            telegram_bot_token="tok",
+            telegram_chat_id="123",
+        )
+        with patch.object(notifier, "_fire_raw") as mock:
+            self._trigger(notifier)
+            notifier.shutdown(timeout=1)
+            self.assertEqual(3, mock.call_count)
+            labels = {call[0][0] for call in mock.call_args_list}
+            self.assertEqual({"webhook", "Discord", "Telegram"}, labels)
+
+    def test_nothing_fires_when_event_disabled(self):
+        notifier = self._make_notifier(
+            webhook_url="http://hook.test",
+            discord_webhook_url="https://discord.com/hook",
+        )
+        notifier._config.notifications.notify_on_download_complete = False
+        with patch.object(notifier, "_fire_raw") as mock:
+            self._trigger(notifier)
+            notifier.shutdown(timeout=1)
+            mock.assert_not_called()
+
+    def test_nothing_fires_when_no_channels_configured(self):
+        notifier = self._make_notifier()
+        with patch.object(notifier, "_fire_raw") as mock:
+            self._trigger(notifier)
+            notifier.shutdown(timeout=1)
+            mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/src/python/web/handler/notifications.py
+++ b/src/python/web/handler/notifications.py
@@ -54,6 +54,13 @@ class NotificationsHandler(IHandler):
         return self.__send_test(url, headers, body, "Telegram")
 
     def __send_test(self, url: str, headers: dict[str, str], body: bytes, service: str) -> HTTPResponse:
+        if not url.startswith(("http://", "https://")):
+            self._logger.warning("%s test URL rejected: scheme is not http/https", service)
+            return HTTPResponse(
+                body=json.dumps({"error": f"{service} URL must start with http:// or https://"}),
+                status=400,
+                headers={"Content-Type": "application/json"},
+            )
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=10):

--- a/src/python/web/handler/notifications.py
+++ b/src/python/web/handler/notifications.py
@@ -1,0 +1,69 @@
+import json
+import logging
+import urllib.request
+from datetime import UTC, datetime
+
+from bottle import HTTPResponse
+
+from common import Config
+from common.types import overrides
+from controller.notification_formatters import format_discord, format_telegram
+
+from ..web_app import IHandler, WebApp
+
+
+class NotificationsHandler(IHandler):
+    """REST endpoints for testing Discord and Telegram notifications."""
+
+    def __init__(self, config: Config):
+        self.__config = config
+        self._logger = logging.getLogger(self.__class__.__name__)
+
+    @overrides(IHandler)
+    def add_routes(self, web_app: WebApp):
+        web_app.add_post_handler("/server/notifications/test/discord", self.__handle_test_discord)
+        web_app.add_post_handler("/server/notifications/test/telegram", self.__handle_test_telegram)
+
+    def __handle_test_discord(self):
+        url = self.__config.notifications.discord_webhook_url
+        if not url:
+            return HTTPResponse(
+                body=json.dumps({"error": "Discord webhook URL is not configured"}),
+                status=400,
+            )
+        headers, body = format_discord("test", "seedsync-test", datetime.now(UTC).isoformat())
+        return self.__send_test(url, headers, body, "Discord")
+
+    def __handle_test_telegram(self):
+        token = self.__config.notifications.telegram_bot_token
+        chat_id = self.__config.notifications.telegram_chat_id
+        if not token:
+            return HTTPResponse(
+                body=json.dumps({"error": "Telegram bot token is not configured"}),
+                status=400,
+            )
+        if not chat_id:
+            return HTTPResponse(
+                body=json.dumps({"error": "Telegram chat ID is not configured"}),
+                status=400,
+            )
+        url, headers, body = format_telegram(token, chat_id, "test", "seedsync-test")
+        return self.__send_test(url, headers, body, "Telegram")
+
+    def __send_test(self, url: str, headers: dict[str, str], body: bytes, service: str) -> HTTPResponse:
+        try:
+            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+            with urllib.request.urlopen(req, timeout=10):
+                pass
+            return HTTPResponse(
+                body=json.dumps({"success": True}),
+                status=200,
+                headers={"Content-Type": "application/json"},
+            )
+        except Exception:
+            self._logger.exception("%s test notification failed", service)
+            return HTTPResponse(
+                body=json.dumps({"error": f"{service} notification failed. Check server logs for details."}),
+                status=502,
+                headers={"Content-Type": "application/json"},
+            )

--- a/src/python/web/handler/notifications.py
+++ b/src/python/web/handler/notifications.py
@@ -30,8 +30,9 @@ class NotificationsHandler(IHandler):
             return HTTPResponse(
                 body=json.dumps({"error": "Discord webhook URL is not configured"}),
                 status=400,
+                headers={"Content-Type": "application/json"},
             )
-        headers, body = format_discord("test", "seedsync-test", datetime.now(UTC).isoformat())
+        headers, body = format_discord("test", "seedsync-test", timestamp=datetime.now(UTC).isoformat())
         return self.__send_test(url, headers, body, "Discord")
 
     def __handle_test_telegram(self):
@@ -41,11 +42,13 @@ class NotificationsHandler(IHandler):
             return HTTPResponse(
                 body=json.dumps({"error": "Telegram bot token is not configured"}),
                 status=400,
+                headers={"Content-Type": "application/json"},
             )
         if not chat_id:
             return HTTPResponse(
                 body=json.dumps({"error": "Telegram chat ID is not configured"}),
                 status=400,
+                headers={"Content-Type": "application/json"},
             )
         url, headers, body = format_telegram(token, chat_id, "test", "seedsync-test")
         return self.__send_test(url, headers, body, "Telegram")

--- a/src/python/web/web_app_builder.py
+++ b/src/python/web/web_app_builder.py
@@ -10,6 +10,7 @@ from .handler.config import ConfigHandler
 from .handler.controller import ControllerHandler
 from .handler.integrations import IntegrationsHandler
 from .handler.logs import LogsHandler
+from .handler.notifications import NotificationsHandler
 from .handler.path_pairs import PathPairsHandler
 from .handler.server import ServerHandler
 from .handler.status import StatusHandler
@@ -37,6 +38,7 @@ class WebAppBuilder:
         self.logs_handler = LogsHandler(logdir=context.args.logdir, service_name=Constants.SERVICE_NAME)
         self.path_pairs_handler = PathPairsHandler(context.path_pairs_config, context.integrations_config)
         self.integrations_handler = IntegrationsHandler(context.integrations_config, context.path_pairs_config)
+        self.notifications_handler = NotificationsHandler(context.config)
 
     def build(self) -> WebApp:
         web_app = WebApp(context=self.__context, controller=self.__controller)
@@ -62,6 +64,7 @@ class WebAppBuilder:
         self.logs_handler.add_routes(web_app)
         self.path_pairs_handler.add_routes(web_app)
         self.integrations_handler.add_routes(web_app)
+        self.notifications_handler.add_routes(web_app)
 
         web_app.add_default_routes()
 


### PR DESCRIPTION
## Summary

- Adds Discord webhook and Telegram bot notification channels alongside the existing raw webhook
- Each channel is independently configurable in Settings with Test buttons for validation
- Discord uses rich embeds with color-coded event types; Telegram uses Markdown formatting
- Credentials (Discord webhook URL, Telegram bot token) are redacted in API responses

Closes #329

## Backend
- **Config**: `discord_webhook_url`, `telegram_bot_token`, `telegram_chat_id` added to `[Notifications]` section with sensitive field redaction
- **Formatters**: Pure `format_discord`/`format_telegram` functions in `notification_formatters.py` — no I/O, easy to test
- **Dispatch**: `WebhookNotifier` refactored with `_resolve_event_type` + `_fire_raw`, gains `_fire_discord` and `_fire_telegram`
- **REST**: `NotificationsHandler` with `POST /server/notifications/test/discord` and `/test/telegram`

## Frontend
- Discord Webhook URL and Telegram Bot Token rendered as Password fields (masked)
- Telegram Chat ID rendered as Text field
- "Test Discord" / "Test Telegram" buttons with success/failure feedback
- 6 new service tests

## Test plan

- [x] `cd src/python && ruff check . && ruff format --check .` — clean
- [x] `cd src/python && PYTHONPATH=. pytest tests/unittests/test_controller/test_notification_formatters.py tests/unittests/test_controller/test_notifier.py tests/integration/test_web/test_handler/test_notifications.py` — all pass
- [x] `cd src/angular && npx ng lint` — clean
- [x] `cd src/angular && npx ng test` — 323 passed
- [x] `cd src/angular && npx ng build` — succeeds
- [ ] Smoke-test: configure a Discord webhook URL, click Test Discord, confirm embed appears in channel
- [ ] Smoke-test: configure Telegram bot token + chat ID, click Test Telegram, confirm message appears
- [ ] Trigger a download completion and confirm all configured channels receive notifications
- [ ] Verify credentials are redacted in GET /server/config/get response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Discord webhook and Telegram bot/chat settings in app settings with in-UI test buttons, dynamic status messages, and styling.
  * Notifications can now be delivered to Discord and Telegram in addition to existing webhook delivery.
  * Notification-related sensitive fields (webhook/token) are redacted in API outputs.

* **Tests**
  * Added unit and integration tests covering formatting, delivery, error handling, and the new test endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->