### PR TITLE
Fix oversized Sonarr/Radarr add buttons

### DIFF
--- a/src/angular/src/app/pages/settings/integrations.component.scss
+++ b/src/angular/src/app/pages/settings/integrations.component.scss
@@ -15,6 +15,7 @@
     .btn-add {
       @extend %button;
 
+      flex-direction: row;
       padding: 2px 10px;
       font-size: 85%;
     }


### PR DESCRIPTION
## Summary

- Adds `flex-direction: row` to `.btn-add` in the integrations component to override the `column` layout inherited from `%button`
- The `%button` placeholder is designed for large icon+text buttons (like Restart) — compact inline buttons need the row override

One-line CSS fix.

## Test plan

- [x] `npx ng lint` — clean
- [x] `npx ng build` — succeeds
- [ ] Visual: confirm + Sonarr / + Radarr buttons match other small buttons in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)