### PR TITLE
Use consistent light text for all dark mode card headers

### DIFF
--- a/src/angular/src/app/pages/settings/path-pairs.component.scss
+++ b/src/angular/src/app/pages/settings/path-pairs.component.scss
@@ -279,7 +279,6 @@
     .header {
       background-color: #161A21;
       border-color: #252C37;
-      color: #8A93A6;
     }
 
     .pair-form {

--- a/src/angular/src/app/pages/settings/settings-page.component.scss
+++ b/src/angular/src/app/pages/settings/settings-page.component.scss
@@ -144,7 +144,6 @@
             .card-header {
                 background-color: #161A21;
                 border-bottom: 1px solid #252C37;
-                color: #8A93A6;
             }
 
             .collapsible-header:hover {


### PR DESCRIPTION
## Summary

- Remove `color: #8A93A6` (gray) from `.card-header` dark mode in settings-page
- Remove `color: #8A93A6` from path-pairs `.header` dark mode
- All section headers now inherit the default light text color, matching Integrations

## Test plan

- [x] `npx ng lint` — clean
- [x] `npx ng test` — 323 passed
- [x] `npx ng build` — succeeds
- [ ] Visual: confirm all headers (Notifications, File Discovery, Path Pairs, Integrations, etc.) have the same text color in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)