### PR TITLE
Flush configs on write, differentiated restart notifications, LFTP hot-reload

### DIFF
--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -7,6 +7,7 @@ export interface IOption {
   description: string | null;
   disabled?: boolean;
   choices?: string[];
+  requiresRestart?: boolean;
 }
 
 export interface IOptionsContext {
@@ -24,48 +25,56 @@ export const OPTIONS_CONTEXT_SERVER: IOptionsContext = {
       label: 'Server Address',
       valuePath: ['lftp', 'remote_address'],
       description: null,
+      requiresRestart: true,
     },
     {
       type: OptionType.Text,
       label: 'Server User',
       valuePath: ['lftp', 'remote_username'],
       description: null,
+      requiresRestart: true,
     },
     {
       type: OptionType.Password,
       label: 'Server Password',
       valuePath: ['lftp', 'remote_password'],
       description: 'Required unless SSH key authentication is enabled',
+      requiresRestart: true,
     },
     {
       type: OptionType.Checkbox,
       label: 'Use password-less key-based authentication',
       valuePath: ['lftp', 'use_ssh_key'],
       description: null,
+      requiresRestart: true,
     },
     {
       type: OptionType.Text,
       label: 'Server Directory',
       valuePath: ['lftp', 'remote_path'],
       description: 'Path to your files on the remote server',
+      requiresRestart: true,
     },
     {
       type: OptionType.Text,
       label: 'Local Directory',
       valuePath: ['lftp', 'local_path'],
       description: 'Downloaded files are placed here',
+      requiresRestart: true,
     },
     {
       type: OptionType.Text,
       label: 'Remote SSH Port',
       valuePath: ['lftp', 'remote_port'],
       description: null,
+      requiresRestart: true,
     },
     {
       type: OptionType.Text,
       label: 'Server Script Path',
       valuePath: ['lftp', 'remote_path_to_scan_script'],
       description: 'Where to install scanner script on remote server',
+      requiresRestart: true,
     },
     {
       type: OptionType.Text,
@@ -74,6 +83,7 @@ export const OPTIONS_CONTEXT_SERVER: IOptionsContext = {
       description:
         'Path to Python 3 on the remote server. Leave empty to use the default "python3". ' +
         'Set this if your seedbox has a custom Python install (e.g. "~/python3/bin/python3").',
+      requiresRestart: true,
     },
   ],
 };
@@ -95,18 +105,21 @@ export const OPTIONS_CONTEXT_DISCOVERY: IOptionsContext = {
       label: 'Remote Scan Interval (ms)',
       valuePath: ['controller', 'interval_ms_remote_scan'],
       description: 'How often the remote server is scanned for new files',
+      requiresRestart: true,
     },
     {
       type: OptionType.Text,
       label: 'Local Scan Interval (ms)',
       valuePath: ['controller', 'interval_ms_local_scan'],
       description: 'How often the local directory is scanned',
+      requiresRestart: true,
     },
     {
       type: OptionType.Text,
       label: 'Downloading Scan Interval (ms)',
       valuePath: ['controller', 'interval_ms_downloading_scan'],
       description: 'How often the downloading information is updated',
+      requiresRestart: true,
     },
   ],
 };
@@ -180,12 +193,14 @@ export const OPTIONS_CONTEXT_OTHER: IOptionsContext = {
       label: 'Web GUI Port',
       valuePath: ['web', 'port'],
       description: null,
+      requiresRestart: true,
     },
     {
       type: OptionType.Password,
       label: 'API Key',
       valuePath: ['web', 'api_key'],
       description: 'Require this key for API access. Leave empty to disable.',
+      requiresRestart: true,
     },
   ],
 };
@@ -199,18 +214,21 @@ export const OPTIONS_CONTEXT_AUTOQUEUE: IOptionsContext = {
       label: 'Enable AutoQueue',
       valuePath: ['autoqueue', 'enabled'],
       description: null,
+      requiresRestart: true,
     },
     {
       type: OptionType.Checkbox,
       label: 'Restrict to patterns',
       valuePath: ['autoqueue', 'patterns_only'],
       description: 'Only autoqueue files that match a pattern',
+      requiresRestart: true,
     },
     {
       type: OptionType.Checkbox,
       label: 'Enable auto extraction',
       valuePath: ['autoqueue', 'auto_extract'],
       description: 'Automatically extract files',
+      requiresRestart: true,
     },
     {
       type: OptionType.Checkbox,
@@ -231,12 +249,14 @@ export const OPTIONS_CONTEXT_STAGING: IOptionsContext = {
       label: 'Use staging directory',
       valuePath: ['controller', 'use_staging'],
       description: 'Download files to a staging directory before moving to the final location',
+      requiresRestart: true,
     },
     {
       type: OptionType.Text,
       label: 'Staging Path',
       valuePath: ['controller', 'staging_path'],
       description: 'Temporary directory where files are downloaded before being moved',
+      requiresRestart: true,
     },
   ],
 };
@@ -315,6 +335,7 @@ export const OPTIONS_CONTEXT_LOGGING: IOptionsContext = {
       valuePath: ['general', 'log_level'],
       description: 'Controls which log messages are recorded',
       choices: ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+      requiresRestart: true,
     },
     {
       type: OptionType.Checkbox,
@@ -328,6 +349,7 @@ export const OPTIONS_CONTEXT_LOGGING: IOptionsContext = {
       valuePath: ['logging', 'log_format'],
       description: 'Log output format',
       choices: ['standard', 'json'],
+      requiresRestart: true,
     },
   ],
 };
@@ -433,6 +455,7 @@ export const OPTIONS_CONTEXT_EXTRACT: IOptionsContext = {
       label: 'Extract archives in the downloads directory',
       valuePath: ['controller', 'use_local_path_as_extract_path'],
       description: null,
+      requiresRestart: true,
     },
     {
       type: OptionType.Text,
@@ -440,6 +463,7 @@ export const OPTIONS_CONTEXT_EXTRACT: IOptionsContext = {
       valuePath: ['controller', 'extract_path'],
       description:
         'When option above is disabled, extract archives to this directory',
+      requiresRestart: true,
     },
   ],
 };

--- a/src/angular/src/app/pages/settings/settings-page.component.html
+++ b/src/angular/src/app/pages/settings/settings-page.component.html
@@ -55,7 +55,7 @@
                   [description]="option.description"
                   [choices]="option.choices || []"
                   [value]="getOptionValue(config$ | async, option.valuePath)"
-                  (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event)">
+                  (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event, option.requiresRestart)">
                 </app-option>
               </div>
             }
@@ -83,7 +83,7 @@
                 [disabled]="!!option.disabled"
                 [choices]="option.choices || []"
                 [value]="getOptionValue(config$ | async, option.valuePath)"
-                (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event)">
+                (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event, option.requiresRestart)">
               </app-option>
             </div>
           }
@@ -152,7 +152,7 @@
             [disabled]="!!option.disabled"
             [choices]="option.choices || []"
             [value]="getOptionValue(config$ | async, option.valuePath)"
-            (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event)">
+            (changeEvent)="onSetConfig(option.valuePath[0], option.valuePath[1], $event, option.requiresRestart)">
           </app-option>
         </div>
       }

--- a/src/angular/src/app/pages/settings/settings-page.component.ts
+++ b/src/angular/src/app/pages/settings/settings-page.component.ts
@@ -164,7 +164,7 @@ export class SettingsPageComponent implements OnInit {
     return section[valuePath[1]] ?? null;
   }
 
-  onSetConfig(section: string, option: string, value: OptionValue): void {
+  onSetConfig(section: string, option: string, value: OptionValue, requiresRestart?: boolean): void {
     this.configService.set(section, option, value).subscribe({
       next: (reaction) => {
         const notifKey = section + '.' + option;
@@ -176,7 +176,9 @@ export class SettingsPageComponent implements OnInit {
             this.badValueNotifs.delete(notifKey);
           }
 
-          this.notifService.show(this.configRestartNotif);
+          if (requiresRestart) {
+            this.notifService.show(this.configRestartNotif);
+          }
         } else {
           const notif = createNotification(
             NotificationLevel.DANGER,

--- a/src/python/common/context.py
+++ b/src/python/common/context.py
@@ -49,6 +49,11 @@ class Context:
         status: Status,
         path_pairs_config: PathPairsConfig | None = None,
         integrations_config: IntegrationsConfig | None = None,
+        config_path: str | None = None,
+        path_pairs_path: str | None = None,
+        integrations_path: str | None = None,
+        auto_queue_persist_path: str | None = None,
+        controller_persist_path: str | None = None,
     ):
         """
         Primary constructor to construct the top-level context
@@ -61,6 +66,13 @@ class Context:
         self.status = status
         self.path_pairs_config = path_pairs_config or PathPairsConfig()
         self.integrations_config = integrations_config or IntegrationsConfig()
+
+        # File paths for flush-on-write
+        self.config_path = config_path
+        self.path_pairs_path = path_pairs_path
+        self.integrations_path = integrations_path
+        self.auto_queue_persist_path = auto_queue_persist_path
+        self.controller_persist_path = controller_persist_path
 
     def create_child_context(self, context_name: str) -> "Context":
         child_context = copy.copy(self)

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from enum import Enum
@@ -145,6 +146,9 @@ class Controller:
 
         # Seed each builder with filtered persist state
         self.__updater.sync_persist_to_all_builders()
+
+        # Flag for hot-reloading LFTP tuning settings (set from REST thread)
+        self.__needs_lftp_reconfigure = threading.Event()
 
         self.__started = False
 
@@ -314,6 +318,13 @@ class Controller:
         self.__mp_logger.start()
         self.__started = True
 
+    def request_lftp_reconfigure(self) -> None:
+        """Signal that LFTP tuning settings have changed and should be reapplied.
+
+        Thread-safe: called from the REST handler thread.
+        """
+        self.__needs_lftp_reconfigure.set()
+
     def process(self):
         """
         Advance the controller state
@@ -322,6 +333,11 @@ class Controller:
         """
         if not self.__started:
             raise ControllerError("Cannot process, controller is not started")
+        if self.__needs_lftp_reconfigure.is_set():
+            self.__needs_lftp_reconfigure.clear()
+            for pc in self.__pair_contexts:
+                self._configure_lftp(pc.lftp)
+            self.logger.info("Reapplied LFTP tuning settings")
         self.__pipeline.propagate_exceptions()
         self.__pipeline.cleanup()
         self.__pipeline.step()

--- a/src/python/seedsync.py
+++ b/src/python/seedsync.py
@@ -148,6 +148,9 @@ class Seedsync:
             status=status,
             path_pairs_config=path_pairs_config,
             integrations_config=integrations_config,
+            config_path=self.config_path,
+            path_pairs_path=self.path_pairs_path,
+            integrations_path=self.integrations_path,
         )
 
         # Register the signal handlers
@@ -163,6 +166,10 @@ class Seedsync:
 
         self.auto_queue_persist_path = os.path.join(args.config_dir, Seedsync.__FILE_AUTO_QUEUE_PERSIST)
         self.auto_queue_persist = self._load_persist(AutoQueuePersist, self.auto_queue_persist_path)
+
+        # Set persist paths on context (these are determined after context creation)
+        self.context.controller_persist_path = self.controller_persist_path
+        self.context.auto_queue_persist_path = self.auto_queue_persist_path
 
     def run(self):
         self.context.logger.info("Starting SeedSync")

--- a/src/python/tests/integration/test_web/test_web_app.py
+++ b/src/python/tests/integration/test_web/test_web_app.py
@@ -1,7 +1,10 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
 import logging
+import os
+import shutil
 import sys
+import tempfile
 import unittest
 from unittest.mock import MagicMock
 
@@ -48,6 +51,14 @@ class BaseTestWebApp(unittest.TestCase):
         # Real auto-queue persist
         self.auto_queue_persist = AutoQueuePersist()
 
+        # Temp directory for flush-on-write file paths
+        self._test_tmpdir = tempfile.mkdtemp()
+        self.context.config_path = os.path.join(self._test_tmpdir, "settings.cfg")
+        self.context.path_pairs_path = os.path.join(self._test_tmpdir, "path_pairs.json")
+        self.context.integrations_path = os.path.join(self._test_tmpdir, "integrations.json")
+        self.context.auto_queue_persist_path = os.path.join(self._test_tmpdir, "autoqueue.persist")
+        self.context.controller_persist_path = os.path.join(self._test_tmpdir, "controller.persist")
+
         # Capture the model listener
         def capture_listener(listener):
             self.model_listener = listener
@@ -62,6 +73,10 @@ class BaseTestWebApp(unittest.TestCase):
         self.web_app_builder = WebAppBuilder(self.context, self.controller, self.auto_queue_persist)
         self.web_app = self.web_app_builder.build()
         self.test_app = TestApp(self.web_app)
+
+    @overrides(unittest.TestCase)
+    def tearDown(self):
+        shutil.rmtree(self._test_tmpdir, ignore_errors=True)
 
 
 class TestWebApp(BaseTestWebApp):

--- a/src/python/web/handler/auto_queue.py
+++ b/src/python/web/handler/auto_queue.py
@@ -14,8 +14,9 @@ from ..web_app import IHandler, WebApp
 class AutoQueueHandler(IHandler):
     _NOSNIFF_HEADERS = {"X-Content-Type-Options": "nosniff"}
 
-    def __init__(self, auto_queue_persist: AutoQueuePersist):
+    def __init__(self, auto_queue_persist: AutoQueuePersist, persist_path: str):
         self.__auto_queue_persist = auto_queue_persist
+        self.__persist_path = persist_path
 
     @overrides(IHandler)
     def add_routes(self, web_app: WebApp):
@@ -44,6 +45,7 @@ class AutoQueueHandler(IHandler):
             )
         try:
             self.__auto_queue_persist.add_pattern(aqp)
+            self.__auto_queue_persist.to_file(self.__persist_path)
             return HTTPResponse(
                 body=f"Added auto-queue pattern '{pattern}'.",
                 content_type="text/plain",
@@ -71,6 +73,7 @@ class AutoQueueHandler(IHandler):
                 headers=self._NOSNIFF_HEADERS,
             )
         self.__auto_queue_persist.remove_pattern(aqp)
+        self.__auto_queue_persist.to_file(self.__persist_path)
         return HTTPResponse(
             body=f"Removed auto-queue pattern '{pattern}'.",
             content_type="text/plain",

--- a/src/python/web/handler/config.py
+++ b/src/python/web/handler/config.py
@@ -1,5 +1,6 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
+from collections.abc import Callable
 from urllib.parse import unquote
 
 from bottle import HTTPResponse
@@ -9,11 +10,37 @@ from common import Config, ConfigError, overrides
 from ..serialize import SerializeConfig
 from ..web_app import IHandler, WebApp
 
+# LFTP tuning keys that can be hot-reloaded without restart
+_LFTP_TUNING_KEYS = frozenset(
+    {
+        "num_max_parallel_downloads",
+        "num_max_parallel_files_per_download",
+        "num_max_connections_per_root_file",
+        "num_max_connections_per_dir_file",
+        "num_max_total_connections",
+        "use_temp_file",
+        "net_limit_rate",
+        "net_socket_buffer",
+        "pget_min_chunk_size",
+        "mirror_parallel_directories",
+        "net_timeout",
+        "net_max_retries",
+        "net_reconnect_interval_base",
+        "net_reconnect_interval_multiplier",
+    }
+)
+
 
 class ConfigHandler(IHandler):
-    def __init__(self, config: Config, config_path: str):
+    def __init__(
+        self,
+        config: Config,
+        config_path: str,
+        on_lftp_config_change: Callable[[], None] | None = None,
+    ):
         self.__config = config
         self.__config_path = config_path
+        self.__on_lftp_config_change = on_lftp_config_change
 
     @overrides(IHandler)
     def add_routes(self, web_app: WebApp):
@@ -44,6 +71,8 @@ class ConfigHandler(IHandler):
         try:
             inner_config.set_property(key, value)
             self.__config.to_file(self.__config_path)
+            if section == "lftp" and key in _LFTP_TUNING_KEYS and self.__on_lftp_config_change:
+                self.__on_lftp_config_change()
             if Config.is_sensitive(section, key):
                 return HTTPResponse(body=f"{section}.{key} updated")
             return HTTPResponse(body=f"{section}.{key} set to {value}")

--- a/src/python/web/handler/config.py
+++ b/src/python/web/handler/config.py
@@ -11,8 +11,9 @@ from ..web_app import IHandler, WebApp
 
 
 class ConfigHandler(IHandler):
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, config_path: str):
         self.__config = config
+        self.__config_path = config_path
 
     @overrides(IHandler)
     def add_routes(self, web_app: WebApp):
@@ -42,6 +43,7 @@ class ConfigHandler(IHandler):
             return HTTPResponse(body="Cannot set sensitive field to redacted value", status=400)
         try:
             inner_config.set_property(key, value)
+            self.__config.to_file(self.__config_path)
             if Config.is_sensitive(section, key):
                 return HTTPResponse(body=f"{section}.{key} updated")
             return HTTPResponse(body=f"{section}.{key} set to {value}")

--- a/src/python/web/handler/config.py
+++ b/src/python/web/handler/config.py
@@ -10,23 +10,26 @@ from common import Config, ConfigError, overrides
 from ..serialize import SerializeConfig
 from ..web_app import IHandler, WebApp
 
-# LFTP tuning keys that can be hot-reloaded without restart
-_LFTP_TUNING_KEYS = frozenset(
+# (section, key) pairs for settings that can be hot-reloaded into the
+# running LFTP process without a full restart.
+_LFTP_TUNING_KEYS: frozenset[tuple[str, str]] = frozenset(
     {
-        "num_max_parallel_downloads",
-        "num_max_parallel_files_per_download",
-        "num_max_connections_per_root_file",
-        "num_max_connections_per_dir_file",
-        "num_max_total_connections",
-        "use_temp_file",
-        "net_limit_rate",
-        "net_socket_buffer",
-        "pget_min_chunk_size",
-        "mirror_parallel_directories",
-        "net_timeout",
-        "net_max_retries",
-        "net_reconnect_interval_base",
-        "net_reconnect_interval_multiplier",
+        ("lftp", "num_max_parallel_downloads"),
+        ("lftp", "num_max_parallel_files_per_download"),
+        ("lftp", "num_max_connections_per_root_file"),
+        ("lftp", "num_max_connections_per_dir_file"),
+        ("lftp", "num_max_total_connections"),
+        ("lftp", "use_temp_file"),
+        ("lftp", "net_limit_rate"),
+        ("lftp", "net_socket_buffer"),
+        ("lftp", "pget_min_chunk_size"),
+        ("lftp", "mirror_parallel_directories"),
+        ("lftp", "net_timeout"),
+        ("lftp", "net_max_retries"),
+        ("lftp", "net_reconnect_interval_base"),
+        ("lftp", "net_reconnect_interval_multiplier"),
+        ("general", "verbose"),
+        ("validate", "xfer_verify"),
     }
 )
 
@@ -71,7 +74,7 @@ class ConfigHandler(IHandler):
         try:
             inner_config.set_property(key, value)
             self.__config.to_file(self.__config_path)
-            if section == "lftp" and key in _LFTP_TUNING_KEYS and self.__on_lftp_config_change:
+            if (section, key) in _LFTP_TUNING_KEYS and self.__on_lftp_config_change:
                 self.__on_lftp_config_change()
             if Config.is_sensitive(section, key):
                 return HTTPResponse(body=f"{section}.{key} updated")

--- a/src/python/web/handler/config.py
+++ b/src/python/web/handler/config.py
@@ -30,6 +30,7 @@ _LFTP_TUNING_KEYS: frozenset[tuple[str, str]] = frozenset(
         ("lftp", "net_reconnect_interval_multiplier"),
         ("general", "verbose"),
         ("validate", "xfer_verify"),
+        ("validate", "algorithm"),
     }
 )
 

--- a/src/python/web/handler/integrations.py
+++ b/src/python/web/handler/integrations.py
@@ -17,9 +17,17 @@ from ..web_app import IHandler, WebApp
 class IntegrationsHandler(IHandler):
     """REST endpoints for managing *arr (Sonarr/Radarr) instances."""
 
-    def __init__(self, integrations_config: IntegrationsConfig, path_pairs_config: PathPairsConfig):
+    def __init__(
+        self,
+        integrations_config: IntegrationsConfig,
+        path_pairs_config: PathPairsConfig,
+        integrations_path: str,
+        path_pairs_path: str,
+    ):
         self.__config = integrations_config
         self.__path_pairs_config = path_pairs_config
+        self.__integrations_path = integrations_path
+        self.__path_pairs_path = path_pairs_path
         self._logger = logging.getLogger(self.__class__.__name__)
 
     @overrides(IHandler)
@@ -49,6 +57,7 @@ class IntegrationsHandler(IHandler):
             self.__config.add_instance(instance)
         except ValueError as e:
             return HTTPResponse(body=str(e), status=409)
+        self.__config.to_file(self.__integrations_path)
         return HTTPResponse(
             body=json.dumps(self._redact(instance.to_dict())),
             status=201,
@@ -90,6 +99,7 @@ class IntegrationsHandler(IHandler):
             if "not found" in msg:
                 return HTTPResponse(body="Integration not found", status=404)
             return HTTPResponse(body=msg, status=400)
+        self.__config.to_file(self.__integrations_path)
         return HTTPResponse(
             body=json.dumps(self._redact(updated.to_dict())),
             headers={"Content-Type": "application/json"},
@@ -102,6 +112,8 @@ class IntegrationsHandler(IHandler):
             return HTTPResponse(body="Integration not found", status=404)
         # Detach from any path pair that referenced it so we don't leave dangling pointers.
         self.__path_pairs_config.detach_arr_target(instance_id)
+        self.__config.to_file(self.__integrations_path)
+        self.__path_pairs_config.to_file(self.__path_pairs_path)
         return HTTPResponse(status=204)
 
     def __handle_test(self, instance_id: str):

--- a/src/python/web/handler/path_pairs.py
+++ b/src/python/web/handler/path_pairs.py
@@ -11,9 +11,12 @@ from ..web_app import IHandler, WebApp
 
 
 class PathPairsHandler(IHandler):
-    def __init__(self, path_pairs_config: PathPairsConfig, integrations_config: IntegrationsConfig):
+    def __init__(
+        self, path_pairs_config: PathPairsConfig, integrations_config: IntegrationsConfig, path_pairs_path: str
+    ):
         self.__config = path_pairs_config
         self.__integrations_config = integrations_config
+        self.__path_pairs_path = path_pairs_path
 
     @overrides(IHandler)
     def add_routes(self, web_app: WebApp):
@@ -111,6 +114,7 @@ class PathPairsHandler(IHandler):
             if "name" in str(e) and "already exists" in str(e):
                 return HTTPResponse(body=str(e), status=409)
             raise
+        self.__config.to_file(self.__path_pairs_path)
         return HTTPResponse(body=json.dumps(pair.to_dict()), status=201, headers={"Content-Type": "application/json"})
 
     def __handle_update(self, pair_id: str):
@@ -150,6 +154,7 @@ class PathPairsHandler(IHandler):
             if "name" in str(e) and "already exists" in str(e):
                 return HTTPResponse(body=str(e), status=409)
             return HTTPResponse(body="Path pair not found", status=404)
+        self.__config.to_file(self.__path_pairs_path)
         return HTTPResponse(body=json.dumps(updated.to_dict()), headers={"Content-Type": "application/json"})
 
     def __handle_delete(self, pair_id: str):
@@ -157,4 +162,5 @@ class PathPairsHandler(IHandler):
             self.__config.remove_pair(pair_id)
         except ValueError:
             return HTTPResponse(body="Path pair not found", status=404)
+        self.__config.to_file(self.__path_pairs_path)
         return HTTPResponse(status=204)

--- a/src/python/web/web_app_builder.py
+++ b/src/python/web/web_app_builder.py
@@ -32,7 +32,9 @@ class WebAppBuilder:
 
         self.controller_handler = ControllerHandler(controller)
         self.server_handler = ServerHandler(context)
-        self.config_handler = ConfigHandler(context.config, context.config_path)
+        self.config_handler = ConfigHandler(
+            context.config, context.config_path, on_lftp_config_change=controller.request_lftp_reconfigure
+        )
         self.auto_queue_handler = AutoQueueHandler(auto_queue_persist, context.auto_queue_persist_path)
         self.status_handler = StatusHandler(context.status)
         self.logs_handler = LogsHandler(logdir=context.args.logdir, service_name=Constants.SERVICE_NAME)

--- a/src/python/web/web_app_builder.py
+++ b/src/python/web/web_app_builder.py
@@ -32,12 +32,16 @@ class WebAppBuilder:
 
         self.controller_handler = ControllerHandler(controller)
         self.server_handler = ServerHandler(context)
-        self.config_handler = ConfigHandler(context.config)
-        self.auto_queue_handler = AutoQueueHandler(auto_queue_persist)
+        self.config_handler = ConfigHandler(context.config, context.config_path)
+        self.auto_queue_handler = AutoQueueHandler(auto_queue_persist, context.auto_queue_persist_path)
         self.status_handler = StatusHandler(context.status)
         self.logs_handler = LogsHandler(logdir=context.args.logdir, service_name=Constants.SERVICE_NAME)
-        self.path_pairs_handler = PathPairsHandler(context.path_pairs_config, context.integrations_config)
-        self.integrations_handler = IntegrationsHandler(context.integrations_config, context.path_pairs_config)
+        self.path_pairs_handler = PathPairsHandler(
+            context.path_pairs_config, context.integrations_config, context.path_pairs_path
+        )
+        self.integrations_handler = IntegrationsHandler(
+            context.integrations_config, context.path_pairs_config, context.integrations_path, context.path_pairs_path
+        )
         self.notifications_handler = NotificationsHandler(context.config)
 
     def build(self) -> WebApp:

--- a/src/python/web/web_app_builder.py
+++ b/src/python/web/web_app_builder.py
@@ -30,10 +30,14 @@ class WebAppBuilder:
         self.__context = context
         self.__controller = controller
 
-        assert context.config_path is not None
-        assert context.path_pairs_path is not None
-        assert context.integrations_path is not None
-        assert context.auto_queue_persist_path is not None
+        if context.config_path is None:
+            raise RuntimeError("Context.config_path must be set before building WebApp")
+        if context.path_pairs_path is None:
+            raise RuntimeError("Context.path_pairs_path must be set before building WebApp")
+        if context.integrations_path is None:
+            raise RuntimeError("Context.integrations_path must be set before building WebApp")
+        if context.auto_queue_persist_path is None:
+            raise RuntimeError("Context.auto_queue_persist_path must be set before building WebApp")
 
         self.controller_handler = ControllerHandler(controller)
         self.server_handler = ServerHandler(context)

--- a/src/python/web/web_app_builder.py
+++ b/src/python/web/web_app_builder.py
@@ -30,6 +30,11 @@ class WebAppBuilder:
         self.__context = context
         self.__controller = controller
 
+        assert context.config_path is not None
+        assert context.path_pairs_path is not None
+        assert context.integrations_path is not None
+        assert context.auto_queue_persist_path is not None
+
         self.controller_handler = ControllerHandler(controller)
         self.server_handler = ServerHandler(context)
         self.config_handler = ConfigHandler(


### PR DESCRIPTION
## Summary

- Configs are now flushed to disk immediately after every REST mutation, eliminating the 30-second crash window
- The UI only shows "Restart required" for settings that truly need it — notification, validation, exclude pattern, and LFTP tuning changes take effect immediately
- LFTP tuning parameters (rate limit, connections, timeouts, etc.) are hot-reloaded without restart

Closes #427

## Phase 1: Flush-on-Write
- Added file paths (`config_path`, `path_pairs_path`, etc.) to `Context`
- All REST handlers (`ConfigHandler`, `PathPairsHandler`, `IntegrationsHandler`, `AutoQueueHandler`) now call `to_file()` immediately after successful mutations
- Integrations DELETE flushes both files (integrations first, then path_pairs)
- 30-second periodic timer kept as safety net for `ControllerPersist`

## Phase 2: Differentiated Restart Notification
- Added `requiresRestart?: boolean` to `IOption` interface
- Marked restart-required settings: server connection, scanner intervals, staging/extraction paths, autoqueue global flags, logging, web port
- Left unmarked: notifications, validation, exclude patterns, LFTP tuning (hot-reloadable)
- `onSetConfig` only shows restart banner when `requiresRestart` is truthy

## Phase 3: LFTP Hot-Reload
- Added `threading.Event` flag `__needs_lftp_reconfigure` to `Controller`
- `request_lftp_reconfigure()` sets the flag from the REST thread
- `process()` checks/clears the flag and re-calls `_configure_lftp()` on all pair contexts
- `ConfigHandler` triggers the callback when LFTP tuning keys change (14 keys + verbose + xfer_verify)

## Test plan

- [x] `PYTHONPATH=. pytest tests/unittests/ tests/integration/test_web/` — 790 passed
- [x] `npx ng lint` — clean
- [x] `npx ng test` — 323 passed
- [x] `ruff check . && ruff format --check .` — clean
- [ ] Smoke: change a notification setting → no restart banner
- [ ] Smoke: change remote_address → restart banner appears
- [ ] Smoke: change rate limit → LFTP applies new value without restart (check logs)
- [ ] Smoke: change a setting, kill process, restart → setting persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional "requires restart" indicator for select settings; restart notices now honor this flag.
  * Support for requesting LFTP tuning updates without a full application restart.

* **Improvements**
  * Configuration mutations (core config, auto-queue, integrations, path pairs) are persisted to disk immediately.
  * Server wiring updated so persistence paths and hot-reload callbacks are applied at runtime.

* **Tests**
  * Tests isolate file-backed persistence using per-test temporary directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->