### PR TITLE
Rewrite test-image Dockerfile as Alpine with Python 3.13

### DIFF
--- a/src/docker/build/test-image/Dockerfile
+++ b/src/docker/build/test-image/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.12-slim-bookworm
-RUN apt-get update && apt-get install -y --no-install-recommends lftp openssh-client \
-    && rm -rf /var/lib/apt/lists/*
+FROM python:3.13-alpine
+
+RUN apk add --no-cache lftp openssh-client
 
 COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
 
@@ -9,8 +9,10 @@ RUN uv pip install --system --no-cache --strict \
         -r /tmp/pyproject.toml --group test \
     && rm -f /usr/local/bin/uv \
     && rm /tmp/pyproject.toml /tmp/uv.lock
-RUN groupadd -r testuser && useradd -r -g testuser -d /app/python -s /sbin/nologin testuser \
+
+RUN addgroup -S testuser && adduser -S -G testuser -h /app/python -s /sbin/nologin testuser \
     && mkdir -p /app/python && chown testuser:testuser /app/python
+
 WORKDIR /app/python
 ENV PYTHONPATH=/app/python
 USER testuser


### PR DESCRIPTION
## Summary
- Switch test-image from `python:3.12-slim-bookworm` (Debian) to `python:3.13-alpine`
- Aligns test image with production Alpine base — no more OS divergence between test and prod
- Replace `apt-get` with `apk add --no-cache`
- Replace `groupadd`/`useradd` with Alpine `addgroup`/`adduser`
- Same contract preserved: lftp, openssh-client, uv deps, non-root testuser, `/app/python` workdir

## Test plan
- [ ] `make test-image` builds successfully
- [ ] `make test` runs unit tests in the Alpine container
- [ ] CI passes (CI does not use this Dockerfile — it runs Python tests natively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)