### PR TITLE
Collapse Dockerfile to 2 stages with Python 3.13-alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -125,7 +125,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7

--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -12,62 +12,52 @@ COPY src/angular/ ./
 RUN npx ng build --configuration=production --output-path /build
 
 # ==============================================================================
-# Stage 2: Prepare Python runtime (install deps)
+# Stage 2: Runtime Image
 # ==============================================================================
-FROM python:3.12-alpine AS python-deps
+FROM python:3.13-alpine AS runtime
 
+LABEL maintainer="nitrobass24" \
+      description="SeedSync - Seedbox file synchronization tool"
+
+# Install Python dependencies with uv, then clean up
 COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
 
 COPY src/python/pyproject.toml src/python/uv.lock /tmp/
 RUN uv pip install --system --no-cache --strict \
         -r /tmp/pyproject.toml \
     && rm -f /usr/local/bin/uv \
-    && pip uninstall -y pip setuptools \
+    && rm -rf /usr/local/lib/python3.13/site-packages/pip* \
+              /usr/local/lib/python3.13/site-packages/setuptools* \
+              /usr/local/bin/pip* \
+              /usr/local/bin/wheel* \
     && rm -rf /root/.cache /tmp/pyproject.toml /tmp/uv.lock \
     && rm -rf \
-        /usr/local/lib/python3.12/ensurepip \
-        /usr/local/lib/python3.12/idlelib \
-        /usr/local/lib/python3.12/turtle.py \
-        /usr/local/lib/python3.12/turtledemo \
-        /usr/local/lib/python3.12/tkinter \
-        /usr/local/lib/python3.12/test \
-        /usr/local/lib/python3.12/unittest \
-        /usr/local/lib/python3.12/pydoc.py \
-        /usr/local/lib/python3.12/pydoc_data \
-        /usr/local/lib/python3.12/doctest.py \
-        /usr/local/lib/python3.12/lib2to3 \
-        /usr/local/lib/python3.12/distutils \
-        /usr/local/lib/python3.12/lib-dynload/_test*.so \
-        /usr/local/lib/python3.12/lib-dynload/_codecs_jp*.so \
-        /usr/local/lib/python3.12/lib-dynload/_codecs_kr*.so \
-        /usr/local/lib/python3.12/lib-dynload/_codecs_hk*.so \
-        /usr/local/lib/python3.12/lib-dynload/_codecs_cn*.so \
-        /usr/local/lib/python3.12/lib-dynload/_codecs_tw*.so \
-        /usr/local/lib/python3.12/lib-dynload/_codecs_iso*.so \
-        /usr/local/lib/python3.12/lib-dynload/_curses*.so \
-        /usr/local/lib/python3.12/lib-dynload/_sqlite3*.so \
-        /usr/local/lib/python3.12/lib-dynload/_lzma*.so \
-        /usr/local/lib/python3.12/lib-dynload/_bz2*.so \
-        /usr/local/lib/python3.12/lib-dynload/_crypt*.so \
-        /usr/local/lib/python3.12/lib-dynload/_dbm*.so \
-        /usr/local/lib/python3.12/lib-dynload/_gdbm*.so \
-        /usr/local/lib/python3.12/lib-dynload/audioop*.so \
-        /usr/local/lib/python3.12/lib-dynload/ossaudiodev*.so \
-        /usr/local/lib/python3.12/lib-dynload/nis*.so \
-        /usr/local/lib/python3.12/lib-dynload/readline*.so \
-        /usr/local/lib/python3.12/lib-dynload/_ctypes_test*.so \
-    && find /usr/local/lib/python3.12 -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
-
-# ==============================================================================
-# Stage 3: Final Runtime Image
-# ==============================================================================
-FROM alpine:3.21 AS runtime
-
-LABEL maintainer="nitrobass24" \
-      description="SeedSync - Seedbox file synchronization tool"
-
-# Copy stripped Python runtime from python-deps stage
-COPY --from=python-deps /usr/local/ /usr/local/
+        /usr/local/lib/python3.13/ensurepip \
+        /usr/local/lib/python3.13/idlelib \
+        /usr/local/lib/python3.13/turtle.py \
+        /usr/local/lib/python3.13/turtledemo \
+        /usr/local/lib/python3.13/tkinter \
+        /usr/local/lib/python3.13/test \
+        /usr/local/lib/python3.13/unittest \
+        /usr/local/lib/python3.13/pydoc.py \
+        /usr/local/lib/python3.13/pydoc_data \
+        /usr/local/lib/python3.13/doctest.py \
+        /usr/local/lib/python3.13/lib-dynload/_test*.so \
+        /usr/local/lib/python3.13/lib-dynload/_codecs_jp*.so \
+        /usr/local/lib/python3.13/lib-dynload/_codecs_kr*.so \
+        /usr/local/lib/python3.13/lib-dynload/_codecs_hk*.so \
+        /usr/local/lib/python3.13/lib-dynload/_codecs_cn*.so \
+        /usr/local/lib/python3.13/lib-dynload/_codecs_tw*.so \
+        /usr/local/lib/python3.13/lib-dynload/_codecs_iso*.so \
+        /usr/local/lib/python3.13/lib-dynload/_curses*.so \
+        /usr/local/lib/python3.13/lib-dynload/_sqlite3*.so \
+        /usr/local/lib/python3.13/lib-dynload/_lzma*.so \
+        /usr/local/lib/python3.13/lib-dynload/_bz2*.so \
+        /usr/local/lib/python3.13/lib-dynload/_dbm*.so \
+        /usr/local/lib/python3.13/lib-dynload/_gdbm*.so \
+        /usr/local/lib/python3.13/lib-dynload/readline*.so \
+        /usr/local/lib/python3.13/lib-dynload/_ctypes_test*.so \
+    && find /usr/local/lib/python3.13 -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 # Copy pre-built 7zz binary with RAR codec support (ghcr.io/nitrobass24/docker-7zip)
 COPY --from=ghcr.io/nitrobass24/docker-7zip:alpine /7zz /usr/bin/7zz


### PR DESCRIPTION
## Summary
- Merge python-deps and runtime stages into a single `python:3.13-alpine` stage (3 stages → 2)
- Eliminates redundant `alpine:3.21` base and `COPY --from=python-deps /usr/local/ /usr/local/` step
- Upgrade Python 3.12 → 3.13 (active bugfix support)
- Remove 6 dead stdlib cleanup entries for modules removed from CPython (distutils, lib2to3, audioop, ossaudiodev, nis, _crypt)
- Replace `pip uninstall -y pip setuptools` with direct `rm -rf` (more reliable)
- Update CI `python-version` from `"3.12"` to `"3.13"` across python-lint, python-typecheck, and python-test jobs

## Test plan
- [ ] CI passes — all jobs (lint, typecheck, unit tests, Docker build + E2E)
- [ ] `make build` builds successfully
- [ ] `make run` — container serves on port 8800
- [ ] `make size` — image size same or smaller

🤖 Generated with [Claude Code](https://claude.com/claude-code)