### PR TITLE
Use RUN --mount for uv to cut image size from 114 MB to 64 MB

### DIFF
--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -90,7 +90,13 @@ RUN apk add --no-cache \
         openssh-client \
         ca-certificates \
         setpriv \
-        libstdc++
+        libstdc++ \
+    && rm -rf /sbin/apk /etc/apk /usr/share/apk /lib/apk /var/cache/apk \
+              /lib/libapk.so* /usr/bin/scanelf \
+              /usr/bin/ssh-keyscan /usr/bin/ssh-add /usr/bin/ssh-agent \
+              /usr/bin/ssh-pkcs11-helper /usr/bin/ssh-copy-id \
+              /usr/bin/findssl.sh /usr/bin/c_rehash \
+              /usr/bin/iconv /usr/bin/getconf /usr/bin/ssl_client
 
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \

--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -19,13 +19,12 @@ FROM python:3.13-alpine AS runtime
 LABEL maintainer="nitrobass24" \
       description="SeedSync - Seedbox file synchronization tool"
 
-# Install Python dependencies with uv, then clean up
-COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
-
+# Install Python dependencies with uv (mounted, never committed to a layer),
+# then strip pip/setuptools/stdlib modules not needed at runtime.
 COPY src/python/pyproject.toml src/python/uv.lock /tmp/
-RUN uv pip install --system --no-cache --strict \
+RUN --mount=from=ghcr.io/astral-sh/uv:0.11,source=/uv,target=/tmp/uv \
+    /tmp/uv pip install --system --no-cache --strict \
         -r /tmp/pyproject.toml \
-    && rm -f /usr/local/bin/uv \
     && rm -rf /usr/local/lib/python3.13/site-packages/pip* \
               /usr/local/lib/python3.13/site-packages/setuptools* \
               /usr/local/bin/pip* \

--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -12,15 +12,10 @@ COPY src/angular/ ./
 RUN npx ng build --configuration=production --output-path /build
 
 # ==============================================================================
-# Stage 2: Runtime Image
+# Stage 2: Prepare Python runtime (install deps, strip stdlib)
 # ==============================================================================
-FROM python:3.13-alpine AS runtime
+FROM python:3.13-alpine AS python-deps
 
-LABEL maintainer="nitrobass24" \
-      description="SeedSync - Seedbox file synchronization tool"
-
-# Install Python dependencies with uv (mounted, never committed to a layer),
-# then strip pip/setuptools/stdlib modules not needed at runtime.
 COPY src/python/pyproject.toml src/python/uv.lock /tmp/
 RUN --mount=from=ghcr.io/astral-sh/uv:0.11,source=/uv,target=/tmp/uv \
     /tmp/uv pip install --system --no-cache --strict \
@@ -57,6 +52,17 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.11,source=/uv,target=/tmp/uv \
         /usr/local/lib/python3.13/lib-dynload/readline*.so \
         /usr/local/lib/python3.13/lib-dynload/_ctypes_test*.so \
     && find /usr/local/lib/python3.13 -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+
+# ==============================================================================
+# Stage 3: Final Runtime Image
+# ==============================================================================
+FROM alpine:3.23 AS runtime
+
+LABEL maintainer="nitrobass24" \
+      description="SeedSync - Seedbox file synchronization tool"
+
+# Copy stripped Python runtime from python-deps stage
+COPY --from=python-deps /usr/local/ /usr/local/
 
 # Copy pre-built 7zz binary with RAR codec support (ghcr.io/nitrobass24/docker-7zip)
 COPY --from=ghcr.io/nitrobass24/docker-7zip:alpine /7zz /usr/bin/7zz

--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -96,7 +96,8 @@ RUN apk add --no-cache \
               /usr/bin/ssh-keyscan /usr/bin/ssh-add /usr/bin/ssh-agent \
               /usr/bin/ssh-pkcs11-helper /usr/bin/ssh-copy-id \
               /usr/bin/findssl.sh /usr/bin/c_rehash \
-              /usr/bin/iconv /usr/bin/getconf /usr/bin/ssl_client
+              /usr/bin/iconv /usr/bin/getconf /usr/bin/ssl_client \
+              /etc/ssh/moduli
 
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \

--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -51,6 +51,19 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.11,source=/uv,target=/tmp/uv \
         /usr/local/lib/python3.13/lib-dynload/_gdbm*.so \
         /usr/local/lib/python3.13/lib-dynload/readline*.so \
         /usr/local/lib/python3.13/lib-dynload/_ctypes_test*.so \
+        /usr/local/lib/python3.13/lib-dynload/xx*.so \
+        /usr/local/lib/python3.13/_pyrepl \
+        /usr/local/lib/python3.13/_pydecimal.py \
+        /usr/local/lib/python3.13/config-3.13-* \
+        /usr/local/include \
+    && find /usr/local/lib/python3.13/encodings -name '*.py' \
+        ! -name '__init__.py' ! -name 'aliases.py' \
+        ! -name 'ascii.py' ! -name 'latin_1.py' \
+        ! -name 'utf_8.py' ! -name 'utf_8_sig.py' \
+        ! -name 'utf_16*.py' ! -name 'utf_32*.py' \
+        ! -name 'unicode_escape.py' ! -name 'raw_unicode_escape.py' \
+        ! -name 'charmap.py' ! -name 'idna.py' \
+        -delete \
     && find /usr/local/lib/python3.13 -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 # ==============================================================================

--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -52,8 +52,13 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.11,source=/uv,target=/tmp/uv \
         /usr/local/lib/python3.13/lib-dynload/readline*.so \
         /usr/local/lib/python3.13/lib-dynload/_ctypes_test*.so \
         /usr/local/lib/python3.13/lib-dynload/xx*.so \
+        /usr/local/lib/python3.13/lib-dynload/_tkinter*.so \
+        /usr/local/lib/python3.13/lib-dynload/_xxtestfuzz*.so \
+        /usr/local/lib/python3.13/lib-dynload/_lsprof*.so \
+        /usr/local/lib/python3.13/lib-dynload/_interp*.so \
         /usr/local/lib/python3.13/_pyrepl \
         /usr/local/lib/python3.13/_pydecimal.py \
+        /usr/local/lib/python3.13/venv \
         /usr/local/lib/python3.13/config-3.13-* \
         /usr/local/include \
     && find /usr/local/lib/python3.13/encodings -name '*.py' \
@@ -92,7 +97,7 @@ RUN apk add --no-cache \
         setpriv \
         libstdc++ \
     && rm -rf /sbin/apk /etc/apk /usr/share/apk /lib/apk /var/cache/apk \
-              /lib/libapk.so* /usr/bin/scanelf \
+              /lib/libapk.so* /usr/lib/libapk.so* /usr/bin/scanelf \
               /usr/bin/ssh-keyscan /usr/bin/ssh-add /usr/bin/ssh-agent \
               /usr/bin/ssh-pkcs11-helper /usr/bin/ssh-copy-id \
               /usr/bin/findssl.sh /usr/bin/c_rehash \

--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -107,8 +107,9 @@ ENV LC_ALL=C.UTF-8 \
 # Create directory structure
 RUN mkdir -p /app/python /app/html /config /downloads /staging
 
-# Copy application source
+# Copy application source (remove dev config files not needed at runtime)
 COPY src/python/ /app/python/
+RUN rm -f /app/python/pyproject.toml /app/python/uv.lock
 
 # Copy built artifacts from previous stages
 COPY --from=angular-builder /build/browser /app/html

--- a/src/docker/build/docker-image/Dockerfile.dockerignore
+++ b/src/docker/build/docker-image/Dockerfile.dockerignore
@@ -3,6 +3,8 @@
 **/node_modules
 **/.venv
 **/.ruff_cache
+**/.pytest_cache
+**/pyrightconfig.json
 .git
 .idea
 build

--- a/src/docker/build/docker-image/Dockerfile.dockerignore
+++ b/src/docker/build/docker-image/Dockerfile.dockerignore
@@ -2,6 +2,7 @@
 **/__pycache__
 **/node_modules
 **/.venv
+**/.ruff_cache
 .git
 .idea
 build

--- a/src/docker/build/docker-image/Dockerfile.dockerignore
+++ b/src/docker/build/docker-image/Dockerfile.dockerignore
@@ -11,3 +11,4 @@ build
 src/angular/dist
 src/python/tests
 src/python/build
+src/python/typings

--- a/src/docker/build/test-image/Dockerfile
+++ b/src/docker/build/test-image/Dockerfile
@@ -2,12 +2,10 @@ FROM python:3.13-alpine
 
 RUN apk add --no-cache lftp openssh-client
 
-COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
-
 COPY src/python/pyproject.toml src/python/uv.lock /tmp/
-RUN uv pip install --system --no-cache --strict \
+RUN --mount=from=ghcr.io/astral-sh/uv:0.11,source=/uv,target=/tmp/uv \
+    /tmp/uv pip install --system --no-cache --strict \
         -r /tmp/pyproject.toml --group test \
-    && rm -f /usr/local/bin/uv \
     && rm /tmp/pyproject.toml /tmp/uv.lock
 
 RUN addgroup -S testuser && adduser -S -G testuser -h /app/python -s /sbin/nologin testuser \


### PR DESCRIPTION
## Summary
Three optimizations to fix the size regression from PR #436 and further reduce image size:

1. **Restore 3-stage build** — The 2-stage collapse caused a regression (45 MB → 114 MB) because `rm -rf` in a `RUN` layer can't reclaim space from the base image's Python layer. The intermediate `python-deps` stage ensures `COPY --from` only brings stripped files into the final `alpine:3.23` image.

2. **Use `RUN --mount` for uv** — Mount the uv binary during `RUN` instead of `COPY`-ing it into a layer. The old `COPY` + `rm` pattern left a 49 MB ghost layer even though uv was deleted afterward. Applied to both production and test-image Dockerfiles.

3. **Strip additional Python artifacts** — Remove C headers (2.4 MB), build config (284 KB), REPL enhancements (240 KB), decimal fallback (224 KB), test extension modules (204 KB), and ~100 unused encoding codepages (~1.2 MB).

**Image size: 114 MB → 44.3 MB** (was 45 MB before PR #436)

## Test plan
- [x] `make build` builds successfully
- [x] Image size verified at 44.3 MB
- [x] Container starts and serves on port 8800
- [ ] CI passes (Docker build + E2E tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker runtime image builds to reduce footprint and improve performance through multi-stage configuration and aggressive cleanup of unnecessary runtime components.
  * Improved Docker build cache efficiency by excluding additional cache directories from the build context.
  * Enhanced Docker test environment setup with improved build tool integration for dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->