### PR TITLE
PR 10: E2E — Integrations CRUD

### DIFF
--- a/src/e2e-playwright/tests/integrations.spec.ts
+++ b/src/e2e-playwright/tests/integrations.spec.ts
@@ -1,0 +1,339 @@
+import { test, expect } from "./fixtures";
+import { IntegrationsPage } from "./pages/integrations.page";
+
+test.describe("Integrations CRUD", () => {
+  let integrations: IntegrationsPage;
+
+  // Clean up all integrations before each test for a clean slate
+  test.beforeEach(async ({ page, apiFetch }) => {
+    const res = await apiFetch("/server/integrations");
+    if (res.ok) {
+      const instances = await res.json();
+      for (const inst of instances) {
+        await apiFetch(`/server/integrations/${inst.id}`, {
+          method: "DELETE",
+        });
+      }
+    }
+
+    integrations = new IntegrationsPage(page);
+    await integrations.goto();
+  });
+
+  // Clean up after each test
+  test.afterEach(async ({ apiFetch }) => {
+    const res = await apiFetch("/server/integrations");
+    if (!res.ok) return;
+    const instances = await res.json();
+    for (const inst of instances) {
+      await apiFetch(`/server/integrations/${inst.id}`, {
+        method: "DELETE",
+      });
+    }
+  });
+
+  test("empty state shows 'No integrations' message and add buttons", async () => {
+    await expect(integrations.emptyState).toBeVisible();
+    await expect(integrations.emptyState).toContainText("No integrations");
+    await expect(integrations.addSonarrButton).toBeVisible();
+    await expect(integrations.addRadarrButton).toBeVisible();
+  });
+
+  test("clicking + Sonarr opens add form with Sonarr pre-selected", async () => {
+    await integrations.addSonarrButton.click();
+    await expect(integrations.instanceForm).toBeVisible();
+
+    const kindSelect = integrations.instanceForm.locator("select");
+    await expect(kindSelect).toHaveValue("sonarr");
+  });
+
+  test("clicking + Radarr opens add form with Radarr pre-selected", async () => {
+    await integrations.addRadarrButton.click();
+    await expect(integrations.instanceForm).toBeVisible();
+
+    const kindSelect = integrations.instanceForm.locator("select");
+    await expect(kindSelect).toHaveValue("radarr");
+  });
+
+  test("save with empty name shows validation error", async () => {
+    await integrations.addSonarrButton.click();
+    await integrations.fillForm({
+      url: "http://localhost:8989",
+      apiKey: "test-key",
+    });
+    await integrations.clickSave();
+
+    await expect(integrations.errorMessage).toBeVisible();
+    await expect(integrations.errorMessage).toContainText("Name is required");
+  });
+
+  test("fill and save creates integration visible in list and API", async ({
+    apiFetch,
+  }) => {
+    await integrations.addSonarrButton.click();
+    await integrations.fillForm({
+      name: "E2E Sonarr",
+      url: "http://localhost:8989",
+      apiKey: "test-api-key-123",
+    });
+    await integrations.clickSave();
+
+    // Form should close
+    await expect(integrations.instanceForm).not.toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Instance should appear in the list
+    const row = integrations.getInstanceByName("E2E Sonarr");
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    // Verify via API
+    await expect
+      .poll(
+        async () => {
+          const res = await apiFetch("/server/integrations");
+          if (!res.ok) return undefined;
+          const instances = await res.json();
+          return instances.find(
+            (i: { name: string }) => i.name === "E2E Sonarr"
+          );
+        },
+        { timeout: 5000 }
+      )
+      .toEqual(
+        expect.objectContaining({
+          name: "E2E Sonarr",
+          kind: "sonarr",
+          url: "http://localhost:8989",
+        })
+      );
+  });
+
+  test("edit populates form and save updates the instance", async ({
+    apiFetch,
+  }) => {
+    // Create an integration via API
+    await apiFetch("/server/integrations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Edit Me",
+        kind: "sonarr",
+        url: "http://localhost:8989",
+        api_key: "old-key",
+        enabled: true,
+      }),
+    });
+
+    await integrations.goto();
+
+    const row = integrations.getInstanceByName("Edit Me");
+    await row.waitFor({ timeout: 10_000 });
+    await integrations.getEditButton(row).click();
+
+    // Form should be visible with existing values
+    await expect(integrations.instanceForm).toBeVisible();
+    const nameInput = integrations.instanceForm.locator(
+      'label:has-text("Name") input'
+    );
+    await expect(nameInput).toHaveValue("Edit Me");
+
+    // Update the URL
+    await integrations.fillForm({
+      url: "http://localhost:7878",
+    });
+    await integrations.clickSave();
+
+    // Verify via API
+    await expect
+      .poll(
+        async () => {
+          const res = await apiFetch("/server/integrations");
+          if (!res.ok) return undefined;
+          const instances = await res.json();
+          return instances.find(
+            (i: { name: string }) => i.name === "Edit Me"
+          );
+        },
+        { timeout: 5000 }
+      )
+      .toEqual(
+        expect.objectContaining({
+          url: "http://localhost:7878",
+        })
+      );
+  });
+
+  test("single-click delete shows confirmation state", async ({
+    apiFetch,
+  }) => {
+    // Create an integration via API
+    await apiFetch("/server/integrations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Confirm Delete",
+        kind: "radarr",
+        url: "http://localhost:7878",
+        api_key: "key",
+        enabled: true,
+      }),
+    });
+
+    await integrations.goto();
+
+    const row = integrations.getInstanceByName("Confirm Delete");
+    await row.waitFor({ timeout: 10_000 });
+    const deleteBtn = integrations.getDeleteButton(row);
+
+    // First click — should enter confirmation state
+    await deleteBtn.click();
+    await expect(deleteBtn).toContainText("Confirm?");
+    await expect(deleteBtn).toHaveClass(/confirming/);
+  });
+
+  test("double-click delete removes the integration", async ({
+    apiFetch,
+  }) => {
+    // Create an integration via API
+    await apiFetch("/server/integrations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Delete Me",
+        kind: "sonarr",
+        url: "http://localhost:8989",
+        api_key: "key",
+        enabled: true,
+      }),
+    });
+
+    await integrations.goto();
+
+    const row = integrations.getInstanceByName("Delete Me");
+    await row.waitFor({ timeout: 10_000 });
+    const deleteBtn = integrations.getDeleteButton(row);
+
+    // First click — confirmation
+    await deleteBtn.click();
+    await expect(deleteBtn).toContainText("Confirm?");
+
+    // Second click — actual delete
+    await deleteBtn.click();
+
+    // Row should disappear
+    await expect(row).not.toBeVisible({ timeout: 5000 });
+
+    // Verify via API
+    await expect
+      .poll(
+        async () => {
+          const res = await apiFetch("/server/integrations");
+          if (!res.ok) return undefined;
+          const instances = await res.json();
+          return instances.find(
+            (i: { name: string }) => i.name === "Delete Me"
+          );
+        },
+        { timeout: 5000 }
+      )
+      .toBeUndefined();
+  });
+
+  test("Test Connection button shows result", async ({ apiFetch }) => {
+    // Create an integration with a URL that will likely fail connection
+    await apiFetch("/server/integrations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Test Conn",
+        kind: "sonarr",
+        url: "http://localhost:19999",
+        api_key: "bad-key",
+        enabled: true,
+      }),
+    });
+
+    await integrations.goto();
+
+    const row = integrations.getInstanceByName("Test Conn");
+    await row.waitFor({ timeout: 10_000 });
+
+    const testBtn = integrations.getTestButton(row);
+    await testBtn.click();
+
+    // Button should show "Testing..." while in progress
+    // Then a result should appear (success or failure)
+    const result = integrations.getTestResult(row);
+    await expect(result).toBeVisible({ timeout: 15_000 });
+    // The result should have either success or failure styling
+    const resultText = await result.textContent();
+    expect(resultText?.trim().length).toBeGreaterThan(0);
+  });
+
+  test("enable/disable toggle updates via API", async ({ apiFetch }) => {
+    // Create an enabled integration
+    await apiFetch("/server/integrations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Toggle Me",
+        kind: "sonarr",
+        url: "http://localhost:8989",
+        api_key: "key",
+        enabled: true,
+      }),
+    });
+
+    await integrations.goto();
+
+    const row = integrations.getInstanceByName("Toggle Me");
+    await row.waitFor({ timeout: 10_000 });
+    const toggle = integrations.getEnabledToggle(row);
+
+    // Should start checked (enabled)
+    await expect(toggle).toBeChecked();
+
+    // Toggle off
+    await toggle.click();
+
+    // Poll API until disabled
+    await expect
+      .poll(
+        async () => {
+          const res = await apiFetch("/server/integrations");
+          if (!res.ok) return undefined;
+          const instances = await res.json();
+          const inst = instances.find(
+            (i: { name: string }) => i.name === "Toggle Me"
+          );
+          return inst?.enabled;
+        },
+        { timeout: 5000 }
+      )
+      .toBe(false);
+  });
+
+  test("cancel button closes the add form without creating", async ({
+    apiFetch,
+  }) => {
+    await integrations.addSonarrButton.click();
+    await expect(integrations.instanceForm).toBeVisible();
+
+    await integrations.fillForm({
+      name: "Should Not Exist",
+      url: "http://localhost:8989",
+    });
+    await integrations.clickCancel();
+
+    // Form should close
+    await expect(integrations.instanceForm).not.toBeVisible();
+
+    // Verify nothing was created
+    const res = await apiFetch("/server/integrations");
+    const instances = res.ok ? await res.json() : [];
+    expect(
+      instances.find((i: { name: string }) => i.name === "Should Not Exist")
+    ).toBeUndefined();
+  });
+});

--- a/src/e2e-playwright/tests/pages/integrations.page.ts
+++ b/src/e2e-playwright/tests/pages/integrations.page.ts
@@ -1,0 +1,101 @@
+import { type Page, type Locator } from "@playwright/test";
+
+export class IntegrationsPage {
+  readonly page: Page;
+  readonly container: Locator;
+  readonly addSonarrButton: Locator;
+  readonly addRadarrButton: Locator;
+  readonly emptyState: Locator;
+  readonly instanceForm: Locator;
+  readonly errorMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    // Scope all selectors to .integrations to avoid collisions with .path-pairs
+    this.container = page.locator(".integrations");
+    this.addSonarrButton = this.container.locator("button.btn-add", {
+      hasText: "Sonarr",
+    });
+    this.addRadarrButton = this.container.locator("button.btn-add", {
+      hasText: "Radarr",
+    });
+    this.emptyState = this.container.locator(".empty-state");
+    this.instanceForm = this.container.locator(".instance-form");
+    this.errorMessage = this.container.locator(".error-message");
+  }
+
+  async goto() {
+    await this.page.goto("/settings");
+    await this.page.waitForURL("**/settings", { timeout: 10_000 });
+    await this.page.waitForSelector('a[href="/dashboard"]', {
+      timeout: 10_000,
+    });
+  }
+
+  /** Fill the add/edit instance form */
+  async fillForm(fields: {
+    name?: string;
+    url?: string;
+    apiKey?: string;
+    kind?: string;
+  }) {
+    const form = this.instanceForm;
+    if (fields.kind !== undefined) {
+      const select = form.locator("select");
+      await select.selectOption(fields.kind);
+    }
+    if (fields.name !== undefined) {
+      const nameInput = form.locator('label:has-text("Name") input');
+      await nameInput.fill(fields.name);
+    }
+    if (fields.url !== undefined) {
+      const urlInput = form.locator('label:has-text("URL") input');
+      await urlInput.fill(fields.url);
+    }
+    if (fields.apiKey !== undefined) {
+      const apiKeyInput = form.locator('label:has-text("API Key") input');
+      await apiKeyInput.fill(fields.apiKey);
+    }
+  }
+
+  async clickSave() {
+    await this.instanceForm.locator("button.btn-save").click();
+  }
+
+  async clickCancel() {
+    await this.instanceForm.locator("button.btn-cancel").click();
+  }
+
+  getInstanceRows() {
+    return this.container.locator(".instance-row");
+  }
+
+  getInstanceByName(name: string) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return this.container.locator(".instance-row").filter({
+      has: this.page.locator(".instance-name", {
+        hasText: new RegExp(escaped),
+      }),
+    });
+  }
+
+  getEditButton(row: Locator) {
+    return row.locator("button.btn-edit");
+  }
+
+  getDeleteButton(row: Locator) {
+    return row.locator("button.btn-delete");
+  }
+
+  getTestButton(row: Locator) {
+    return row.locator("button", { hasText: /Test Connection|Testing/i });
+  }
+
+  getTestResult(row: Locator) {
+    return row.locator(".test-result");
+  }
+
+  getEnabledToggle(row: Locator) {
+    return row.locator('input[type="checkbox"]');
+  }
+}


### PR DESCRIPTION
## Summary
- Add `integrations.page.ts` page object scoped to `.integrations` container with helpers for form filling, instance rows, and action buttons
- Add `integrations.spec.ts` with 10 tests covering empty state, add form with kind pre-selection, validation error on empty name, create/edit/delete flows with API verification, double-click delete confirmation, test connection, enable/disable toggle, and cancel without creating

## Test plan
- [ ] CI passes (Playwright tests require running container)
- [ ] beforeEach/afterEach cleanup ensures all integrations are removed between tests
- [ ] No flaky tests — uses Playwright built-in waiting and `expect.poll()` for async backend verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)