### PR TITLE
PR 11: E2E — Settings Coverage Expansion

### DIFF
--- a/src/e2e-playwright/tests/settings.spec.ts
+++ b/src/e2e-playwright/tests/settings.spec.ts
@@ -228,3 +228,286 @@ test.describe("Settings Page", () => {
     await expect(field).toHaveAttribute("type", "password");
   });
 });
+
+test.describe("Settings — Staging Directory", () => {
+  test("staging path text field saves to backend", async ({
+    page,
+    apiGet,
+    apiSetConfig,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    const configBefore = await apiGet("/server/config/get");
+    const originalPath = configBefore.controller.staging_path;
+
+    try {
+      const field = settings.getTextInput("Staging Path");
+      await field.clear();
+      const testValue = "/tmp/e2e-staging-" + Date.now();
+      await field.fill(testValue);
+
+      await expect
+        .poll(
+          async () => {
+            const config = await apiGet("/server/config/get");
+            return config.controller.staging_path;
+          },
+          { timeout: 5000 }
+        )
+        .toBe(testValue);
+    } finally {
+      await apiSetConfig("controller", "staging_path", originalPath ?? "");
+    }
+  });
+
+  test("use staging directory checkbox toggles and saves", async ({
+    page,
+    apiGet,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    const checkbox = settings.getCheckbox("Use staging directory");
+    const wasBefore = await checkbox.isChecked();
+    const expected = !wasBefore;
+
+    await checkbox.click();
+
+    try {
+      await expect
+        .poll(
+          async () => {
+            const config = await apiGet("/server/config/get");
+            return config.controller.use_staging;
+          },
+          { timeout: 5000 }
+        )
+        .toBe(expected);
+    } finally {
+      await checkbox.click();
+      await expect
+        .poll(
+          async () => {
+            const config = await apiGet("/server/config/get");
+            return config.controller.use_staging;
+          },
+          { timeout: 5000 }
+        )
+        .toBe(wasBefore);
+    }
+  });
+});
+
+test.describe("Settings — Archive Extraction", () => {
+  test("extract in downloads directory checkbox toggles and saves", async ({
+    page,
+    apiGet,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    const checkbox = settings.getCheckbox(
+      "Extract archives in the downloads directory"
+    );
+    const wasBefore = await checkbox.isChecked();
+    const expected = !wasBefore;
+
+    await checkbox.click();
+
+    try {
+      await expect
+        .poll(
+          async () => {
+            const config = await apiGet("/server/config/get");
+            return config.controller.use_local_path_as_extract_path;
+          },
+          { timeout: 5000 }
+        )
+        .toBe(expected);
+    } finally {
+      await checkbox.click();
+      await expect
+        .poll(
+          async () => {
+            const config = await apiGet("/server/config/get");
+            return config.controller.use_local_path_as_extract_path;
+          },
+          { timeout: 5000 }
+        )
+        .toBe(wasBefore);
+    }
+  });
+});
+
+test.describe("Settings — Integrity Check", () => {
+  test("verify transfers checkbox and algorithm select are present", async ({
+    page,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    const section = settings.getSection("Integrity Check");
+    await expect(section).toBeVisible();
+
+    const verifyCheckbox = settings.getCheckbox(
+      "Verify transfers inline"
+    );
+    await expect(verifyCheckbox).toBeVisible();
+
+    const algorithmSelect = settings.getSelect("Hash Algorithm");
+    await expect(algorithmSelect).toBeVisible();
+  });
+
+  test("hash algorithm select changes and saves to backend", async ({
+    page,
+    apiGet,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    const configBefore = await apiGet("/server/config/get");
+    const originalAlgorithm = configBefore.validate.algorithm;
+
+    const select = settings.getSelect("Hash Algorithm");
+    // Pick a different algorithm than current
+    const newValue = originalAlgorithm === "sha256" ? "md5" : "sha256";
+
+    try {
+      await select.selectOption(newValue);
+
+      await expect
+        .poll(
+          async () => {
+            const config = await apiGet("/server/config/get");
+            return config.validate.algorithm;
+          },
+          { timeout: 5000 }
+        )
+        .toBe(newValue);
+    } finally {
+      await select.selectOption(String(originalAlgorithm));
+      await expect
+        .poll(
+          async () => {
+            const config = await apiGet("/server/config/get");
+            return config.validate.algorithm;
+          },
+          { timeout: 5000 }
+        )
+        .toBe(originalAlgorithm);
+    }
+  });
+});
+
+test.describe("Settings — Connections", () => {
+  test("Max Parallel Downloads field saves to backend", async ({
+    page,
+    apiGet,
+    apiSetConfig,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    const configBefore = await apiGet("/server/config/get");
+    const originalValue = configBefore.lftp.num_max_parallel_downloads;
+
+    try {
+      const field = settings.getTextInput("Max Parallel Downloads");
+      await field.clear();
+      await field.fill("7");
+
+      await expect
+        .poll(
+          async () => {
+            const config = await apiGet("/server/config/get");
+            return String(config.lftp.num_max_parallel_downloads);
+          },
+          { timeout: 5000 }
+        )
+        .toBe("7");
+    } finally {
+      await apiSetConfig(
+        "lftp",
+        "num_max_parallel_downloads",
+        String(originalValue)
+      );
+    }
+  });
+});
+
+test.describe("Settings — Notifications", () => {
+  test("Discord and Telegram webhook fields are present", async ({
+    page,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    const section = settings.getSection("Notifications");
+    await expect(section).toBeVisible();
+
+    // Discord Webhook URL is a password field
+    const discordField = section
+      .locator("app-option", { hasText: "Discord Webhook URL" })
+      .locator("input[type='text'], input[type='password']");
+    await expect(discordField).toBeVisible();
+
+    // Telegram Bot Token is a password field
+    const telegramTokenField = section
+      .locator("app-option", { hasText: "Telegram Bot Token" })
+      .locator("input[type='text'], input[type='password']");
+    await expect(telegramTokenField).toBeVisible();
+
+    // Telegram Chat ID is a text field
+    const telegramChatField = section
+      .locator("app-option", { hasText: "Telegram Chat ID" })
+      .locator("input[type='text'], input[type='password']");
+    await expect(telegramChatField).toBeVisible();
+  });
+});
+
+test.describe("Settings — Logging", () => {
+  test("Log Level dropdown persists selected value", async ({
+    page,
+    apiGet,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    const configBefore = await apiGet("/server/config/get");
+    const originalLevel = configBefore.general.log_level;
+
+    const select = settings.getSelect("Log Level");
+    const newValue = originalLevel === "DEBUG" ? "WARNING" : "DEBUG";
+
+    try {
+      await select.selectOption(newValue);
+
+      await expect
+        .poll(
+          async () => {
+            const config = await apiGet("/server/config/get");
+            return config.general.log_level;
+          },
+          { timeout: 5000 }
+        )
+        .toBe(newValue);
+
+      // Reload the page and verify the value persists
+      await settings.goto();
+      const reloadedSelect = settings.getSelect("Log Level");
+      await expect(reloadedSelect).toHaveValue(newValue);
+    } finally {
+      await select.selectOption(String(originalLevel));
+      await expect
+        .poll(
+          async () => {
+            const config = await apiGet("/server/config/get");
+            return config.general.log_level;
+          },
+          { timeout: 5000 }
+        )
+        .toBe(originalLevel);
+    }
+  });
+});

--- a/src/e2e-playwright/tests/settings.spec.ts
+++ b/src/e2e-playwright/tests/settings.spec.ts
@@ -363,23 +363,24 @@ test.describe("Settings — Integrity Check", () => {
     page,
     apiGet,
     apiSetConfig,
+    waitForStream,
   }) => {
-    const settings = new SettingsPage(page);
-    await settings.goto();
-
+    // Enable integrity check first so the algorithm select is enabled
     const configBefore = await apiGet("/server/config/get");
     const originalAlgorithm = configBefore.validate.algorithm;
     const originalXferVerify = configBefore.validate.xfer_verify;
 
-    // Enable integrity check so the algorithm select is enabled
     if (!originalXferVerify) {
       await apiSetConfig("validate", "xfer_verify", "True");
-      await page.reload();
-      await settings.goto();
     }
 
+    // Navigate after config is set so the page loads with xfer_verify enabled
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await waitForStream(page);
+
     const select = settings.getSelect("Hash Algorithm");
-    await expect(select).toBeEnabled({ timeout: 5000 });
+    await expect(select).toBeEnabled({ timeout: 10_000 });
 
     // Pick a different algorithm than current
     const newValue = originalAlgorithm === "sha256" ? "md5" : "sha256";

--- a/src/e2e-playwright/tests/settings.spec.ts
+++ b/src/e2e-playwright/tests/settings.spec.ts
@@ -362,6 +362,7 @@ test.describe("Settings — Integrity Check", () => {
   test("hash algorithm select changes and saves to backend", async ({
     page,
     apiGet,
+    apiSetConfig,
   }) => {
     const settings = new SettingsPage(page);
     await settings.goto();
@@ -386,16 +387,7 @@ test.describe("Settings — Integrity Check", () => {
         )
         .toBe(newValue);
     } finally {
-      await select.selectOption(String(originalAlgorithm));
-      await expect
-        .poll(
-          async () => {
-            const config = await apiGet("/server/config/get");
-            return config.validate.algorithm;
-          },
-          { timeout: 5000 }
-        )
-        .toBe(originalAlgorithm);
+      await apiSetConfig("validate", "algorithm", String(originalAlgorithm));
     }
   });
 });

--- a/src/e2e-playwright/tests/settings.spec.ts
+++ b/src/e2e-playwright/tests/settings.spec.ts
@@ -369,8 +369,18 @@ test.describe("Settings — Integrity Check", () => {
 
     const configBefore = await apiGet("/server/config/get");
     const originalAlgorithm = configBefore.validate.algorithm;
+    const originalXferVerify = configBefore.validate.xfer_verify;
+
+    // Enable integrity check so the algorithm select is enabled
+    if (!originalXferVerify) {
+      await apiSetConfig("validate", "xfer_verify", "True");
+      await page.reload();
+      await settings.goto();
+    }
 
     const select = settings.getSelect("Hash Algorithm");
+    await expect(select).toBeEnabled({ timeout: 5000 });
+
     // Pick a different algorithm than current
     const newValue = originalAlgorithm === "sha256" ? "md5" : "sha256";
 
@@ -388,6 +398,9 @@ test.describe("Settings — Integrity Check", () => {
         .toBe(newValue);
     } finally {
       await apiSetConfig("validate", "algorithm", String(originalAlgorithm));
+      if (!originalXferVerify) {
+        await apiSetConfig("validate", "xfer_verify", "False");
+      }
     }
   });
 });

--- a/src/e2e-playwright/tests/settings.spec.ts
+++ b/src/e2e-playwright/tests/settings.spec.ts
@@ -380,7 +380,10 @@ test.describe("Settings — Integrity Check", () => {
     await waitForStream(page);
 
     const select = settings.getSelect("Hash Algorithm");
-    await expect(select).toBeEnabled({ timeout: 10_000 });
+    // Wait for the config value to arrive via SSE — the select is disabled
+    // until its value is non-null (see option.component.html)
+    await expect(select).not.toHaveValue("", { timeout: 10_000 });
+    await expect(select).toBeEnabled({ timeout: 5_000 });
 
     // Pick a different algorithm than current
     const newValue = originalAlgorithm === "sha256" ? "md5" : "sha256";


### PR DESCRIPTION
## Summary
- Add 8 new E2E tests to `settings.spec.ts` covering previously untested settings sections:
  - **Staging Directory**: path field save, use staging checkbox toggle
  - **Archive Extraction**: extract-in-downloads-directory checkbox toggle
  - **Integrity Check**: verify checkbox + algorithm select presence, algorithm select save/restore
  - **Connections**: max parallel downloads field save
  - **Notifications**: Discord/Telegram webhook field presence
  - **Logging**: log level dropdown persistence after page reload

## Test plan
- [ ] CI passes (Playwright tests require running container)
- [ ] All tests restore original config values in `finally` blocks
- [ ] No flaky tests — uses `expect.poll()` for async backend verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)