### PR TITLE
PR 2: Python — Controller Core tests (pair_context, scanners, delete)

### DIFF
--- a/src/python/tests/unittests/test_controller/test_delete/test_delete_process.py
+++ b/src/python/tests/unittests/test_controller/test_delete/test_delete_process.py
@@ -1,0 +1,165 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import logging
+import sys
+import unittest
+from unittest.mock import patch
+
+from controller.delete.delete_process import DeleteLocalProcess, DeleteRemoteProcess
+
+
+class TestDeleteLocalProcess(unittest.TestCase):
+    """Tests for DeleteLocalProcess.run_once()."""
+
+    def setUp(self):
+        logger = logging.getLogger()
+        handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+
+    @patch("controller.delete.delete_process.shutil.rmtree")
+    @patch("controller.delete.delete_process.os.path.isfile", return_value=False)
+    @patch("controller.delete.delete_process.os.path.exists", return_value=True)
+    @patch("controller.delete.delete_process.os.path.realpath")
+    def test_directory_uses_rmtree(self, mock_realpath, mock_exists, mock_isfile, mock_rmtree):
+        """Directory deletion uses shutil.rmtree."""
+        mock_realpath.side_effect = lambda p: p
+        proc = DeleteLocalProcess("/base", "mydir")
+        proc.run_once()
+        mock_rmtree.assert_called_once_with("/base/mydir", ignore_errors=True)
+
+    @patch("controller.delete.delete_process.os.remove")
+    @patch("controller.delete.delete_process.os.path.isfile", return_value=True)
+    @patch("controller.delete.delete_process.os.path.exists", return_value=True)
+    @patch("controller.delete.delete_process.os.path.realpath")
+    def test_regular_file_uses_os_remove(self, mock_realpath, mock_exists, mock_isfile, mock_remove):
+        """Regular file deletion uses os.remove."""
+        mock_realpath.side_effect = lambda p: p
+        proc = DeleteLocalProcess("/base", "myfile.txt")
+        proc.run_once()
+        mock_remove.assert_called_once_with("/base/myfile.txt")
+
+    @patch("controller.delete.delete_process.os.path.realpath")
+    def test_symlink_escaping_base_blocked(self, mock_realpath):
+        """Symlink escaping base directory is blocked and logged."""
+        mock_realpath.side_effect = lambda p: "/etc/passwd" if "evil" in p else p
+        proc = DeleteLocalProcess("/base", "evil_symlink")
+
+        with self.assertLogs(level="ERROR") as log_ctx:
+            proc.run_once()
+
+        self.assertTrue(any("Path traversal blocked" in msg for msg in log_ctx.output))
+
+    @patch("controller.delete.delete_process.os.path.realpath")
+    def test_path_traversal_blocked(self, mock_realpath):
+        """../../etc/passwd style paths are blocked."""
+        mock_realpath.side_effect = lambda p: "/etc/passwd" if "etc" in p else "/base"
+        proc = DeleteLocalProcess("/base", "../../etc/passwd")
+
+        with self.assertLogs(level="ERROR") as log_ctx:
+            proc.run_once()
+
+        self.assertTrue(any("Path traversal blocked" in msg for msg in log_ctx.output))
+
+    @patch("controller.delete.delete_process.os.path.exists", return_value=False)
+    @patch("controller.delete.delete_process.os.path.realpath")
+    def test_nonexistent_file_logs_error(self, mock_realpath, mock_exists):
+        """Non-existing file logs error, no crash."""
+        mock_realpath.side_effect = lambda p: p
+        proc = DeleteLocalProcess("/base", "gone.txt")
+
+        with self.assertLogs(level="ERROR") as log_ctx:
+            proc.run_once()
+
+        self.assertTrue(any("non-existing" in msg for msg in log_ctx.output))
+
+
+class TestDeleteRemoteProcess(unittest.TestCase):
+    """Tests for DeleteRemoteProcess.run_once()."""
+
+    def setUp(self):
+        logger = logging.getLogger()
+        handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+
+    @patch("controller.delete.delete_process.Sshcp")
+    def test_constructs_correct_ssh_command(self, mock_sshcp_cls):
+        """Remote delete constructs correct SSH rm -rf command."""
+        mock_ssh = mock_sshcp_cls.return_value
+        mock_ssh.shell.return_value = b""
+
+        proc = DeleteRemoteProcess(
+            remote_address="host",
+            remote_username="user",
+            remote_password="pass",
+            remote_port=22,
+            remote_path="/remote",
+            file_name="myfile.txt",
+        )
+        proc.run_once()
+
+        mock_ssh.shell.assert_called_once()
+        cmd = mock_ssh.shell.call_args[0][0]
+        self.assertIn("rm -rf", cmd)
+        self.assertIn("myfile.txt", cmd)
+
+    @patch("controller.delete.delete_process.Sshcp")
+    def test_remote_path_starting_with_dotdot_blocked(self, mock_sshcp_cls):
+        """Remote paths starting with .. are blocked."""
+        mock_ssh = mock_sshcp_cls.return_value
+
+        proc = DeleteRemoteProcess(
+            remote_address="host",
+            remote_username="user",
+            remote_password="pass",
+            remote_port=22,
+            remote_path="/remote",
+            file_name="../etc/passwd",
+        )
+
+        with self.assertLogs(level="ERROR") as log_ctx:
+            proc.run_once()
+
+        self.assertTrue(any("Path traversal blocked" in msg for msg in log_ctx.output))
+        mock_ssh.shell.assert_not_called()
+
+    @patch("controller.delete.delete_process.Sshcp")
+    def test_remote_absolute_path_blocked(self, mock_sshcp_cls):
+        """Remote file names with absolute paths are blocked."""
+        mock_ssh = mock_sshcp_cls.return_value
+
+        proc = DeleteRemoteProcess(
+            remote_address="host",
+            remote_username="user",
+            remote_password="pass",
+            remote_port=22,
+            remote_path="/remote",
+            file_name="/etc/passwd",
+        )
+
+        with self.assertLogs(level="ERROR") as log_ctx:
+            proc.run_once()
+
+        self.assertTrue(any("Path traversal blocked" in msg for msg in log_ctx.output))
+        mock_ssh.shell.assert_not_called()
+
+    @patch("controller.delete.delete_process.Sshcp")
+    def test_tilde_path_uses_double_escape(self, mock_sshcp_cls):
+        """Paths starting with ~ use double-quote escaping."""
+        mock_ssh = mock_sshcp_cls.return_value
+        mock_ssh.shell.return_value = b""
+
+        proc = DeleteRemoteProcess(
+            remote_address="host",
+            remote_username="user",
+            remote_password="pass",
+            remote_port=22,
+            remote_path="~/downloads",
+            file_name="myfile.txt",
+        )
+        proc.run_once()
+
+        cmd = mock_ssh.shell.call_args[0][0]
+        # Tilde paths use double-quote escaping (escape_remote_path_double)
+        self.assertIn('"', cmd)

--- a/src/python/tests/unittests/test_controller/test_pair_context.py
+++ b/src/python/tests/unittests/test_controller/test_pair_context.py
@@ -1,0 +1,272 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import unittest
+from unittest.mock import MagicMock
+
+from common import Args, Config, Constants, Context, Status
+from controller.pair_context import (
+    ControllerError,
+    PairContext,
+    configure_lftp,
+    validate_config,
+)
+
+
+class TestPairContextInit(unittest.TestCase):
+    """PairContext initializes with empty tracking state."""
+
+    def test_tracking_state_initialized_empty(self):
+        pc = PairContext(
+            pair_id="test-id",
+            name="test-pair",
+            remote_path="/remote",
+            local_path="/local",
+            effective_local_path="/local",
+            lftp=MagicMock(),
+            active_scanner=MagicMock(),
+            local_scanner=MagicMock(),
+            remote_scanner=MagicMock(),
+            active_scan_process=MagicMock(),
+            local_scan_process=MagicMock(),
+            remote_scan_process=MagicMock(),
+            model_builder=MagicMock(),
+        )
+        self.assertEqual(pc.active_downloading_file_names, [])
+        self.assertEqual(pc.active_extracting_file_names, [])
+        self.assertEqual(pc.prev_downloading_file_names, set())
+        self.assertEqual(pc.pending_completion, set())
+        self.assertFalse(pc.remote_scan_received)
+        self.assertFalse(pc.local_scan_received)
+        self.assertIsNone(pc.latest_remote_scan)
+        self.assertIsNone(pc.latest_local_scan)
+
+    def test_stores_constructor_args(self):
+        mock_lftp = MagicMock()
+        pc = PairContext(
+            pair_id="id-1",
+            name="my-pair",
+            remote_path="/r",
+            local_path="/l",
+            effective_local_path="/eff",
+            lftp=mock_lftp,
+            active_scanner=MagicMock(),
+            local_scanner=MagicMock(),
+            remote_scanner=MagicMock(),
+            active_scan_process=MagicMock(),
+            local_scan_process=MagicMock(),
+            remote_scan_process=MagicMock(),
+            model_builder=MagicMock(),
+        )
+        self.assertEqual(pc.pair_id, "id-1")
+        self.assertEqual(pc.name, "my-pair")
+        self.assertEqual(pc.remote_path, "/r")
+        self.assertEqual(pc.local_path, "/l")
+        self.assertEqual(pc.effective_local_path, "/eff")
+        self.assertIs(pc.lftp, mock_lftp)
+
+
+def _make_valid_context() -> Context:
+    """Create a Context with all required fields populated."""
+    config = Config()
+    # Lftp required
+    config.lftp.remote_address = "host"
+    config.lftp.remote_username = "user"
+    config.lftp.remote_port = 22
+    config.lftp.remote_path_to_scan_script = "/scan"
+    config.lftp.use_ssh_key = True
+    config.lftp.use_temp_file = True
+    config.lftp.num_max_parallel_downloads = 2
+    config.lftp.num_max_parallel_files_per_download = 3
+    config.lftp.num_max_connections_per_root_file = 4
+    config.lftp.num_max_connections_per_dir_file = 5
+    config.lftp.num_max_total_connections = 10
+    # Controller required
+    config.controller.interval_ms_remote_scan = 5000
+    config.controller.interval_ms_local_scan = 3000
+    config.controller.interval_ms_downloading_scan = 1000
+    config.controller.use_local_path_as_extract_path = True
+    # General
+    config.general.verbose = True
+    # AutoQueue
+    config.autoqueue.auto_delete_remote = False
+
+    args = Args()
+    args.local_path_to_scanfs = "/scanfs"
+
+    import logging
+
+    logger = logging.getLogger("test")
+    web_logger = logging.getLogger("test.web")
+    status = Status()
+    return Context(logger=logger, web_access_logger=web_logger, config=config, args=args, status=status)
+
+
+class TestValidateConfig(unittest.TestCase):
+    """Tests for validate_config."""
+
+    def test_fully_populated_config_passes(self):
+        ctx = _make_valid_context()
+        # Should not raise
+        validate_config(ctx)
+
+    def test_missing_lftp_field_raises(self):
+        ctx = _make_valid_context()
+        # Bypass property checker by setting internal attribute directly
+        setattr(ctx.config.lftp, "__remote_address", None)
+        with self.assertRaises(ControllerError) as cm:
+            validate_config(ctx)
+        self.assertIn("Lftp.remote_address", str(cm.exception))
+
+    def test_missing_multiple_fields_lists_all(self):
+        ctx = _make_valid_context()
+        setattr(ctx.config.lftp, "__remote_address", None)
+        setattr(ctx.config.lftp, "__remote_port", None)
+        setattr(ctx.config.controller, "__interval_ms_remote_scan", None)
+        with self.assertRaises(ControllerError) as cm:
+            validate_config(ctx)
+        msg = str(cm.exception)
+        self.assertIn("Lftp.remote_address", msg)
+        self.assertIn("Lftp.remote_port", msg)
+        self.assertIn("Controller.interval_ms_remote_scan", msg)
+
+    def test_extract_path_required_when_not_using_local(self):
+        ctx = _make_valid_context()
+        ctx.config.controller.use_local_path_as_extract_path = False
+        ctx.config.controller.extract_path = None
+        with self.assertRaises(ControllerError) as cm:
+            validate_config(ctx)
+        self.assertIn("Controller.extract_path", str(cm.exception))
+
+    def test_extract_path_not_required_when_using_local(self):
+        ctx = _make_valid_context()
+        ctx.config.controller.use_local_path_as_extract_path = True
+        ctx.config.controller.extract_path = None
+        # Should not raise
+        validate_config(ctx)
+
+    def test_missing_scanfs_arg_raises(self):
+        ctx = _make_valid_context()
+        ctx.args.local_path_to_scanfs = None
+        with self.assertRaises(ControllerError) as cm:
+            validate_config(ctx)
+        self.assertIn("Args.local_path_to_scanfs", str(cm.exception))
+
+    def test_missing_verbose_raises(self):
+        ctx = _make_valid_context()
+        ctx.config.general.verbose = None
+        with self.assertRaises(ControllerError) as cm:
+            validate_config(ctx)
+        self.assertIn("General.verbose", str(cm.exception))
+
+    def test_missing_auto_delete_remote_raises(self):
+        ctx = _make_valid_context()
+        ctx.config.autoqueue.auto_delete_remote = None
+        with self.assertRaises(ControllerError) as cm:
+            validate_config(ctx)
+        self.assertIn("AutoQueue.auto_delete_remote", str(cm.exception))
+
+
+class TestConfigureLftp(unittest.TestCase):
+    """Tests for configure_lftp."""
+
+    def test_mandatory_settings_applied(self):
+        lftp = MagicMock()
+        config = Config()
+        config.lftp.num_max_parallel_downloads = 2
+        config.lftp.num_max_parallel_files_per_download = 3
+        config.lftp.num_max_connections_per_root_file = 4
+        config.lftp.num_max_connections_per_dir_file = 5
+        config.lftp.num_max_total_connections = 10
+        config.lftp.use_temp_file = True
+
+        configure_lftp(lftp, config)
+
+        self.assertEqual(lftp.num_parallel_jobs, 2)
+        self.assertEqual(lftp.num_parallel_files, 3)
+        self.assertEqual(lftp.num_connections_per_root_file, 4)
+        self.assertEqual(lftp.num_connections_per_dir_file, 5)
+        self.assertEqual(lftp.num_max_total_connections, 10)
+        self.assertTrue(lftp.use_temp_file)
+        self.assertEqual(lftp.temp_file_name, "*" + Constants.LFTP_TEMP_FILE_SUFFIX)
+
+    def test_optional_settings_applied_when_truthy(self):
+        lftp = MagicMock()
+        config = Config()
+        config.lftp.num_max_parallel_downloads = 1
+        config.lftp.num_max_parallel_files_per_download = 1
+        config.lftp.num_max_connections_per_root_file = 1
+        config.lftp.num_max_connections_per_dir_file = 1
+        config.lftp.num_max_total_connections = 1
+        config.lftp.use_temp_file = True
+        config.lftp.net_limit_rate = "1M"
+        config.lftp.net_socket_buffer = "65536"
+        config.lftp.pget_min_chunk_size = "100k"
+
+        configure_lftp(lftp, config)
+
+        self.assertEqual(lftp.rate_limit, "1M")
+        self.assertEqual(lftp.net_socket_buffer, "65536")
+        self.assertEqual(lftp.min_chunk_size, "100k")
+
+    def test_optional_settings_skipped_when_falsy(self):
+        """Optional LFTP settings are not applied when their config values are falsy."""
+
+        class TrackingMock:
+            """Mock that tracks which attributes were set."""
+
+            def __init__(self):
+                self._set_attrs: list[str] = []
+
+            def __setattr__(self, name, value):
+                if not name.startswith("_"):
+                    self._set_attrs.append(name)
+                super().__setattr__(name, value)
+
+        lftp = TrackingMock()
+        config = Config()
+        config.lftp.num_max_parallel_downloads = 1
+        config.lftp.num_max_parallel_files_per_download = 1
+        config.lftp.num_max_connections_per_root_file = 1
+        config.lftp.num_max_connections_per_dir_file = 1
+        config.lftp.num_max_total_connections = 1
+        config.lftp.use_temp_file = True
+        config.lftp.net_limit_rate = ""
+        # net_socket_buffer and pget_min_chunk_size are None by default
+
+        configure_lftp(lftp, config)
+
+        self.assertNotIn("rate_limit", lftp._set_attrs)
+        self.assertNotIn("net_socket_buffer", lftp._set_attrs)
+        self.assertNotIn("min_chunk_size", lftp._set_attrs)
+
+    def test_xfer_verify_enabled(self):
+        lftp = MagicMock()
+        config = Config()
+        config.lftp.num_max_parallel_downloads = 1
+        config.lftp.num_max_parallel_files_per_download = 1
+        config.lftp.num_max_connections_per_root_file = 1
+        config.lftp.num_max_connections_per_dir_file = 1
+        config.lftp.num_max_total_connections = 1
+        config.lftp.use_temp_file = True
+        config.validate.xfer_verify = True
+        config.validate.algorithm = "sha256"
+
+        configure_lftp(lftp, config)
+
+        self.assertTrue(lftp.xfer_verify)
+        self.assertEqual(lftp.xfer_verify_command, "sha256sum")
+
+    def test_xfer_verify_disabled(self):
+        lftp = MagicMock()
+        config = Config()
+        config.lftp.num_max_parallel_downloads = 1
+        config.lftp.num_max_parallel_files_per_download = 1
+        config.lftp.num_max_connections_per_root_file = 1
+        config.lftp.num_max_connections_per_dir_file = 1
+        config.lftp.num_max_total_connections = 1
+        config.lftp.use_temp_file = True
+        config.validate.xfer_verify = False
+
+        configure_lftp(lftp, config)
+
+        self.assertFalse(lftp.xfer_verify)

--- a/src/python/tests/unittests/test_controller/test_scan/test_active_scanner.py
+++ b/src/python/tests/unittests/test_controller/test_scan/test_active_scanner.py
@@ -1,0 +1,117 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import logging
+import sys
+import time
+import unittest
+from unittest.mock import patch
+
+from controller.scan.active_scanner import ActiveScanner
+from system import SystemFile, SystemScannerError
+
+
+class TestActiveScanner(unittest.TestCase):
+    """Tests for ActiveScanner."""
+
+    def setUp(self):
+        logger = logging.getLogger("test_active_scanner")
+        handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+
+    @patch("controller.scan.active_scanner.SystemScanner")
+    def test_empty_active_files_returns_empty(self, mock_scanner_cls):
+        """With no active files set, scan returns empty."""
+        scanner = ActiveScanner("/local")
+        result = scanner.scan()
+        self.assertEqual(result, [])
+        scanner.close()
+
+    @patch("controller.scan.active_scanner.SystemScanner")
+    def test_scan_returns_files_after_set_active(self, mock_scanner_cls):
+        """After set_active_files, scan returns SystemFile objects for those files."""
+        mock_scanner = mock_scanner_cls.return_value
+        file_a = SystemFile("fileA", 100, False)
+        file_b = SystemFile("fileB", 200, True)
+        mock_scanner.scan_single.side_effect = [file_a, file_b]
+
+        scanner = ActiveScanner("/local")
+        scanner.set_active_files(["fileA", "fileB"])
+        # multiprocessing.Queue.put() uses a background thread; brief pause
+        # ensures the data is available for the non-blocking get() in scan()
+        time.sleep(0.05)
+        result = scanner.scan()
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].name, "fileA")
+        self.assertEqual(result[1].name, "fileB")
+        scanner.close()
+
+    @patch("controller.scan.active_scanner.SystemScanner")
+    def test_latest_list_wins_when_multiple_set_before_scan(self, mock_scanner_cls):
+        """Multiple set_active_files before scan: latest list wins (queue draining)."""
+        mock_scanner = mock_scanner_cls.return_value
+        file_c = SystemFile("fileC", 300, False)
+        mock_scanner.scan_single.return_value = file_c
+
+        scanner = ActiveScanner("/local")
+        scanner.set_active_files(["fileA", "fileB"])
+        scanner.set_active_files(["fileC"])
+        time.sleep(0.05)
+        result = scanner.scan()
+
+        # Only the latest list should be used
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "fileC")
+        scanner.close()
+
+    @patch("controller.scan.active_scanner.SystemScanner")
+    def test_missing_file_logged_at_debug(self, mock_scanner_cls):
+        """Missing file during download logged at DEBUG, not ERROR."""
+        mock_scanner = mock_scanner_cls.return_value
+        mock_scanner.scan_single.side_effect = SystemScannerError("file does not exist: /local/missing")
+
+        scanner = ActiveScanner("/local")
+        scanner.set_active_files(["missing"])
+        time.sleep(0.05)
+
+        with self.assertLogs("ActiveScanner", level="DEBUG") as log_ctx:
+            result = scanner.scan()
+
+        self.assertEqual(result, [])
+        self.assertTrue(any("does not exist" in msg for msg in log_ctx.output))
+        scanner.close()
+
+    @patch("controller.scan.active_scanner.SystemScanner")
+    def test_unexpected_error_logged_at_warning(self, mock_scanner_cls):
+        """Unexpected SystemScannerError logged at WARNING."""
+        mock_scanner = mock_scanner_cls.return_value
+        mock_scanner.scan_single.side_effect = SystemScannerError("permission denied")
+
+        scanner = ActiveScanner("/local")
+        scanner.set_active_files(["restricted"])
+        time.sleep(0.05)
+
+        with self.assertLogs("ActiveScanner", level="WARNING") as log_ctx:
+            result = scanner.scan()
+
+        self.assertEqual(result, [])
+        self.assertTrue(any("Unexpected scan error" in msg for msg in log_ctx.output))
+        scanner.close()
+
+    @patch("controller.scan.active_scanner.SystemScanner")
+    def test_set_base_logger(self, mock_scanner_cls):
+        """set_base_logger creates a child logger."""
+        scanner = ActiveScanner("/local")
+        parent_logger = logging.getLogger("parent")
+        scanner.set_base_logger(parent_logger)
+        self.assertEqual(scanner.logger.name, "parent.ActiveScanner")
+        scanner.close()
+
+    @patch("controller.scan.active_scanner.SystemScanner")
+    def test_lftp_temp_suffix_forwarded(self, mock_scanner_cls):
+        """lftp_temp_suffix is forwarded to SystemScanner."""
+        mock_scanner = mock_scanner_cls.return_value
+        scanner = ActiveScanner("/local", lftp_temp_suffix=".partial")
+        mock_scanner.set_lftp_temp_suffix.assert_called_once_with(".partial")
+        scanner.close()

--- a/src/python/tests/unittests/test_controller/test_scan/test_local_scanner.py
+++ b/src/python/tests/unittests/test_controller/test_scan/test_local_scanner.py
@@ -1,0 +1,67 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import logging
+import unittest
+from unittest.mock import patch
+
+from controller.scan.local_scanner import LocalScanner
+from controller.scan.scanner_process import ScannerError
+from system import SystemFile, SystemScannerError
+
+
+class TestLocalScanner(unittest.TestCase):
+    """Tests for LocalScanner."""
+
+    @patch("controller.scan.local_scanner.os.path.isdir", return_value=False)
+    @patch("controller.scan.local_scanner.SystemScanner")
+    def test_missing_path_returns_empty_with_warning(self, mock_scanner_cls, mock_isdir):
+        """Missing scan path returns empty list + warning log."""
+        scanner = LocalScanner("/nonexistent", use_temp_file=False)
+
+        with self.assertLogs("LocalScanner", level="WARNING") as log_ctx:
+            result = scanner.scan()
+
+        self.assertEqual(result, [])
+        self.assertTrue(any("does not exist" in msg for msg in log_ctx.output))
+
+    @patch("controller.scan.local_scanner.os.path.isdir", return_value=True)
+    @patch("controller.scan.local_scanner.SystemScanner")
+    def test_successful_scan_returns_results(self, mock_scanner_cls, mock_isdir):
+        """Successful scan returns SystemScanner results."""
+        mock_scanner = mock_scanner_cls.return_value
+        files = [SystemFile("a", 10, False), SystemFile("b", 20, True)]
+        mock_scanner.scan.return_value = files
+
+        scanner = LocalScanner("/exists", use_temp_file=False)
+        result = scanner.scan()
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].name, "a")
+        self.assertEqual(result[1].name, "b")
+
+    @patch("controller.scan.local_scanner.os.path.isdir", return_value=True)
+    @patch("controller.scan.local_scanner.SystemScanner")
+    def test_scanner_error_raises_localized(self, mock_scanner_cls, mock_isdir):
+        """SystemScannerError raises ScannerError with localized message."""
+        mock_scanner = mock_scanner_cls.return_value
+        mock_scanner.scan.side_effect = SystemScannerError("disk failure")
+
+        scanner = LocalScanner("/exists", use_temp_file=False)
+
+        with self.assertRaises(ScannerError):
+            scanner.scan()
+
+    @patch("controller.scan.local_scanner.SystemScanner")
+    def test_set_base_logger(self, mock_scanner_cls):
+        """set_base_logger creates a child logger."""
+        scanner = LocalScanner("/local", use_temp_file=False)
+        parent_logger = logging.getLogger("parent")
+        scanner.set_base_logger(parent_logger)
+        self.assertEqual(scanner.logger.name, "parent.LocalScanner")
+
+    @patch("controller.scan.local_scanner.SystemScanner")
+    def test_temp_file_suffix_set(self, mock_scanner_cls):
+        """When use_temp_file is True, lftp temp suffix is set on SystemScanner."""
+        mock_scanner = mock_scanner_cls.return_value
+        LocalScanner("/local", use_temp_file=True)
+        mock_scanner.set_lftp_temp_suffix.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds unit tests for four previously untested controller modules
- **pair_context** (15 tests): `PairContext` initialization tracking state, `validate_config` with missing fields/extract path logic/boundary checks, `configure_lftp` mandatory/optional settings and xfer_verify enable/disable
- **active_scanner** (7 tests): empty scan, `set_active_files` with queue draining, missing file debug logging, unexpected error warning logging, base logger, temp suffix forwarding
- **local_scanner** (5 tests): missing scan path returns empty + warning, successful scan, `SystemScannerError` raises localized `ScannerError`, base logger, temp file suffix
- **delete_process** (9 tests): local file/dir deletion, symlink/path-traversal blocking, non-existent file error logging, remote SSH command construction, `..`/absolute path rejection, tilde path double-quote escaping

## Test plan
- [x] `cd src/python && PYTHONPATH=. python3 -m pytest tests/unittests/test_controller/test_pair_context.py tests/unittests/test_controller/test_scan/test_active_scanner.py tests/unittests/test_controller/test_scan/test_local_scanner.py tests/unittests/test_controller/test_delete/test_delete_process.py -v` — 36 passed
- [x] `python3 -m ruff check` — all checks passed
- [x] `python3 -m ruff format --check` — already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for deletion operations (local and remote paths).
  * Added validation tests for configuration initialization and LFTP settings.
  * Added unit tests for file scanning and system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->