### PR TITLE
Add Python integration tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,34 @@ jobs:
           --ignore=tests/unittests/test_controller/test_scan/test_remote_scanner.py
           --ignore=tests/unittests/test_common/test_multiprocessing_logger.py
 
+  python-integration-test:
+    name: Python Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        working-directory: src/python
+        run: uv pip install --system -r pyproject.toml --group test
+
+      - name: Run web handler integration tests
+        working-directory: src/python
+        env:
+          PYTHONPATH: .
+        run: >-
+          pytest tests/integration/test_web -v --tb=short
+          --timeout=30
+
   angular-build:
     name: Build Angular
     if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
@@ -392,9 +420,10 @@ jobs:
       && needs.python-lint.result == 'success'
       && needs.python-typecheck.result == 'success'
       && needs.python-test.result == 'success'
+      && needs.python-integration-test.result == 'success'
       && needs.build-amd64.result == 'success'
       && needs.build-arm64.result == 'success'
-    needs: [unit-test, angular-lint, python-lint, python-typecheck, python-test, build-amd64, build-arm64]
+    needs: [unit-test, angular-lint, python-lint, python-typecheck, python-test, python-integration-test, build-amd64, build-arm64]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/src/python/tests/integration/test_web/test_handler/test_auto_queue.py
+++ b/src/python/tests/integration/test_web/test_handler/test_auto_queue.py
@@ -1,6 +1,5 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
-import json
 from urllib.parse import quote
 
 from controller import AutoQueuePattern
@@ -16,7 +15,7 @@ class TestAutoQueueHandler(BaseTestWebApp):
         self.auto_queue_persist.add_pattern(AutoQueuePattern(pattern="fi%ve"))
         resp = self.test_app.get("/server/autoqueue/get")
         self.assertEqual(200, resp.status_int)
-        json_list = json.loads(str(resp.html))
+        json_list = resp.json
         self.assertEqual(5, len(json_list))
         self.assertIn({"pattern": "one"}, json_list)
         self.assertIn({"pattern": "t wo"}, json_list)
@@ -32,7 +31,7 @@ class TestAutoQueueHandler(BaseTestWebApp):
         self.auto_queue_persist.add_pattern(AutoQueuePattern(pattern="e"))
         resp = self.test_app.get("/server/autoqueue/get")
         self.assertEqual(200, resp.status_int)
-        json_list = json.loads(str(resp.html))
+        json_list = resp.json
         self.assertEqual(5, len(json_list))
         self.assertEqual(
             [{"pattern": "a"}, {"pattern": "b"}, {"pattern": "c"}, {"pattern": "d"}, {"pattern": "e"}], json_list
@@ -73,7 +72,7 @@ class TestAutoQueueHandler(BaseTestWebApp):
         self.assertEqual(200, resp.status_int)
         resp = self.test_app.get("/server/autoqueue/add/one", expect_errors=True)
         self.assertEqual(400, resp.status_int)
-        self.assertEqual("Auto-queue pattern 'one' already exists.", str(resp.html))
+        self.assertEqual("Auto-queue pattern 'one' already exists.", resp.text)
 
     def test_add_empty_value(self):
         uri = quote(quote("  ", safe=""), safe="")
@@ -124,13 +123,13 @@ class TestAutoQueueHandler(BaseTestWebApp):
     def test_remove_non_existing(self):
         resp = self.test_app.get("/server/autoqueue/remove/one", expect_errors=True)
         self.assertEqual(400, resp.status_int)
-        self.assertEqual("Auto-queue pattern 'one' doesn't exist.", str(resp.html))
+        self.assertEqual("Auto-queue pattern 'one' doesn't exist.", resp.text)
 
     def test_remove_empty_value(self):
         uri = quote(quote("  ", safe=""), safe="")
         resp = self.test_app.get("/server/autoqueue/remove/" + uri, expect_errors=True)
         self.assertEqual(400, resp.status_int)
-        self.assertEqual("Auto-queue pattern '  ' doesn't exist.", str(resp.html))
+        self.assertEqual("Auto-queue pattern '  ' doesn't exist.", resp.text)
         self.assertEqual(0, len(self.auto_queue_persist.patterns))
 
         resp = self.test_app.get("/server/autoqueue/remove/", expect_errors=True)

--- a/src/python/tests/integration/test_web/test_handler/test_stream_log.py
+++ b/src/python/tests/integration/test_web/test_handler/test_stream_log.py
@@ -11,7 +11,7 @@ class TestLogStreamHandler(BaseTestWebApp):
     @patch("web.handler.stream_log.SerializeLogRecord")
     def test_stream_log_serializes_record(self, mock_serialize_log_record_cls):
         # Schedule server stop
-        Timer(0.5, self.web_app.stop).start()
+        Timer(2.0, self.web_app.stop).start()
 
         # Schedule status update
         def issue_logs():

--- a/src/python/tests/integration/test_web/test_handler/test_stream_model.py
+++ b/src/python/tests/integration/test_web/test_handler/test_stream_model.py
@@ -12,14 +12,14 @@ from web.serialize import SerializeModel
 class TestModelStreamHandler(BaseTestWebApp):
     def test_stream_model_fetches_model_and_adds_listener(self):
         # Schedule server stop
-        Timer(0.5, self.web_app.stop).start()
+        Timer(2.0, self.web_app.stop).start()
 
         self.test_app.get("/server/stream")
         self.controller.get_model_files_and_add_listener.assert_called_once_with(unittest.mock.ANY)
 
     def test_stream_model_removes_listener(self):
         # Schedule server stop
-        Timer(0.5, self.web_app.stop).start()
+        Timer(2.0, self.web_app.stop).start()
 
         self.test_app.get("/server/stream")
         self.controller.remove_model_listener.assert_called_once_with(self.model_listener)
@@ -27,7 +27,7 @@ class TestModelStreamHandler(BaseTestWebApp):
     @patch("web.handler.stream_model.SerializeModel")
     def test_stream_model_serializes_initial_model(self, mock_serialize_model_cls):
         # Schedule server stop
-        Timer(0.5, self.web_app.stop).start()
+        Timer(2.0, self.web_app.stop).start()
 
         # Setup mock serialize instance
         mock_serialize = mock_serialize_model_cls.return_value

--- a/src/python/tests/integration/test_web/test_handler/test_stream_status.py
+++ b/src/python/tests/integration/test_web/test_handler/test_stream_status.py
@@ -10,7 +10,7 @@ class TestStatusStreamHandler(BaseTestWebApp):
     @patch("web.handler.stream_status.SerializeStatus")
     def test_stream_status_serializes_initial_status(self, mock_serialize_status_cls):
         # Schedule server stop
-        Timer(0.5, self.web_app.stop).start()
+        Timer(2.0, self.web_app.stop).start()
 
         # Setup mock serialize instance
         mock_serialize = mock_serialize_status_cls.return_value
@@ -26,7 +26,7 @@ class TestStatusStreamHandler(BaseTestWebApp):
     @patch("web.handler.stream_status.SerializeStatus")
     def test_stream_status_serializes_new_status(self, mock_serialize_status_cls):
         # Schedule server stop
-        Timer(0.5, self.web_app.stop).start()
+        Timer(2.0, self.web_app.stop).start()
 
         # Schedule status update
         def update_status():


### PR DESCRIPTION
## Summary
- Add new CI job `Python Integration Tests` that runs `tests/integration/test_web` (web handler integration tests using webtest.TestApp)
- These tests were previously only runnable locally via `make test` — now they run on every PR
- Gate the publish job on this new job passing
- Excludes heavier integration tests (test_lftp, test_controller) that require real lftp/SSH

## Test plan
- [ ] New `Python Integration Tests` job appears in CI and passes
- [ ] Existing jobs unaffected
- [ ] Publish job correctly depends on the new job

🤖 Generated with [Claude Code](https://claude.com/claude-code)