### PR TITLE
Cache Playwright browsers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,12 +243,29 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: src/e2e-playwright/package-lock.json
 
-      - name: Install Playwright
+      - name: Install Playwright dependencies
         working-directory: src/e2e-playwright
-        run: |
-          npm install
-          npx playwright install --with-deps chromium
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('src/e2e-playwright/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: src/e2e-playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+        working-directory: src/e2e-playwright
 
       - name: Run E2E tests
         working-directory: src/e2e-playwright


### PR DESCRIPTION
## Summary
- Cache Playwright browser binaries (~150 MB) between CI runs using `actions/cache`
- Cache npm deps via `setup-node` cache option
- Use `npm ci` instead of `npm install` for deterministic installs
- On cache hit, skip browser download and only install system deps (apt packages)
- Cache key includes `package-lock.json` hash so it invalidates on Playwright version bumps

## Test plan
- [ ] First run: cache miss, full install (same speed as before)
- [ ] Second run: cache hit, skips browser download (faster)
- [ ] E2E tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)