### PR TITLE
Track Playwright package-lock.json so CI cache step resolves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 package-lock.json
 !src/angular/package-lock.json
 !website/package-lock.json
+!src/e2e-playwright/package-lock.json
 src/python/build
 src/python/site
 dev-config/

--- a/src/e2e-playwright/package-lock.json
+++ b/src/e2e-playwright/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "seedsync-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "seedsync-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `!src/e2e-playwright/package-lock.json` to root `.gitignore` (the existing `package-lock.json` rule was filtering it out, alongside angular and website allow-list entries)
- Commit the generated lockfile so `actions/setup-node`'s `cache-dependency-path` resolves and `npm ci` has something to install from

## Why
Playwright caching landed in #452, but the workflow references `src/e2e-playwright/package-lock.json` and that file was being silently filtered by `.gitignore`. CI on `develop` (and any new PR against it) fails at the **Set up Node.js** step with:

```
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

`npm ci` on the next line would also have failed without a lockfile. Adding the allow-list entry plus the lockfile unblocks the cache step and the subsequent install.

## Test plan
- [ ] CI on this PR passes the **Set up Node.js**, **Install Playwright dependencies**, **Cache Playwright browsers**, **Install Playwright browsers**, and **Run E2E tests** steps
- [ ] On a re-run, the Playwright browser cache step reports a hit (`Cache hit for ...`) and `Install Playwright browsers` is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)