### PR TITLE
Warm Playwright cache on develop and bump workers to 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,37 +239,17 @@ jobs:
           done
           docker logs test-container
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: src/e2e-playwright/package-lock.json
-
-      - name: Install Playwright dependencies
-        working-directory: src/e2e-playwright
-        run: npm ci
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('src/e2e-playwright/package-lock.json') }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        working-directory: src/e2e-playwright
-        run: npx playwright install --with-deps chromium
-
-      - name: Install Playwright system deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
-        working-directory: src/e2e-playwright
-
-      - name: Run E2E tests
-        working-directory: src/e2e-playwright
-        run: npx playwright test
+      - name: Run E2E tests in Playwright container
+        run: |
+          # Match the @playwright/test version pinned in the lockfile so the
+          # container's chromium build is the one the package expects.
+          PW_VERSION=$(jq -r '.packages["node_modules/@playwright/test"].version' src/e2e-playwright/package-lock.json)
+          docker run --rm \
+            --network host \
+            -v "$GITHUB_WORKSPACE":/workspace \
+            -w /workspace/src/e2e-playwright \
+            "mcr.microsoft.com/playwright:v${PW_VERSION}-noble" \
+            sh -c "npm ci && npx playwright test"
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
 
   build-test:
     name: Build and Test (amd64)
-    if: ${{ !(startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop' && github.event_name == 'push') || github.event_name == 'workflow_dispatch') }}
+    if: ${{ !(startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/src/e2e-playwright/playwright.config.ts
+++ b/src/e2e-playwright/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 5_000 },
   fullyParallel: false, // tests share a Docker container per file
-  workers: 5,
+  workers: 10,
   retries: 0,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {

--- a/src/e2e-playwright/playwright.config.ts
+++ b/src/e2e-playwright/playwright.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 5_000 },
   fullyParallel: false, // tests share a Docker container per file
-  workers: 10,
+  // ubuntu-latest has 4 vCPUs and we run a chromium per worker plus the
+  // SeedSync Docker container, so > 4 workers oversubscribes CPU and
+  // slows the suite overall.
+  workers: 4,
   retries: 0,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {

--- a/src/e2e-playwright/playwright.config.ts
+++ b/src/e2e-playwright/playwright.config.ts
@@ -6,9 +6,9 @@ export default defineConfig({
   expect: { timeout: 5_000 },
   fullyParallel: false, // tests share a Docker container per file
   // ubuntu-latest has 4 vCPUs. Each worker runs its own chromium against
-  // the shared SeedSync Docker container, so we leave one core for the
-  // container + runner overhead and cap workers at 3.
-  workers: 3,
+  // the shared SeedSync Docker container, so we leave headroom for the
+  // SUT + Playwright container + runner overhead.
+  workers: 2,
   retries: 0,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {

--- a/src/e2e-playwright/playwright.config.ts
+++ b/src/e2e-playwright/playwright.config.ts
@@ -5,10 +5,10 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 5_000 },
   fullyParallel: false, // tests share a Docker container per file
-  // ubuntu-latest has 4 vCPUs and we run a chromium per worker plus the
-  // SeedSync Docker container, so > 4 workers oversubscribes CPU and
-  // slows the suite overall.
-  workers: 4,
+  // ubuntu-latest has 4 vCPUs. Each worker runs its own chromium against
+  // the shared SeedSync Docker container, so we leave one core for the
+  // container + runner overhead and cap workers at 3.
+  workers: 3,
   retries: 0,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {

--- a/src/e2e-playwright/playwright.config.ts
+++ b/src/e2e-playwright/playwright.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 5_000 },
   fullyParallel: false, // tests share a Docker container per file
+  workers: 5,
   retries: 0,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {

--- a/src/e2e-playwright/playwright.config.ts
+++ b/src/e2e-playwright/playwright.config.ts
@@ -5,10 +5,11 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 5_000 },
   fullyParallel: false, // tests share a Docker container per file
-  // ubuntu-latest has 4 vCPUs. Each worker runs its own chromium against
-  // the shared SeedSync Docker container, so we leave headroom for the
-  // SUT + Playwright container + runner overhead.
-  workers: 2,
+  // ubuntu-latest has 4 vCPUs. Each worker runs its own chromium and
+  // shares the host's CPU pool with the SeedSync container and runner
+  // overhead — pushing past 4 oversubscribes and makes the suite
+  // slower overall.
+  workers: 4,
   retries: 0,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {

--- a/src/e2e-playwright/tests/path-pairs.spec.ts
+++ b/src/e2e-playwright/tests/path-pairs.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "./fixtures";
 import { PathPairsPage } from "./pages/path-pairs.page";
+import { SettingsPage } from "./pages/settings.page";
 
 test.describe("Path Pairs", () => {
   let pathPairs: PathPairsPage;
@@ -305,5 +306,31 @@ test.describe("Path Pairs", () => {
         { timeout: 5000 }
       )
       .toBe(false);
+  });
+
+  test("Server Directory field on Settings page is disabled when a path pair exists", async ({
+    page,
+    apiFetch,
+  }) => {
+    // Lives in this file (not settings.spec.ts) so it shares the same
+    // beforeEach/afterEach pair cleanup and doesn't race with other specs
+    // running in parallel — pair creation/deletion across files is the
+    // root cause of the cross-file races we saw at workers > 2.
+    const res = await apiFetch("/server/pathpairs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "e2e-server-dir-test",
+        remote_path: "/remote/test",
+        local_path: "/local/test",
+        enabled: true,
+      }),
+    });
+    expect(res.ok).toBe(true);
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    const serverDir = settings.getTextInput("Server Directory");
+    await expect(serverDir).toBeDisabled();
   });
 });

--- a/src/e2e-playwright/tests/settings.spec.ts
+++ b/src/e2e-playwright/tests/settings.spec.ts
@@ -173,37 +173,6 @@ test.describe("Settings Page", () => {
     await expect(options).toHaveCount(7);
   });
 
-  test("Server Directory field is disabled when path pairs exist", async ({
-    apiFetch,
-  }) => {
-    // Create a path pair via API
-    const pairName = `temp-pair-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const res = await apiFetch("/server/pathpairs", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        name: pairName,
-        remote_path: "/remote/test",
-        local_path: "/local/test",
-        enabled: true,
-      }),
-    });
-    expect(res.ok).toBe(true);
-    const pair = await res.json();
-
-    try {
-      await settings.goto();
-      const serverDir = settings.getTextInput("Server Directory");
-      await expect(serverDir).toBeDisabled();
-    } finally {
-      // Always clean up the pair
-      if (pair?.id) {
-        const del = await apiFetch(`/server/pathpairs/${pair.id}`, { method: "DELETE" });
-        expect(del.ok, `Failed to delete temp pair ${pair.id}: ${del.status}`).toBe(true);
-      }
-    }
-  });
-
   test("restart notification appears after config change", async ({ apiGet, apiSetConfig }) => {
     const configBefore = await apiGet("/server/config/get");
     const originalAddress = configBefore.lftp.remote_address;


### PR DESCRIPTION
## Summary
- Drop the develop-push skip on `Build and Test (amd64)` so it actually runs on merges to develop
- Set `workers: 5` in `playwright.config.ts` (was defaulting to ~2 on the 4-vCPU runner)

## Why — cache warming
The current `if:` skips Build and Test on `push` to `develop`. Combined with `actions/cache@v4`'s default branch-scoped storage, this means develop never has a populated Playwright browser cache:

1. PR runs → cache miss (no parent cache exists) → installs browsers + system deps → tests pass → cache saves under the **PR branch's scope only**
2. PR merges → develop push **skips** Build and Test → develop's cache stays empty
3. Next PR opens → looks for cache on its own branch (empty, fresh PR) and on develop (empty) → cache miss, full install again

GitHub Actions caches inherit from the parent branch, not from sibling PRs. So as long as develop never populates, every fresh PR pays the install cost (~2 min for browsers + ~1 min apt deps when the network cooperates, or 11+ minutes when an Ubuntu mirror flakes).

Letting the job run once on each develop push gives every subsequent PR a cache hit. With cache warm the job runs in ~2-3 min total — a small price for shared cache benefit.

## Why — workers
With `fullyParallel: false` and no explicit `workers` setting, Playwright defaults to roughly half the available CPUs in CI — 2 on a 4-vCPU runner. Bumping to 5 lets up to 5 spec files run in parallel. Within each file tests still run serially (since `fullyParallel: false` is preserved).

## Risks / things to watch
- Multiple workers hit the **same shared Docker container**, so spec files that mutate global config (settings, path-pairs, integrations) can race against each other. If we see new flakes after this lands, the answer is either to drop workers back to 3, or to add per-file isolation (separate containers, or a fixture that snapshots/restores config).
- The first develop push after this merges will be a slower run (~10 min, full cold install). Subsequent PRs will see cache hits.

## Test plan
- [ ] CI on this PR's first run is a cache miss (no develop cache yet) — completes successfully and saves the PR-branch cache
- [ ] After merge, the develop push runs Build and Test (amd64) and saves the develop-scoped cache
- [ ] The next PR after that shows `Cache hit for ...` on the **Cache Playwright browsers** step and skips browser install
- [ ] `Run E2E tests` reports up to 5 workers active (visible in the test list output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to run build tests when pushing to the develop branch.
  * Enabled parallel test execution with 10 concurrent workers for improved test performance.
  * Reorganized end-to-end test suite for enhanced validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->