### PR TITLE
Address round-2 CodeRabbit test-quality findings

### DIFF
--- a/src/e2e-playwright/tests/integrations.spec.ts
+++ b/src/e2e-playwright/tests/integrations.spec.ts
@@ -1,6 +1,14 @@
 import { test, expect } from "./fixtures";
 import { IntegrationsPage } from "./pages/integrations.page";
 
+// Wrap a fixture-setup API call so failures surface as "fixture creation
+// failed" instead of cascading into confusing UI assertion failures.
+async function expectFixtureOk(res: Response, label: string): Promise<void> {
+  if (!res.ok) {
+    throw new Error(`fixture creation failed: ${label} → ${res.status} ${res.statusText}`);
+  }
+}
+
 test.describe("Integrations CRUD", () => {
   let integrations: IntegrationsPage;
 
@@ -129,7 +137,7 @@ test.describe("Integrations CRUD", () => {
     apiFetch,
   }) => {
     // Create an integration via API
-    await apiFetch("/server/integrations", {
+    const created = await apiFetch("/server/integrations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -140,6 +148,7 @@ test.describe("Integrations CRUD", () => {
         enabled: true,
       }),
     });
+    await expectFixtureOk(created, 'POST /server/integrations (Edit Me)');
 
     await integrations.goto();
 
@@ -184,7 +193,7 @@ test.describe("Integrations CRUD", () => {
     apiFetch,
   }) => {
     // Create an integration via API
-    await apiFetch("/server/integrations", {
+    const created = await apiFetch("/server/integrations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -195,6 +204,7 @@ test.describe("Integrations CRUD", () => {
         enabled: true,
       }),
     });
+    await expectFixtureOk(created, 'POST /server/integrations (Confirm Delete)');
 
     await integrations.goto();
 
@@ -212,7 +222,7 @@ test.describe("Integrations CRUD", () => {
     apiFetch,
   }) => {
     // Create an integration via API
-    await apiFetch("/server/integrations", {
+    const created = await apiFetch("/server/integrations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -223,6 +233,7 @@ test.describe("Integrations CRUD", () => {
         enabled: true,
       }),
     });
+    await expectFixtureOk(created, 'POST /server/integrations (Delete Me)');
 
     await integrations.goto();
 
@@ -258,7 +269,7 @@ test.describe("Integrations CRUD", () => {
 
   test("Test Connection button shows result", async ({ apiFetch }) => {
     // Create an integration with a URL that will likely fail connection
-    await apiFetch("/server/integrations", {
+    const created = await apiFetch("/server/integrations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -269,6 +280,7 @@ test.describe("Integrations CRUD", () => {
         enabled: true,
       }),
     });
+    await expectFixtureOk(created, 'POST /server/integrations (Test Conn)');
 
     await integrations.goto();
 
@@ -289,7 +301,7 @@ test.describe("Integrations CRUD", () => {
 
   test("enable/disable toggle updates via API", async ({ apiFetch }) => {
     // Create an enabled integration
-    await apiFetch("/server/integrations", {
+    const created = await apiFetch("/server/integrations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -300,6 +312,7 @@ test.describe("Integrations CRUD", () => {
         enabled: true,
       }),
     });
+    await expectFixtureOk(created, 'POST /server/integrations (Toggle Me)');
 
     await integrations.goto();
 
@@ -345,9 +358,14 @@ test.describe("Integrations CRUD", () => {
     // Form should close
     await expect(integrations.instanceForm).not.toBeVisible();
 
-    // Verify nothing was created
+    // Verify nothing was created. Fail loudly if the GET itself fails so
+    // we don't get a false-positive (an empty list always satisfies the
+    // "Should Not Exist" check).
     const res = await apiFetch("/server/integrations");
-    const instances = res.ok ? await res.json() : [];
+    if (!res.ok) {
+      throw new Error(`GET /server/integrations failed: ${res.status} ${res.statusText}`);
+    }
+    const instances = await res.json();
     expect(
       instances.find((i: { name: string }) => i.name === "Should Not Exist")
     ).toBeUndefined();

--- a/src/e2e-playwright/tests/settings.spec.ts
+++ b/src/e2e-playwright/tests/settings.spec.ts
@@ -470,6 +470,10 @@ test.describe("Settings — Logging", () => {
     const originalLevel = configBefore.general.log_level;
 
     const select = settings.getSelect("Log Level");
+    // Wait for the SSE config delivery to populate the model before
+    // interacting with the select — same pattern as the Hash Algorithm
+    // test. settings.goto() only waits for Angular bootstrap, not SSE.
+    await expect(select).toBeEnabled({ timeout: 10_000 });
     const newValue = originalLevel === "DEBUG" ? "WARNING" : "DEBUG";
 
     try {

--- a/src/python/tests/unittests/test_common/test_context.py
+++ b/src/python/tests/unittests/test_common/test_context.py
@@ -73,7 +73,9 @@ class TestPrintToLog(unittest.TestCase):
         pair.name = "TestPair"
         pair.enabled = True
         pair.auto_queue = True
-        ppc._pairs = [pair]
+        # Use the public property setter so PathPairsConfig's lock is
+        # acquired, instead of touching the private _pairs attribute.
+        ppc.pairs = [pair]
         ctx.path_pairs_config = ppc
 
         with self.assertLogs("test_context", level="DEBUG") as log_ctx:

--- a/src/python/tests/unittests/test_controller/test_scan/test_active_scanner.py
+++ b/src/python/tests/unittests/test_controller/test_scan/test_active_scanner.py
@@ -27,7 +27,6 @@ class TestActiveScanner(unittest.TestCase):
         self.addCleanup(scanner.close)
         result = scanner.scan()
         self.assertEqual(result, [])
-        scanner.close()
 
     @patch("controller.scan.active_scanner.SystemScanner")
     def test_scan_returns_files_after_set_active(self, mock_scanner_cls):
@@ -48,7 +47,6 @@ class TestActiveScanner(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].name, "fileA")
         self.assertEqual(result[1].name, "fileB")
-        scanner.close()
 
     @patch("controller.scan.active_scanner.SystemScanner")
     def test_latest_list_wins_when_multiple_set_before_scan(self, mock_scanner_cls):
@@ -67,7 +65,6 @@ class TestActiveScanner(unittest.TestCase):
         # Only the latest list should be used
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].name, "fileC")
-        scanner.close()
 
     @patch("controller.scan.active_scanner.SystemScanner")
     def test_missing_file_logged_at_debug(self, mock_scanner_cls):
@@ -85,7 +82,6 @@ class TestActiveScanner(unittest.TestCase):
 
         self.assertEqual(result, [])
         self.assertTrue(any("does not exist" in msg for msg in log_ctx.output))
-        scanner.close()
 
     @patch("controller.scan.active_scanner.SystemScanner")
     def test_unexpected_error_logged_at_warning(self, mock_scanner_cls):
@@ -103,7 +99,6 @@ class TestActiveScanner(unittest.TestCase):
 
         self.assertEqual(result, [])
         self.assertTrue(any("Unexpected scan error" in msg for msg in log_ctx.output))
-        scanner.close()
 
     @patch("controller.scan.active_scanner.SystemScanner")
     def test_set_base_logger(self, mock_scanner_cls):
@@ -113,7 +108,6 @@ class TestActiveScanner(unittest.TestCase):
         parent_logger = logging.getLogger("parent")
         scanner.set_base_logger(parent_logger)
         self.assertEqual(scanner.logger.name, "parent.ActiveScanner")
-        scanner.close()
 
     @patch("controller.scan.active_scanner.SystemScanner")
     def test_lftp_temp_suffix_forwarded(self, mock_scanner_cls):

--- a/src/python/tests/unittests/test_web/test_web_app_job.py
+++ b/src/python/tests/unittests/test_web/test_web_app_job.py
@@ -111,9 +111,7 @@ class TestRequestLoggingMiddleware(unittest.TestCase):
         self.assertEqual(result, [b"ok"])
         # Some log line should contain method, path, and status. Don't index
         # log_ctx.output[0] — other loggers might emit lines first under load.
-        self.assertTrue(
-            any("GET" in o and "/test/path" in o and "200" in o for o in log_ctx.output)
-        )
+        self.assertTrue(any("GET" in o and "/test/path" in o and "200" in o for o in log_ctx.output))
 
     def test_logs_even_on_app_error(self):
         """Duration is logged even when the app raises."""

--- a/src/python/tests/unittests/test_web/test_web_app_job.py
+++ b/src/python/tests/unittests/test_web/test_web_app_job.py
@@ -102,20 +102,18 @@ class TestRequestLoggingMiddleware(unittest.TestCase):
             "PATH_INFO": "/test/path",
         }
 
-        captured_status = {}
-
         def start_response(status, headers, *args):
-            captured_status["status"] = status
+            pass
 
         with self.assertLogs("test_request_logging", level="DEBUG") as log_ctx:
             result = list(middleware(environ, start_response))
 
         self.assertEqual(result, [b"ok"])
-        # Verify log message contains method, path, and status code
-        log_output = log_ctx.output[0]
-        self.assertIn("GET", log_output)
-        self.assertIn("/test/path", log_output)
-        self.assertIn("200", log_output)
+        # Some log line should contain method, path, and status. Don't index
+        # log_ctx.output[0] — other loggers might emit lines first under load.
+        self.assertTrue(
+            any("GET" in o and "/test/path" in o and "200" in o for o in log_ctx.output)
+        )
 
     def test_logs_even_on_app_error(self):
         """Duration is logged even when the app raises."""


### PR DESCRIPTION
Second round of CodeRabbit findings on PR #467 (develop → master). All 7 findings verified against current code; all valid; all fixed. Test-only — production findings remain tracked in #469.

## Acted on (7 of 7)

| # | File | Change |
|---|---|---|
| 1 | `integrations.spec.ts:349-353` | GET on the \"should not exist\" assertion now fails fast on `!res.ok` instead of returning `[]` (which would always satisfy the \"not found\" check, masking real failures) |
| 2 | `integrations.spec.ts` (5 sites) | Capture each POST-fixture response and pass it to a small `expectFixtureOk` helper so 4xx/5xx surfaces as `\"fixture creation failed: …\"` instead of cascading into a confusing UI assertion failure |
| 3 | `settings.spec.ts:472-498` | Log Level select-change test waits for `toBeEnabled({ timeout: 10_000 })` before calling `selectOption` — same SSE-delivery race the Hash Algorithm test had |
| 4 | `test_context.py:71-77` | Use `ppc.pairs = [pair]` (public property setter, acquires the internal lock) instead of touching `ppc._pairs` directly |
| 5 | `test_active_scanner.py` (6 sites) | Drop the redundant trailing `scanner.close()` calls now that `addCleanup` handles the close path. One cleanup mechanism instead of two. |
| 6 | `test_web_app_job.py:105-118` | Drop the unused `captured_status` dict from the WSGI middleware logging test; simplify `start_response` to a no-op |
| 7 | `test_web_app_job.py:114-118` | Replace `log_ctx.output[0]` indexing with `any(...)` over all captured lines so other loggers emitting first don't break the test |

## Validation
- All Python files parse via `python3 -m py_compile`
- TS diagnostics show only pre-existing issues (unused `page` param at unrelated line, WSGI `start_response` typing for unrelated middleware test paths)
- CI on this PR will run the full Vitest + pytest + Playwright suites against the rebuilt image

## What this is *not*
The 4 production-code findings tracked in #469 (handler error handling and persistence ordering) are still deferred to their own PRs — same rationale as last round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)