### PR TITLE
Pin Python builder to alpine3.23 to match runtime stage

### DIFF
--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -14,7 +14,12 @@ RUN npx ng build --configuration=production --output-path /build
 # ==============================================================================
 # Stage 2: Prepare Python runtime (install deps, strip stdlib)
 # ==============================================================================
-FROM python:3.13-alpine AS python-deps
+# Pin to the same Alpine minor as the runtime stage (FROM alpine:3.23
+# below) so Python + C extensions in site-packages are compiled against
+# the same musl ABI they'll run on. The floating "python:3.13-alpine"
+# tag could otherwise resolve to a newer Alpine and silently introduce
+# a musl mismatch when /usr/local is copied into the runtime stage.
+FROM python:3.13-alpine3.23 AS python-deps
 
 COPY src/python/pyproject.toml src/python/uv.lock /tmp/
 RUN --mount=from=ghcr.io/astral-sh/uv:0.11,source=/uv,target=/tmp/uv \


### PR DESCRIPTION
Re-evaluating a finding I previously skipped from CodeRabbit's review of #467 — turns out it's a real correctness issue, not just a reproducibility nit, so worth fixing now rather than waiting for a separate hardening PR.

## Context
`src/docker/build/docker-image/Dockerfile` has three stages:
1. `FROM node:22-alpine` — Angular build (output copied as static assets, no ABI concern)
2. `FROM python:3.13-alpine AS python-deps` — installs Python + dependencies
3. `FROM alpine:3.23 AS runtime` — copies `/usr/local/` verbatim from stage 2

Stage 3 line 83: `COPY --from=python-deps /usr/local/ /usr/local/`

That copies the Python interpreter binary + every C extension in site-packages from a builder compiled against whatever Alpine `python:3.13-alpine` resolves to today, into a runtime that's pinned to Alpine 3.23.

## The risk
If the floating `python:3.13-alpine` tag ever resolves to a newer Alpine (3.24+), the Python binary and any C extensions in site-packages were compiled against the newer Alpine's musl. They then execute against alpine:3.23's older musl at runtime. musl is mostly backwards-compatible but the ABI isn't formally stable across minor versions — this is a real silent-runtime-failure hazard, not just a reproducibility concern.

## The fix
Pin the builder to `python:3.13-alpine3.23` so both stages use the same Alpine minor.

Tag verified to exist on Docker Hub via `docker manifest inspect python:3.13-alpine3.23`.

## Validation
- CI on this PR runs the full Docker build + E2E suite, which exercises Python imports against the runtime — any musl ABI breakage would surface there
- Image build itself fails fast if the tag doesn't exist (it does)

🤖 Generated with [Claude Code](https://claude.com/claude-code)