### PR TITLE
Fix Discord webhook 403 by setting explicit User-Agent

### DIFF
--- a/src/python/controller/notification_formatters.py
+++ b/src/python/controller/notification_formatters.py
@@ -53,7 +53,12 @@ def format_discord(
     if fields:
         embed["fields"] = fields
     payload = {"embeds": [embed]}
-    headers = {"Content-Type": "application/json"}
+    # Discord returns 403 Forbidden for requests with Python's default
+    # "Python-urllib/x.y" User-Agent. Identify ourselves explicitly. (#483)
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "seedsync (https://github.com/nitrobass24/seedsync)",
+    }
     return headers, json.dumps(payload).encode("utf-8")
 
 

--- a/src/python/tests/unittests/test_controller/test_notification_formatters.py
+++ b/src/python/tests/unittests/test_controller/test_notification_formatters.py
@@ -14,6 +14,15 @@ class TestFormatDiscord(unittest.TestCase):
         headers, _ = format_discord("download_complete", "file.mkv")
         self.assertEqual("application/json", headers["Content-Type"])
 
+    def test_sets_non_default_user_agent(self):
+        """Discord returns 403 to requests with Python's default urllib UA, so
+        format_discord must supply its own. Regression test for #483."""
+        headers, _ = format_discord("download_complete", "file.mkv")
+        self.assertIn("User-Agent", headers)
+        ua = headers["User-Agent"]
+        self.assertNotIn("Python-urllib", ua)
+        self.assertIn("seedsync", ua.lower())
+
     def test_body_is_valid_json(self):
         _, body = format_discord("download_complete", "file.mkv")
         payload = json.loads(body)


### PR DESCRIPTION
## Summary

- Discord returns 403 Forbidden for HTTP requests carrying Python's default \`Python-urllib/x.y\` User-Agent — a long-standing, undocumented-but-well-known block on their CDN.
- \`format_discord\` only set \`Content-Type\`, so urllib filled in its default UA. Telegram and the generic webhook path worked because their endpoints don't filter on UA, which matches the symptom in #483.
- Fix: add an explicit \`User-Agent: seedsync (https://github.com/nitrobass24/seedsync)\` header. The same headers dict is reused by the test endpoint and the live \`WebhookNotifier\` so this covers every Discord send path.

Closes #483.

## Test plan

- [x] \`cd src/python && PYTHONPATH=. python3 -m pytest tests/unittests/test_controller/test_notification_formatters.py\` — 14 passed, including the new regression test that asserts the header is present and not the urllib default.
- [x] \`ruff format --check\`, \`ruff check\`, \`pyright\` — clean.
- [ ] Smoke test in Docker: configure a Discord webhook URL, click Test in Settings, confirm the embed posts to Discord (was 403 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Discord webhook notifications now include a project-identifying User-Agent header.

* **Tests**
  * Added test to verify User-Agent header is correctly configured for Discord webhooks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nitrobass24/seedsync/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->