### PR TITLE
Add notify_on_download_start option (#486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Notify on download start** — New `notify_on_download_start` option (disabled by default) emits a `download_start` event when a file enters the `DOWNLOADING` state. Fires through the existing webhook, Discord, and Telegram channels, with a yellow Discord embed color and "Download Started" label. (#486)
+
 ## [0.18.1] - 2026-05-16
 
 ### Fixed

--- a/src/angular/src/app/models/config.ts
+++ b/src/angular/src/app/models/config.ts
@@ -62,6 +62,7 @@ export interface Logging {
 
 export interface Notifications {
   webhook_url: string | null;
+  notify_on_download_start: boolean | null;
   notify_on_download_complete: boolean | null;
   notify_on_extraction_complete: boolean | null;
   notify_on_extraction_failed: boolean | null;
@@ -151,6 +152,7 @@ export const DEFAULT_LOGGING: Logging = {
 
 export const DEFAULT_NOTIFICATIONS: Notifications = {
   webhook_url: null,
+  notify_on_download_start: null,
   notify_on_download_complete: null,
   notify_on_extraction_complete: null,
   notify_on_extraction_failed: null,

--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -366,6 +366,12 @@ export const OPTIONS_CONTEXT_NOTIFICATIONS: IOptionsContext = {
     },
     {
       type: OptionType.Checkbox,
+      label: 'Notify on download start',
+      valuePath: ['notifications', 'notify_on_download_start'],
+      description: null,
+    },
+    {
+      type: OptionType.Checkbox,
       label: 'Notify on download complete',
       valuePath: ['notifications', 'notify_on_download_complete'],
       description: null,

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -56,6 +56,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     logging: { log_format: null },
     notifications: {
       webhook_url: null,
+      notify_on_download_start: false,
       notify_on_download_complete: false,
       notify_on_extraction_complete: false,
       notify_on_extraction_failed: false,

--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -366,6 +366,7 @@ class Config(Persist):
 
     class Notifications(IC):
         webhook_url = PROP("webhook_url", Checkers.string_allow_empty, Converters.null)
+        notify_on_download_start = PROP("notify_on_download_start", Checkers.null, Converters.bool)
         notify_on_download_complete = PROP("notify_on_download_complete", Checkers.null, Converters.bool)
         notify_on_extraction_complete = PROP("notify_on_extraction_complete", Checkers.null, Converters.bool)
         notify_on_extraction_failed = PROP("notify_on_extraction_failed", Checkers.null, Converters.bool)
@@ -377,6 +378,7 @@ class Config(Persist):
         def __init__(self):
             super().__init__()
             self.webhook_url = ""
+            self.notify_on_download_start = False
             self.notify_on_download_complete = True
             self.notify_on_extraction_complete = True
             self.notify_on_extraction_failed = True

--- a/src/python/controller/notification_formatters.py
+++ b/src/python/controller/notification_formatters.py
@@ -8,6 +8,7 @@ import json
 from datetime import UTC, datetime
 
 EVENT_LABELS: dict[str, str] = {
+    "download_start": "Download Started",
     "download_complete": "Download Complete",
     "extraction_complete": "Extraction Complete",
     "extraction_failed": "Extraction Failed",
@@ -16,6 +17,7 @@ EVENT_LABELS: dict[str, str] = {
 }
 
 DISCORD_COLORS: dict[str, int] = {
+    "download_start": 0xFEE75C,  # yellow
     "download_complete": 0x57F287,  # green
     "extraction_complete": 0x5865F2,  # blurple
     "extraction_failed": 0xED4245,  # red

--- a/src/python/controller/notifier.py
+++ b/src/python/controller/notifier.py
@@ -48,6 +48,8 @@ class WebhookNotifier(IModelListener):
     def _resolve_event_type(self, state: ModelFile.State) -> str | None:
         """Map a file state to an event type string, gated by config flags."""
         notif = self._config.notifications
+        if state == ModelFile.State.DOWNLOADING and notif.notify_on_download_start:
+            return "download_start"
         if state == ModelFile.State.DOWNLOADED and notif.notify_on_download_complete:
             return "download_complete"
         if state == ModelFile.State.EXTRACTED and notif.notify_on_extraction_complete:

--- a/src/python/tests/unittests/test_common/test_config.py
+++ b/src/python/tests/unittests/test_common/test_config.py
@@ -665,6 +665,7 @@ class TestConfig(unittest.TestCase):
 
         [Notifications]
         webhook_url =
+        notify_on_download_start = False
         notify_on_download_complete = True
         notify_on_extraction_complete = True
         notify_on_extraction_failed = True

--- a/src/python/tests/unittests/test_controller/test_notification_formatters.py
+++ b/src/python/tests/unittests/test_controller/test_notification_formatters.py
@@ -56,6 +56,10 @@ class TestFormatDiscord(unittest.TestCase):
         embed = json.loads(body)["embeds"][0]
         self.assertIn("custom_event", embed["title"])
 
+    def test_download_start_has_label_and_color(self):
+        self.assertEqual("Download Started", EVENT_LABELS["download_start"])
+        self.assertEqual(0xFEE75C, DISCORD_COLORS["download_start"])
+
 
 class TestFormatTelegram(unittest.TestCase):
     def test_url_contains_bot_token(self):

--- a/src/python/tests/unittests/test_controller/test_notifier.py
+++ b/src/python/tests/unittests/test_controller/test_notifier.py
@@ -20,6 +20,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
     ):
         config = MagicMock()
         config.notifications.webhook_url = webhook_url
+        config.notifications.notify_on_download_start = False
         config.notifications.notify_on_download_complete = True
         config.notifications.notify_on_extraction_complete = True
         config.notifications.notify_on_extraction_failed = True
@@ -166,6 +167,7 @@ class TestWebhookNotifierDispatch(unittest.TestCase):
     ):
         config = MagicMock()
         config.notifications.webhook_url = webhook_url
+        config.notifications.notify_on_download_start = False
         config.notifications.notify_on_download_complete = True
         config.notifications.notify_on_extraction_complete = True
         config.notifications.notify_on_extraction_failed = True
@@ -254,6 +256,60 @@ class TestWebhookNotifierDispatch(unittest.TestCase):
         notifier = self._make_notifier()
         with patch.object(notifier, "_fire_raw") as mock:
             self._trigger(notifier)
+            notifier.shutdown(timeout=1)
+            mock.assert_not_called()
+
+
+class TestWebhookNotifierDownloadStart(unittest.TestCase):
+    """Tests for the download_start event (state → DOWNLOADING)."""
+
+    def _make_config(self, **flags):
+        config = MagicMock()
+        config.notifications.webhook_url = "http://hook.test"
+        config.notifications.notify_on_download_start = flags.get("notify_on_download_start", True)
+        config.notifications.notify_on_download_complete = True
+        config.notifications.notify_on_extraction_complete = True
+        config.notifications.notify_on_extraction_failed = True
+        config.notifications.notify_on_delete_complete = True
+        config.notifications.discord_webhook_url = ""
+        config.notifications.telegram_bot_token = ""
+        config.notifications.telegram_chat_id = ""
+        return config
+
+    def _make_notifier(self, **flags):
+        return WebhookNotifier(self._make_config(**flags), logging.getLogger("test_download_start"))
+
+    def _transition(self, from_state, to_state):
+        old = ModelFile("test.mkv", False)
+        old.state = from_state
+        new = ModelFile("test.mkv", False)
+        new.state = to_state
+        return old, new
+
+    def test_default_to_downloading_fires_when_enabled(self):
+        notifier = self._make_notifier(notify_on_download_start=True)
+        old, new = self._transition(ModelFile.State.DEFAULT, ModelFile.State.DOWNLOADING)
+        with patch.object(notifier, "_fire_raw") as mock:
+            notifier.file_updated(old, new)
+            notifier.shutdown(timeout=1)
+            mock.assert_called_once()
+            # Payload body carries event_type
+            body = mock.call_args[0][3]
+            self.assertIn(b'"event_type": "download_start"', body)
+
+    def test_queued_to_downloading_fires_when_enabled(self):
+        notifier = self._make_notifier(notify_on_download_start=True)
+        old, new = self._transition(ModelFile.State.QUEUED, ModelFile.State.DOWNLOADING)
+        with patch.object(notifier, "_fire_raw") as mock:
+            notifier.file_updated(old, new)
+            notifier.shutdown(timeout=1)
+            mock.assert_called_once()
+
+    def test_does_not_fire_when_disabled(self):
+        notifier = self._make_notifier(notify_on_download_start=False)
+        old, new = self._transition(ModelFile.State.DEFAULT, ModelFile.State.DOWNLOADING)
+        with patch.object(notifier, "_fire_raw") as mock:
+            notifier.file_updated(old, new)
             notifier.shutdown(timeout=1)
             mock.assert_not_called()
 


### PR DESCRIPTION
## Summary
- Adds a new `notify_on_download_start` notifications flag (default `False`) that emits a `download_start` event when a file transitions into `DOWNLOADING`.
- Fires through the existing webhook, Discord, and Telegram channels — no new transport code; just a new branch in `WebhookNotifier._resolve_event_type` plus label/color entries in `notification_formatters.py`.
- Settings UI gains a new "Notify on download start" checkbox under Notifications.

Closes #486.

## Why default `False`?
Downloads start far more often than they complete (one per file vs. one per completed batch in some workflows). Opt-in keeps existing installs from suddenly being noisier after upgrade.

## Test plan
- [x] `cd src/angular && npx ng lint` — passes
- [x] `cd src/angular && npx ng test` — 413 tests pass, including the updated `config.service.spec.ts` fixture
- [x] `cd src/python && pytest tests/unittests/test_controller/test_notifier.py tests/unittests/test_controller/test_notification_formatters.py tests/unittests/test_common/test_config.py` — 64 tests pass, including:
  - 3 new tests for `DEFAULT → DOWNLOADING` and `QUEUED → DOWNLOADING` transitions, plus the disabled-flag case
  - Updated `test_to_file` golden config string with the new field
  - Auto-coverage of `download_start` label and color via existing `EVENT_LABELS` / `DISCORD_COLORS` iteration, plus an explicit assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional notifications for download start events. Users can enable "Notify on download start" in settings to receive alerts through webhooks, Discord, and Telegram when downloads begin. Disabled by default with custom Discord formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nitrobass24/seedsync/pull/494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->