### PR TITLE
Roll back config handler on persistence failure (#469.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Notify on download start** — New `notify_on_download_start` option (disabled by default) emits a `download_start` event when a file enters the `DOWNLOADING` state. Fires through the existing webhook, Discord, and Telegram channels, with a yellow Discord embed color and "Download Started" label. (#486)
 
+### Fixed
+
+- **Config handler persistence atomicity** — `/server/config/set` now captures the pre-mutation value, attempts the disk write, and on `OSError` rolls back the in-memory state and returns a structured HTTP 500 instead of letting the exception bubble up as a stack trace. The LFTP hot-reload callback only fires after a successful write, preventing the runtime from being reconfigured to a value that never made it to disk. (#469)
+
 ## [0.18.1] - 2026-05-16
 
 ### Fixed

--- a/src/python/tests/integration/test_web/test_handler/test_config.py
+++ b/src/python/tests/integration/test_web/test_handler/test_config.py
@@ -136,3 +136,21 @@ class TestConfigHandler(BaseTestWebApp):
         self.assertEqual(200, resp.status_int)
         self.assertEqual(7, self.context.config.lftp.num_max_parallel_downloads)
         self.controller.request_lftp_reconfigure.assert_called_once()
+
+    def test_set_persistence_failure_skips_rollback_when_concurrent_update(self):
+        """If another request overwrote the value before our rollback fires,
+        we must not clobber the newer value with our stale old_value."""
+        self.context.config.general.log_level = "INFO"
+
+        # Simulate a concurrent write landing between set_property and rollback:
+        # to_file raises, but before the except handler runs, another mutation
+        # has already changed the in-memory value to "WARNING".
+        def fail_then_simulate_concurrent_write(*_args, **_kw):
+            self.context.config.general.log_level = "WARNING"
+            raise OSError("disk full")
+
+        with patch.object(Config, "to_file", side_effect=fail_then_simulate_concurrent_write):
+            resp = self.test_app.get("/server/config/set/general/log_level/DEBUG", expect_errors=True)
+        self.assertEqual(500, resp.status_int)
+        # Rollback must be skipped — the newer "WARNING" survives, not "INFO".
+        self.assertEqual("WARNING", self.context.config.general.log_level)

--- a/src/python/tests/integration/test_web/test_handler/test_config.py
+++ b/src/python/tests/integration/test_web/test_handler/test_config.py
@@ -1,6 +1,7 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
 import json
+from unittest.mock import patch
 from urllib.parse import quote
 
 from common import Config
@@ -107,3 +108,31 @@ class TestConfigHandler(BaseTestWebApp):
         self.assertEqual(400, resp.status_int)
         self.assertIn("Cannot set sensitive field to redacted value", str(resp.html))
         self.assertEqual("real-password", self.context.config.lftp.remote_password)
+
+    def test_set_persistence_failure_rolls_back(self):
+        """If to_file raises, in-memory state must revert and no LFTP callback fires."""
+        self.context.config.general.log_level = "INFO"
+        with patch.object(Config, "to_file", side_effect=OSError("disk full")):
+            resp = self.test_app.get("/server/config/set/general/log_level/DEBUG", expect_errors=True)
+        self.assertEqual(500, resp.status_int)
+        self.assertIn("Failed to persist config general.log_level", str(resp.html))
+        self.assertEqual("INFO", self.context.config.general.log_level)
+        self.controller.request_lftp_reconfigure.assert_not_called()
+
+    def test_set_persistence_failure_rolls_back_lftp_tuning_key(self):
+        """A failed write on a hot-reload key must not fire the LFTP callback."""
+        self.context.config.lftp.num_max_parallel_downloads = 3
+        with patch.object(Config, "to_file", side_effect=OSError("disk full")):
+            resp = self.test_app.get(
+                "/server/config/set/lftp/num_max_parallel_downloads/7", expect_errors=True
+            )
+        self.assertEqual(500, resp.status_int)
+        self.assertEqual(3, self.context.config.lftp.num_max_parallel_downloads)
+        self.controller.request_lftp_reconfigure.assert_not_called()
+
+    def test_set_persistence_success_fires_lftp_callback(self):
+        """Baseline: a successful write on a hot-reload key still fires the callback."""
+        resp = self.test_app.get("/server/config/set/lftp/num_max_parallel_downloads/7")
+        self.assertEqual(200, resp.status_int)
+        self.assertEqual(7, self.context.config.lftp.num_max_parallel_downloads)
+        self.controller.request_lftp_reconfigure.assert_called_once()

--- a/src/python/tests/integration/test_web/test_handler/test_config.py
+++ b/src/python/tests/integration/test_web/test_handler/test_config.py
@@ -135,20 +135,50 @@ class TestConfigHandler(BaseTestWebApp):
         self.assertEqual(7, self.context.config.lftp.num_max_parallel_downloads)
         self.controller.request_lftp_reconfigure.assert_called_once()
 
-    def test_set_persistence_failure_skips_rollback_when_concurrent_update(self):
-        """If another request overwrote the value before our rollback fires,
-        we must not clobber the newer value with our stale old_value."""
-        self.context.config.general.log_level = "INFO"
+    def test_set_serializes_concurrent_writers(self):
+        """The handler's __write_lock must serialize concurrent set_config calls.
 
-        # Simulate a concurrent write landing between set_property and rollback:
-        # to_file raises, but before the except handler runs, another mutation
-        # has already changed the in-memory value to "WARNING".
-        def fail_then_simulate_concurrent_write(*_args, **_kw):
-            self.context.config.general.log_level = "WARNING"
+        Without the lock, two threads can interleave the mutate → persist →
+        rollback sequence and the second thread's value can be captured into
+        to_file mid-way through the first thread's rollback. With the lock,
+        every full mutate→persist→rollback runs atomically.
+        """
+        import threading
+
+        # Block to_file just long enough that thread B's request would
+        # interleave with thread A's failed write if the lock were missing.
+        enter_to_file = threading.Event()
+        release_to_file = threading.Event()
+
+        def slow_failing_write(*_args, **_kw):
+            enter_to_file.set()
+            release_to_file.wait(timeout=5)
             raise OSError("disk full")
 
-        with patch.object(Config, "to_file", side_effect=fail_then_simulate_concurrent_write):
-            resp = self.test_app.get("/server/config/set/general/log_level/DEBUG", expect_errors=True)
-        self.assertEqual(500, resp.status_int)
-        # Rollback must be skipped — the newer "WARNING" survives, not "INFO".
+        results: dict[str, int] = {}
+
+        def writer_a():
+            with patch.object(Config, "to_file", side_effect=slow_failing_write):
+                resp = self.test_app.get("/server/config/set/general/log_level/DEBUG", expect_errors=True)
+                results["a"] = resp.status_int
+
+        def writer_b():
+            enter_to_file.wait(timeout=5)
+            resp = self.test_app.get("/server/config/set/general/log_level/WARNING", expect_errors=True)
+            results["b"] = resp.status_int
+
+        t_a = threading.Thread(target=writer_a)
+        t_b = threading.Thread(target=writer_b)
+        t_a.start()
+        t_b.start()
+        # Give B a moment to block on the lock, then release A.
+        enter_to_file.wait(timeout=5)
+        release_to_file.set()
+        t_a.join(timeout=10)
+        t_b.join(timeout=10)
+
+        # A failed (500), B saw a fully-rolled-back state, then succeeded (200).
+        self.assertEqual(500, results["a"])
+        self.assertEqual(200, results["b"])
+        # B's value wins because it ran after A's rollback completed.
         self.assertEqual("WARNING", self.context.config.general.log_level)

--- a/src/python/tests/integration/test_web/test_handler/test_config.py
+++ b/src/python/tests/integration/test_web/test_handler/test_config.py
@@ -123,9 +123,7 @@ class TestConfigHandler(BaseTestWebApp):
         """A failed write on a hot-reload key must not fire the LFTP callback."""
         self.context.config.lftp.num_max_parallel_downloads = 3
         with patch.object(Config, "to_file", side_effect=OSError("disk full")):
-            resp = self.test_app.get(
-                "/server/config/set/lftp/num_max_parallel_downloads/7", expect_errors=True
-            )
+            resp = self.test_app.get("/server/config/set/lftp/num_max_parallel_downloads/7", expect_errors=True)
         self.assertEqual(500, resp.status_int)
         self.assertEqual(3, self.context.config.lftp.num_max_parallel_downloads)
         self.controller.request_lftp_reconfigure.assert_not_called()

--- a/src/python/web/handler/config.py
+++ b/src/python/web/handler/config.py
@@ -83,11 +83,25 @@ class ConfigHandler(IHandler):
             inner_config.set_property(key, value)
         except ConfigError as e:
             return HTTPResponse(body=str(e), status=400)
+        # set_property runs the value through the type converter, so capture
+        # the native form for the post-failure equality check below.
+        set_native = getattr(inner_config, key)
         try:
             self.__config.to_file(self.__config_path)
         except OSError:
-            inner_config.set_property(key, old_value)
-            self.__logger.exception("Failed to persist config %s.%s", section, key)
+            # Only roll back if the in-memory value is still what we just set.
+            # A concurrent request may have overwritten it with a newer value
+            # that we shouldn't clobber.
+            current = getattr(inner_config, key)
+            if current == set_native:
+                inner_config.set_property(key, old_value)
+                self.__logger.exception("Failed to persist config %s.%s", section, key)
+            else:
+                self.__logger.exception(
+                    "Failed to persist config %s.%s; a newer value is present, skipping rollback",
+                    section,
+                    key,
+                )
             return HTTPResponse(body=f"Failed to persist config {section}.{key}", status=500)
         if (section, key) in _LFTP_TUNING_KEYS and self.__on_lftp_config_change:
             self.__on_lftp_config_change()

--- a/src/python/web/handler/config.py
+++ b/src/python/web/handler/config.py
@@ -1,5 +1,6 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
+import logging
 from collections.abc import Callable
 from urllib.parse import unquote
 
@@ -45,6 +46,7 @@ class ConfigHandler(IHandler):
         self.__config = config
         self.__config_path = config_path
         self.__on_lftp_config_change = on_lftp_config_change
+        self.__logger = logging.getLogger(self.__class__.__name__)
 
     @overrides(IHandler)
     def add_routes(self, web_app: WebApp):
@@ -72,13 +74,23 @@ class ConfigHandler(IHandler):
         # real credentials with "********"
         if Config.is_sensitive(section, key) and value == Config.REDACTED_SENTINEL:
             return HTTPResponse(body="Cannot set sensitive field to redacted value", status=400)
+        # Capture the current native value before mutation so a persistence
+        # failure can be rolled back, keeping in-memory state aligned with
+        # what's on disk and preventing the LFTP hot-reload callback from
+        # firing on a value that never made it to the file.
+        old_value = getattr(inner_config, key)
         try:
             inner_config.set_property(key, value)
-            self.__config.to_file(self.__config_path)
-            if (section, key) in _LFTP_TUNING_KEYS and self.__on_lftp_config_change:
-                self.__on_lftp_config_change()
-            if Config.is_sensitive(section, key):
-                return HTTPResponse(body=f"{section}.{key} updated")
-            return HTTPResponse(body=f"{section}.{key} set to {value}")
         except ConfigError as e:
             return HTTPResponse(body=str(e), status=400)
+        try:
+            self.__config.to_file(self.__config_path)
+        except OSError:
+            inner_config.set_property(key, old_value)
+            self.__logger.exception("Failed to persist config %s.%s", section, key)
+            return HTTPResponse(body=f"Failed to persist config {section}.{key}", status=500)
+        if (section, key) in _LFTP_TUNING_KEYS and self.__on_lftp_config_change:
+            self.__on_lftp_config_change()
+        if Config.is_sensitive(section, key):
+            return HTTPResponse(body=f"{section}.{key} updated")
+        return HTTPResponse(body=f"{section}.{key} set to {value}")

--- a/src/python/web/handler/config.py
+++ b/src/python/web/handler/config.py
@@ -1,6 +1,7 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
 import logging
+import threading
 from collections.abc import Callable
 from urllib.parse import unquote
 
@@ -47,6 +48,12 @@ class ConfigHandler(IHandler):
         self.__config_path = config_path
         self.__on_lftp_config_change = on_lftp_config_change
         self.__logger = logging.getLogger(self.__class__.__name__)
+        # Serializes the mutate → persist → rollback sequence in
+        # __handle_set_config. Without it, two concurrent writers can
+        # interleave (the in-memory mutation, the whole-config to_file,
+        # or the post-failure rollback) and leave on-disk and in-memory
+        # state diverged.
+        self.__write_lock = threading.Lock()
 
     @overrides(IHandler)
     def add_routes(self, web_app: WebApp):
@@ -74,35 +81,22 @@ class ConfigHandler(IHandler):
         # real credentials with "********"
         if Config.is_sensitive(section, key) and value == Config.REDACTED_SENTINEL:
             return HTTPResponse(body="Cannot set sensitive field to redacted value", status=400)
-        # Capture the current native value before mutation so a persistence
-        # failure can be rolled back, keeping in-memory state aligned with
-        # what's on disk and preventing the LFTP hot-reload callback from
-        # firing on a value that never made it to the file.
-        old_value = getattr(inner_config, key)
-        try:
-            inner_config.set_property(key, value)
-        except ConfigError as e:
-            return HTTPResponse(body=str(e), status=400)
-        # set_property runs the value through the type converter, so capture
-        # the native form for the post-failure equality check below.
-        set_native = getattr(inner_config, key)
-        try:
-            self.__config.to_file(self.__config_path)
-        except OSError:
-            # Only roll back if the in-memory value is still what we just set.
-            # A concurrent request may have overwritten it with a newer value
-            # that we shouldn't clobber.
-            current = getattr(inner_config, key)
-            if current == set_native:
+        # Hold __write_lock across the mutate → persist → rollback sequence so
+        # writers can't interleave. With the lock, the rollback is unconditional:
+        # no other writer can have changed the value between set_property and
+        # the OSError handler.
+        with self.__write_lock:
+            old_value = getattr(inner_config, key)
+            try:
+                inner_config.set_property(key, value)
+            except ConfigError as e:
+                return HTTPResponse(body=str(e), status=400)
+            try:
+                self.__config.to_file(self.__config_path)
+            except OSError:
                 inner_config.set_property(key, old_value)
                 self.__logger.exception("Failed to persist config %s.%s", section, key)
-            else:
-                self.__logger.exception(
-                    "Failed to persist config %s.%s; a newer value is present, skipping rollback",
-                    section,
-                    key,
-                )
-            return HTTPResponse(body=f"Failed to persist config {section}.{key}", status=500)
+                return HTTPResponse(body=f"Failed to persist config {section}.{key}", status=500)
         if (section, key) in _LFTP_TUNING_KEYS and self.__on_lftp_config_change:
             self.__on_lftp_config_change()
         if Config.is_sensitive(section, key):


### PR DESCRIPTION
## Summary

Addresses item #2 in #469.

\`/server/config/set\` previously mutated the in-memory \`Config\` before attempting \`to_file\`. If the write failed (disk full, permissions, …), the in-memory state ended up ahead of the on-disk state, and the LFTP hot-reload callback could fire on a value that never persisted — so after a restart the runtime would silently revert to the on-disk value, contradicting what the UI showed.

The handler now:
1. Captures the old native value via \`getattr(inner_config, key)\`.
2. Calls \`inner_config.set_property(key, value)\` (existing \`ConfigError\` → 400 preserved).
3. Attempts \`self.__config.to_file(...)\`.
4. On \`OSError\`: restores via \`set_property(key, old_value)\`, logs via \`logger.exception\`, returns a structured HTTP 500.
5. Only on write success: fires \`__on_lftp_config_change\` (when the key is in \`_LFTP_TUNING_KEYS\`).

## Deviation from the issue's suggested approach

The original write-up suggested a copy-then-write-then-swap pattern. That doesn't actually work in this codebase because the \`Config\` instance is shared with the \`Controller\` via \`Context\` — swapping the handler's reference wouldn't propagate to the rest of the app, and the LFTP runtime would still read the old config. Capture-and-rollback is the equivalent semantically and works with the existing aliasing. Called out in the commit message.

## Test plan

- [x] \`cd src/python && pytest tests/integration/test_web/test_handler/test_config.py\` — 12 tests pass (3 new + 9 existing)
- New tests:
  - \`test_set_persistence_failure_rolls_back\` — patches \`Config.to_file\` to raise \`OSError\`, asserts 500, asserts old value restored, asserts LFTP callback not invoked
  - \`test_set_persistence_failure_rolls_back_lftp_tuning_key\` — same on an actual hot-reload key
  - \`test_set_persistence_success_fires_lftp_callback\` — positive baseline that successful writes still trigger the callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration writes now handle disk write failures gracefully: on failure the in-memory setting is reverted to its prior value, a structured HTTP 500 error is returned, and automatic reload callbacks are only invoked after a successful persist.
* **Tests**
  * Added integration tests covering persistence failures, rollback behavior, callback suppression on failed writes, successful callback invocation, and concurrent-update edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nitrobass24/seedsync/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->