### PR TITLE
Persist path_pairs before integrations on detach (#469.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - **Config handler persistence atomicity** — `/server/config/set` now captures the pre-mutation value, attempts the disk write, and on `OSError` rolls back the in-memory state and returns a structured HTTP 500 instead of letting the exception bubble up as a stack trace. The LFTP hot-reload callback only fires after a successful write, preventing the runtime from being reconfigured to a value that never made it to disk. (#469)
-- **Integration delete persistence ordering** — `/server/integrations/<id>` DELETE now writes `path_pairs.json` before `integrations.json`. A crash between the two writes previously left a dangling `arr_target_id` (instance gone from integrations but still referenced from a path pair), which is rejected by cross-validation on next load. The new order downgrades the worst-case crash outcome to a harmless orphaned instance. (#469)
+- **Integration delete persistence ordering** — `/server/integrations/<id>` DELETE now writes `path_pairs.json` before `integrations.json`. A crash between the two writes previously left a dangling `arr_target_id` (instance gone from integrations but still referenced from a path pair), which is rejected by cross-validation on next load. The new order downgrades the worst-case crash outcome to a harmless orphaned instance. (#496)
 
 ## [0.18.1] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - **Config handler persistence atomicity** — `/server/config/set` now captures the pre-mutation value, attempts the disk write, and on `OSError` rolls back the in-memory state and returns a structured HTTP 500 instead of letting the exception bubble up as a stack trace. The LFTP hot-reload callback only fires after a successful write, preventing the runtime from being reconfigured to a value that never made it to disk. (#469)
+- **Integration delete persistence ordering** — `/server/integrations/<id>` DELETE now writes `path_pairs.json` before `integrations.json`. A crash between the two writes previously left a dangling `arr_target_id` (instance gone from integrations but still referenced from a path pair), which is rejected by cross-validation on next load. The new order downgrades the worst-case crash outcome to a harmless orphaned instance. (#469)
 
 ## [0.18.1] - 2026-05-16
 

--- a/src/python/tests/integration/test_web/test_handler/test_integrations.py
+++ b/src/python/tests/integration/test_web/test_handler/test_integrations.py
@@ -216,6 +216,51 @@ class TestIntegrationsHandler(BaseTestWebApp):
         refreshed = self.path_pairs_config.get_pair(pair.id)
         self.assertEqual([], refreshed.arr_target_ids)
 
+    def test_delete_persists_path_pairs_before_integrations(self):
+        """Ordering invariant: path_pairs.to_file must complete before integrations.to_file.
+
+        If the order reverses, a crash between writes leaves integrations.json
+        without the instance but path_pairs.json still referencing it (dangling).
+        """
+        inst = self._add_instance()
+        pair = PathPair(name="TV", remote_path="/r/tv", local_path="/l/tv", arr_target_ids=[inst.id])
+        self.path_pairs_config.add_pair(pair)
+
+        call_order: list[str] = []
+        with (
+            patch.object(
+                self.path_pairs_config,
+                "to_file",
+                side_effect=lambda *_args, **_kw: call_order.append("path_pairs"),
+            ),
+            patch.object(
+                self.integrations_config,
+                "to_file",
+                side_effect=lambda *_args, **_kw: call_order.append("integrations"),
+            ),
+        ):
+            self.test_app.delete(f"/server/integrations/{inst.id}")
+
+        self.assertEqual(["path_pairs", "integrations"], call_order)
+
+    def test_delete_with_integrations_write_failure_leaves_no_dangling_refs(self):
+        """If the second write (integrations) fails, the first (path_pairs) has
+        already persisted with the detach applied — so on-disk path_pairs.json
+        no longer references the deleted instance, the worst-case outcome is an
+        orphan in integrations.json, not a dangling pointer."""
+        inst = self._add_instance()
+        pair = PathPair(name="TV", remote_path="/r/tv", local_path="/l/tv", arr_target_ids=[inst.id])
+        self.path_pairs_config.add_pair(pair)
+
+        with patch.object(self.integrations_config, "to_file", side_effect=OSError("disk full")):
+            self.test_app.delete(f"/server/integrations/{inst.id}", expect_errors=True)
+
+        # path_pairs.json was written first, before the failing integrations write.
+        with open(self.context.path_pairs_path) as f:
+            persisted_pairs = json.load(f)
+        self.assertEqual(1, len(persisted_pairs["path_pairs"]))
+        self.assertEqual([], persisted_pairs["path_pairs"][0]["arr_target_ids"])
+
     # ------------------------------------------------------------------
     # POST /server/integrations/<id>/test
     # ------------------------------------------------------------------

--- a/src/python/tests/integration/test_web/test_handler/test_integrations.py
+++ b/src/python/tests/integration/test_web/test_handler/test_integrations.py
@@ -253,7 +253,8 @@ class TestIntegrationsHandler(BaseTestWebApp):
         self.path_pairs_config.add_pair(pair)
 
         with patch.object(self.integrations_config, "to_file", side_effect=OSError("disk full")):
-            self.test_app.delete(f"/server/integrations/{inst.id}", expect_errors=True)
+            resp = self.test_app.delete(f"/server/integrations/{inst.id}", expect_errors=True)
+        self.assertEqual(500, resp.status_int)
 
         # path_pairs.json was written first, before the failing integrations write.
         with open(self.context.path_pairs_path) as f:

--- a/src/python/web/handler/integrations.py
+++ b/src/python/web/handler/integrations.py
@@ -112,8 +112,12 @@ class IntegrationsHandler(IHandler):
             return HTTPResponse(body="Integration not found", status=404)
         # Detach from any path pair that referenced it so we don't leave dangling pointers.
         self.__path_pairs_config.detach_arr_target(instance_id)
-        self.__config.to_file(self.__integrations_path)
+        # Persist path_pairs *before* integrations: if the process dies between
+        # writes, an orphaned instance (still in integrations.json, no longer
+        # referenced) is recoverable; a dangling arr_target_id (instance gone,
+        # path pair still references it) is rejected by cross-validation on load.
         self.__path_pairs_config.to_file(self.__path_pairs_path)
+        self.__config.to_file(self.__integrations_path)
         return HTTPResponse(status=204)
 
     def __handle_test(self, instance_id: str):


### PR DESCRIPTION
## Summary

Addresses item #3 in #469.

\`IntegrationsHandler.__handle_delete\` writes integrations.json *after* path_pairs.json (instead of before). Process death between the two writes previously left the on-disk integrations file without the instance but the on-disk path_pairs file still referencing it — a dangling \`arr_target_id\`, which the cross-validation added in #426 rejects when the path_pairs config loads on next start.

The new order downgrades the worst-case crash outcome to an orphaned (no-longer-referenced) instance in integrations.json. That's harmless: load succeeds, and the next delete attempt cleans it up.

## Test plan

- [x] \`cd src/python && pytest tests/integration/test_web/test_handler/test_integrations.py\` — 28 tests pass (2 new + 26 existing)
- New tests:
  - \`test_delete_persists_path_pairs_before_integrations\` — spies both \`to_file\` calls and asserts the captured order is \`["path_pairs", "integrations"]\`
  - \`test_delete_with_integrations_write_failure_leaves_no_dangling_refs\` — patches \`integrations_config.to_file\` to raise \`OSError\`, asserts the on-disk \`path_pairs.json\` has the detach applied (instance is no longer referenced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a data consistency issue in deletion operations where crashes could leave orphaned references. The operation now properly cleans up dependencies before removing primary records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nitrobass24/seedsync/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->