### PR TITLE
Wrap auto-queue and path-pairs persistence in try/except (#469.1, #469.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **Config handler persistence atomicity** — `/server/config/set` now captures the pre-mutation value, attempts the disk write, and on `OSError` rolls back the in-memory state and returns a structured HTTP 500 instead of letting the exception bubble up as a stack trace. The LFTP hot-reload callback only fires after a successful write, preventing the runtime from being reconfigured to a value that never made it to disk. (#469)
 - **Integration delete persistence ordering** — `/server/integrations/<id>` DELETE now writes `path_pairs.json` before `integrations.json`. A crash between the two writes previously left a dangling `arr_target_id` (instance gone from integrations but still referenced from a path pair), which is rejected by cross-validation on next load. The new order downgrades the worst-case crash outcome to a harmless orphaned instance. (#496)
+- **Auto-queue and path-pairs handlers wrap persistence in try/except** — `/server/autoqueue/{add,remove}` and `/server/pathpairs/{create,update,delete}` now return a controlled HTTP 500 with a structured body when the underlying `to_file` raises `OSError`, instead of leaking a stack trace. The in-memory mutation still happens (and may diverge from disk in the failure case); the change converts an unhandled exception into a recoverable client error. (#497)
 
 ## [0.18.1] - 2026-05-16
 

--- a/src/python/tests/integration/test_web/test_handler/test_auto_queue.py
+++ b/src/python/tests/integration/test_web/test_handler/test_auto_queue.py
@@ -1,8 +1,9 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
+from unittest.mock import patch
 from urllib.parse import quote
 
-from controller import AutoQueuePattern
+from controller import AutoQueuePattern, AutoQueuePersist
 from tests.integration.test_web.test_web_app import BaseTestWebApp
 
 
@@ -135,3 +136,16 @@ class TestAutoQueueHandler(BaseTestWebApp):
         resp = self.test_app.get("/server/autoqueue/remove/", expect_errors=True)
         self.assertEqual(404, resp.status_int)
         self.assertEqual(0, len(self.auto_queue_persist.patterns))
+
+    def test_add_returns_500_when_persistence_fails(self):
+        with patch.object(AutoQueuePersist, "to_file", side_effect=OSError("disk full")):
+            resp = self.test_app.get("/server/autoqueue/add/onepattern", expect_errors=True)
+        self.assertEqual(500, resp.status_int)
+        self.assertEqual("Failed to persist auto-queue", resp.text)
+
+    def test_remove_returns_500_when_persistence_fails(self):
+        self.auto_queue_persist.add_pattern(AutoQueuePattern(pattern="onepattern"))
+        with patch.object(AutoQueuePersist, "to_file", side_effect=OSError("disk full")):
+            resp = self.test_app.get("/server/autoqueue/remove/onepattern", expect_errors=True)
+        self.assertEqual(500, resp.status_int)
+        self.assertEqual("Failed to persist auto-queue", resp.text)

--- a/src/python/tests/integration/test_web/test_handler/test_auto_queue.py
+++ b/src/python/tests/integration/test_web/test_handler/test_auto_queue.py
@@ -142,6 +142,10 @@ class TestAutoQueueHandler(BaseTestWebApp):
             resp = self.test_app.get("/server/autoqueue/add/onepattern", expect_errors=True)
         self.assertEqual(500, resp.status_int)
         self.assertEqual("Failed to persist auto-queue", resp.text)
+        # Contract: the in-memory mutation is *not* rolled back on persistence
+        # failure. The 500 signals "disk and memory may diverge — retry"; the
+        # pattern stays in memory so a subsequent retry persists the same state.
+        self.assertIn(AutoQueuePattern("onepattern"), self.auto_queue_persist.patterns)
 
     def test_remove_returns_500_when_persistence_fails(self):
         self.auto_queue_persist.add_pattern(AutoQueuePattern(pattern="onepattern"))
@@ -149,3 +153,5 @@ class TestAutoQueueHandler(BaseTestWebApp):
             resp = self.test_app.get("/server/autoqueue/remove/onepattern", expect_errors=True)
         self.assertEqual(500, resp.status_int)
         self.assertEqual("Failed to persist auto-queue", resp.text)
+        # Contract: the in-memory removal is *not* rolled back on persistence failure.
+        self.assertNotIn(AutoQueuePattern("onepattern"), self.auto_queue_persist.patterns)

--- a/src/python/tests/integration/test_web/test_handler/test_path_pairs.py
+++ b/src/python/tests/integration/test_web/test_handler/test_path_pairs.py
@@ -1,6 +1,7 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
 import json
+from unittest.mock import patch
 
 from common import ArrInstance, IntegrationsConfig, PathPair, PathPairsConfig, overrides
 from tests.integration.test_web.test_web_app import BaseTestWebApp
@@ -446,3 +447,34 @@ class TestPathPairsHandler(BaseTestWebApp):
         # Confirm gone
         list_resp2 = self.test_app.get("/server/pathpairs")
         self.assertEqual([], json.loads(list_resp2.text))
+
+    # ---------------------------------------------------------------
+    # Persistence-failure handling
+    # ---------------------------------------------------------------
+    def test_create_returns_500_when_persistence_fails(self):
+        with patch.object(PathPairsConfig, "to_file", side_effect=OSError("disk full")):
+            resp = self._post_json(
+                "/server/pathpairs",
+                {"name": "X", "remote_path": "/r/x", "local_path": "/l/x"},
+                expect_errors=True,
+            )
+        self.assertEqual(500, resp.status_int)
+        self.assertEqual({"error": "failed to persist path pairs"}, json.loads(resp.text))
+
+    def test_update_returns_500_when_persistence_fails(self):
+        pair = self._add_pair()
+        with patch.object(PathPairsConfig, "to_file", side_effect=OSError("disk full")):
+            resp = self._put_json(
+                f"/server/pathpairs/{pair.id}",
+                {"enabled": False},
+                expect_errors=True,
+            )
+        self.assertEqual(500, resp.status_int)
+        self.assertEqual({"error": "failed to persist path pairs"}, json.loads(resp.text))
+
+    def test_delete_returns_500_when_persistence_fails(self):
+        pair = self._add_pair()
+        with patch.object(PathPairsConfig, "to_file", side_effect=OSError("disk full")):
+            resp = self.test_app.delete(f"/server/pathpairs/{pair.id}", expect_errors=True)
+        self.assertEqual(500, resp.status_int)
+        self.assertEqual({"error": "failed to persist path pairs"}, json.loads(resp.text))

--- a/src/python/tests/integration/test_web/test_handler/test_path_pairs.py
+++ b/src/python/tests/integration/test_web/test_handler/test_path_pairs.py
@@ -460,6 +460,8 @@ class TestPathPairsHandler(BaseTestWebApp):
             )
         self.assertEqual(500, resp.status_int)
         self.assertEqual({"error": "failed to persist path pairs"}, json.loads(resp.text))
+        # Contract: in-memory mutation is *not* rolled back on persistence failure.
+        self.assertTrue(any(p.name == "X" for p in self.path_pairs_config.pairs))
 
     def test_update_returns_500_when_persistence_fails(self):
         pair = self._add_pair()
@@ -471,6 +473,8 @@ class TestPathPairsHandler(BaseTestWebApp):
             )
         self.assertEqual(500, resp.status_int)
         self.assertEqual({"error": "failed to persist path pairs"}, json.loads(resp.text))
+        # Contract: in-memory mutation is *not* rolled back on persistence failure.
+        self.assertFalse(self.path_pairs_config.get_pair(pair.id).enabled)
 
     def test_delete_returns_500_when_persistence_fails(self):
         pair = self._add_pair()
@@ -478,3 +482,5 @@ class TestPathPairsHandler(BaseTestWebApp):
             resp = self.test_app.delete(f"/server/pathpairs/{pair.id}", expect_errors=True)
         self.assertEqual(500, resp.status_int)
         self.assertEqual({"error": "failed to persist path pairs"}, json.loads(resp.text))
+        # Contract: in-memory removal is *not* rolled back on persistence failure.
+        self.assertIsNone(self.path_pairs_config.get_pair(pair.id))

--- a/src/python/web/handler/auto_queue.py
+++ b/src/python/web/handler/auto_queue.py
@@ -1,5 +1,6 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
+import logging
 from urllib.parse import unquote
 
 from bottle import HTTPResponse
@@ -17,6 +18,7 @@ class AutoQueueHandler(IHandler):
     def __init__(self, auto_queue_persist: AutoQueuePersist, persist_path: str):
         self.__auto_queue_persist = auto_queue_persist
         self.__persist_path = persist_path
+        self.__logger = logging.getLogger(self.__class__.__name__)
 
     @overrides(IHandler)
     def add_routes(self, web_app: WebApp):
@@ -45,12 +47,6 @@ class AutoQueueHandler(IHandler):
             )
         try:
             self.__auto_queue_persist.add_pattern(aqp)
-            self.__auto_queue_persist.to_file(self.__persist_path)
-            return HTTPResponse(
-                body=f"Added auto-queue pattern '{pattern}'.",
-                content_type="text/plain",
-                headers=self._NOSNIFF_HEADERS,
-            )
         except ValueError as e:
             return HTTPResponse(
                 body=str(e),
@@ -58,6 +54,21 @@ class AutoQueueHandler(IHandler):
                 content_type="text/plain",
                 headers=self._NOSNIFF_HEADERS,
             )
+        try:
+            self.__auto_queue_persist.to_file(self.__persist_path)
+        except OSError:
+            self.__logger.exception("Failed to persist auto-queue after adding pattern %r", pattern)
+            return HTTPResponse(
+                body="Failed to persist auto-queue",
+                status=500,
+                content_type="text/plain",
+                headers=self._NOSNIFF_HEADERS,
+            )
+        return HTTPResponse(
+            body=f"Added auto-queue pattern '{pattern}'.",
+            content_type="text/plain",
+            headers=self._NOSNIFF_HEADERS,
+        )
 
     def __handle_remove_autoqueue(self, pattern: str):
         # value is double encoded
@@ -73,7 +84,16 @@ class AutoQueueHandler(IHandler):
                 headers=self._NOSNIFF_HEADERS,
             )
         self.__auto_queue_persist.remove_pattern(aqp)
-        self.__auto_queue_persist.to_file(self.__persist_path)
+        try:
+            self.__auto_queue_persist.to_file(self.__persist_path)
+        except OSError:
+            self.__logger.exception("Failed to persist auto-queue after removing pattern %r", pattern)
+            return HTTPResponse(
+                body="Failed to persist auto-queue",
+                status=500,
+                content_type="text/plain",
+                headers=self._NOSNIFF_HEADERS,
+            )
         return HTTPResponse(
             body=f"Removed auto-queue pattern '{pattern}'.",
             content_type="text/plain",

--- a/src/python/web/handler/path_pairs.py
+++ b/src/python/web/handler/path_pairs.py
@@ -1,6 +1,7 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
 import json
+import logging
 from typing import Any, cast
 
 from bottle import HTTPResponse, request
@@ -17,6 +18,20 @@ class PathPairsHandler(IHandler):
         self.__config = path_pairs_config
         self.__integrations_config = integrations_config
         self.__path_pairs_path = path_pairs_path
+        self.__logger = logging.getLogger(self.__class__.__name__)
+
+    def _persist_or_500(self, action: str) -> HTTPResponse | None:
+        """Persist the config; return a 500 response on OSError, else None."""
+        try:
+            self.__config.to_file(self.__path_pairs_path)
+        except OSError:
+            self.__logger.exception("Failed to persist path pairs after %s", action)
+            return HTTPResponse(
+                body=json.dumps({"error": "failed to persist path pairs"}),
+                status=500,
+                headers={"Content-Type": "application/json"},
+            )
+        return None
 
     @overrides(IHandler)
     def add_routes(self, web_app: WebApp):
@@ -114,7 +129,9 @@ class PathPairsHandler(IHandler):
             if "name" in str(e) and "already exists" in str(e):
                 return HTTPResponse(body=str(e), status=409)
             raise
-        self.__config.to_file(self.__path_pairs_path)
+        err = self._persist_or_500(f"creating pair {pair.id!r}")
+        if err is not None:
+            return err
         return HTTPResponse(body=json.dumps(pair.to_dict()), status=201, headers={"Content-Type": "application/json"})
 
     def __handle_update(self, pair_id: str):
@@ -154,7 +171,9 @@ class PathPairsHandler(IHandler):
             if "name" in str(e) and "already exists" in str(e):
                 return HTTPResponse(body=str(e), status=409)
             return HTTPResponse(body="Path pair not found", status=404)
-        self.__config.to_file(self.__path_pairs_path)
+        err = self._persist_or_500(f"updating pair {pair_id!r}")
+        if err is not None:
+            return err
         return HTTPResponse(body=json.dumps(updated.to_dict()), headers={"Content-Type": "application/json"})
 
     def __handle_delete(self, pair_id: str):
@@ -162,5 +181,7 @@ class PathPairsHandler(IHandler):
             self.__config.remove_pair(pair_id)
         except ValueError:
             return HTTPResponse(body="Path pair not found", status=404)
-        self.__config.to_file(self.__path_pairs_path)
+        err = self._persist_or_500(f"deleting pair {pair_id!r}")
+        if err is not None:
+            return err
         return HTTPResponse(status=204)


### PR DESCRIPTION
## Summary

Addresses items #1 and #4 in #469.

\`AutoQueueHandler\` and \`PathPairsHandler\` previously let \`OSError\` from \`to_file\` bubble up as an unhandled HTTP 500 with a stack trace. They now catch \`OSError\`, log via \`logger.exception\`, and return a controlled 500 with a structured body.

- **Auto-queue** (\`/server/autoqueue/add\`, \`/server/autoqueue/remove\`): text/plain \`"Failed to persist auto-queue"\`.
- **Path-pairs** (\`/server/pathpairs\` POST/PUT/DELETE): JSON \`{"error": "failed to persist path pairs"}\`. The persistence logic is extracted into a small \`_persist_or_500\` helper so all three CRUD handlers share the same error path.

## Deliberate deviation: no in-memory rollback

The issue explicitly accepts the in-memory/disk divergence on these endpoints — the goal is to convert a stack trace into a recoverable client error the UI can react to. Differs from #495 (config handler), where rollback was necessary because the alternative was the LFTP runtime hot-reloading to a value that never made it to disk.

For auto-queue specifically, rollback is also undesirable: \`add_pattern\` fires a listener side-effect (\`AutoQueuePersistListener.pattern_added\` adds to \`new_patterns\` for the controller's auto-queue thread to pick up). A \`remove_pattern\` rollback would undo the in-memory state but the controller thread could already have observed the transient state between the two calls.

Called out in the commit message.

## Test plan

- [x] \`cd src/python && pytest tests/integration/test_web/test_handler/test_auto_queue.py tests/integration/test_web/test_handler/test_path_pairs.py\` — 50 tests pass (5 new + 45 existing)
- New tests, all patching \`<config>.to_file\` to raise \`OSError\`:
  - \`test_add_returns_500_when_persistence_fails\` (auto-queue)
  - \`test_remove_returns_500_when_persistence_fails\` (auto-queue)
  - \`test_create_returns_500_when_persistence_fails\` (path-pairs)
  - \`test_update_returns_500_when_persistence_fails\` (path-pairs)
  - \`test_delete_returns_500_when_persistence_fails\` (path-pairs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-queue and path‑pairs endpoints now return a controlled HTTP 500 with a clear error message when disk persistence fails, instead of exposing internal stack traces. In-memory updates still occur even if writing to disk fails, which may cause temporary divergence between memory and disk.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nitrobass24/seedsync/pull/497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->