### PR TITLE
CI: re-enable mock-based lftp/ssh/scanner unit tests; gate live suites (#529)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,14 +142,16 @@ jobs:
         working-directory: src/python
         env:
           PYTHONPATH: .
+        # Only the live-server suites stay excluded: test_lftp.py and
+        # test_sshcp.py drive a real lftp/SSH transfer against the seedsynctest
+        # account (also gated at runtime by SEEDSYNC_LIVE_SSH_TESTS). The
+        # mock-based lftp/ssh/scanner suites now run here (#529).
+        # test_multiprocessing_logger stays excluded as before (out of scope).
         run: >-
           pytest tests/unittests -v --tb=short
           --timeout=30
           --ignore=tests/unittests/test_lftp/test_lftp.py
-          --ignore=tests/unittests/test_lftp/test_lftp_queue_command.py
-          --ignore=tests/unittests/test_ssh
-          --ignore=tests/unittests/test_system
-          --ignore=tests/unittests/test_controller/test_scan/test_remote_scanner.py
+          --ignore=tests/unittests/test_ssh/test_sshcp.py
           --ignore=tests/unittests/test_common/test_multiprocessing_logger.py
 
   python-integration-test:
@@ -176,6 +178,11 @@ jobs:
         working-directory: src/python
         env:
           PYTHONPATH: .
+        # Only the web-handler integration tests run in CI. The
+        # tests/integration/test_controller and test_lftp suites drive a real
+        # lftp/SSH transfer against the seedsynctest account (gated by
+        # SEEDSYNC_LIVE_SSH_TESTS) and have no mock subset, so they cannot run
+        # without that live server (#529).
         run: >-
           pytest tests/integration/test_web -v --tb=short
           --timeout=30

--- a/doc/DeveloperReadme.md
+++ b/doc/DeveloperReadme.md
@@ -86,6 +86,24 @@ docker run --rm -v $(pwd)/src/python:/app -w /app \
   sh -c "pip install pytest && pytest tests/unittests -v"
 ```
 
+### Live-server SSH tests
+
+A few suites — `tests/unittests/test_lftp/test_lftp.py`,
+`tests/unittests/test_ssh/test_sshcp.py`, and the
+`tests/integration/test_controller` / `tests/integration/test_lftp` suites —
+drive a real lftp/SSH transfer against a `seedsynctest` SSH account on
+`localhost`. They are **skipped by default**, including under `make test` and in
+CI (neither provisions that account), so the fully-mocked lftp/ssh/scanner tests
+in the same packages still run.
+
+To run the live suites, set up the `seedsynctest` account (an SSH user on
+`localhost` with password `seedsyncpass` and key-based login enabled), then opt
+in with the `SEEDSYNC_LIVE_SSH_TESTS` environment variable:
+
+```bash
+SEEDSYNC_LIVE_SSH_TESTS=1 pytest tests/unittests/test_ssh/test_sshcp.py -v
+```
+
 ### Debugging
 
 ```bash

--- a/doc/DeveloperReadme.md
+++ b/doc/DeveloperReadme.md
@@ -98,10 +98,12 @@ in the same packages still run.
 
 To run the live suites, set up the `seedsynctest` account (an SSH user on
 `localhost` with password `seedsyncpass` and key-based login enabled), then opt
-in with the `SEEDSYNC_LIVE_SSH_TESTS` environment variable:
+in with the `SEEDSYNC_LIVE_SSH_TESTS` environment variable. Run from the
+`src/python` directory (the same working directory and `PYTHONPATH` CI uses):
 
 ```bash
-SEEDSYNC_LIVE_SSH_TESTS=1 pytest tests/unittests/test_ssh/test_sshcp.py -v
+cd src/python
+SEEDSYNC_LIVE_SSH_TESTS=1 PYTHONPATH=. pytest tests/unittests/test_ssh/test_sshcp.py -v
 ```
 
 ### Debugging

--- a/src/python/tests/integration/test_controller/test_controller.py
+++ b/src/python/tests/integration/test_controller/test_controller.py
@@ -18,7 +18,7 @@ import timeout_decorator
 from common import AppError, Args, Config, Context, Localization, Status, overrides
 from controller import Controller, ControllerPersist
 from model import IModelListener, ModelFile
-from tests.utils import TestUtils
+from tests.utils import TestUtils, requires_live_ssh
 
 
 class DummyListener(IModelListener):
@@ -46,6 +46,7 @@ class DummyCommandCallback(Controller.Command.ICallback):
 
 
 # noinspection SpellCheckingInspection
+@requires_live_ssh
 class TestController(unittest.TestCase):
     __KEEP_FILES = False  # for debugging
 

--- a/src/python/tests/integration/test_lftp/test_lftp.py
+++ b/src/python/tests/integration/test_lftp/test_lftp.py
@@ -11,9 +11,10 @@ from filecmp import dircmp
 import timeout_decorator
 
 from lftp import Lftp
-from tests.utils import TestUtils
+from tests.utils import TestUtils, requires_live_ssh
 
 
+@requires_live_ssh
 class TestLftp(unittest.TestCase):
     temp_dir = None
 

--- a/src/python/tests/unittests/test_lftp/test_lftp.py
+++ b/src/python/tests/unittests/test_lftp/test_lftp.py
@@ -10,10 +10,11 @@ import unittest
 import timeout_decorator
 
 from lftp import Lftp, LftpError, LftpJobStatus
-from tests.utils import TestUtils
+from tests.utils import TestUtils, requires_live_ssh
 
 
 # noinspection PyPep8Naming,SpellCheckingInspection
+@requires_live_ssh
 class TestLftp(unittest.TestCase):
     temp_dir = None
 

--- a/src/python/tests/unittests/test_lftp/test_lftp_queue_command.py
+++ b/src/python/tests/unittests/test_lftp/test_lftp_queue_command.py
@@ -19,6 +19,9 @@ class TestLftpQueueCommand(unittest.TestCase):
         lftp._Lftp__base_remote_dir_path = "/remote/path"
         lftp._Lftp__base_local_dir_path = "/local/path"
         lftp._Lftp__run_command = MagicMock()
+        # queue() logs the constructed command; __init__ is stubbed out, so
+        # supply a mock logger in its place.
+        lftp.logger = MagicMock()
         return lftp
 
     def test_queue_dir_no_excludes(self):
@@ -41,9 +44,9 @@ class TestLftpQueueCommand(unittest.TestCase):
         lftp.queue("mydir", True, exclude_patterns=["*.nfo", "*.txt", "Sample/"])
         cmd = lftp._Lftp__run_command.call_args[0][0]
         self.assertIn("mirror", cmd)
-        self.assertIn('--exclude "*.nfo"', cmd)
-        self.assertIn('--exclude "*.txt"', cmd)
-        self.assertIn('--exclude "Sample/"', cmd)
+        self.assertIn('--exclude-glob "*.nfo"', cmd)
+        self.assertIn('--exclude-glob "*.txt"', cmd)
+        self.assertIn('--exclude-glob "Sample/"', cmd)
 
     def test_queue_file_ignores_excludes(self):
         """Exclude patterns only apply to mirror (directory) downloads, not pget (file)."""

--- a/src/python/tests/unittests/test_ssh/test_sshcp.py
+++ b/src/python/tests/unittests/test_ssh/test_sshcp.py
@@ -13,7 +13,7 @@ from parameterized import parameterized
 
 from common import overrides
 from ssh import Sshcp, SshcpError
-from tests.utils import TestUtils
+from tests.utils import TestUtils, requires_live_ssh
 
 # This is outside so it can be used in the parameterized decorators
 # noinspection SpellCheckingInspection
@@ -23,6 +23,7 @@ _PARAMS = [("password", _PASSWORD), ("keyauth", None)]
 
 
 # noinspection SpellCheckingInspection
+@requires_live_ssh
 class TestSshcp(unittest.TestCase):
     __KEEP_FILES = False  # for debugging
 

--- a/src/python/tests/unittests/test_system/test_file.py
+++ b/src/python/tests/unittests/test_system/test_file.py
@@ -17,7 +17,7 @@ class TestSystemFile(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             # noinspection PyUnusedLocal
             sf = SystemFile("", -42, False)
-        self.assertTrue("File size must be greater than zero" in str(context.exception))
+        self.assertTrue("File size must be non-negative" in str(context.exception))
 
     def test_is_dir(self):
         sf = SystemFile("", 0, True)

--- a/src/python/tests/utils.py
+++ b/src/python/tests/utils.py
@@ -2,6 +2,28 @@
 
 import contextlib
 import os
+import unittest
+
+# Live-server test suites talk to a real SSH/SFTP server using the
+# `seedsynctest` account on localhost (see doc/DeveloperReadme.md). They are
+# skipped unless SEEDSYNC_LIVE_SSH_TESTS is set to a truthy value, so CI and
+# `make test` (neither of which provisions that account) stay green while the
+# fully-mocked tests in the same packages still run.
+LIVE_SSH_TESTS_ENV_VAR = "SEEDSYNC_LIVE_SSH_TESTS"
+
+
+def live_ssh_tests_enabled() -> bool:
+    """True if the live seedsynctest SSH account is available (opt-in via env var)."""
+    return os.environ.get(LIVE_SSH_TESTS_ENV_VAR, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def requires_live_ssh(test_item):
+    """Class/method decorator: skip a live-server test unless the seedsynctest account is enabled."""
+    reason = (
+        f"requires the live seedsynctest SSH account; "
+        f"set {LIVE_SSH_TESTS_ENV_VAR}=1 to run (see doc/DeveloperReadme.md)"
+    )
+    return unittest.skipUnless(live_ssh_tests_enabled(), reason)(test_item)
 
 
 class TestUtils:


### PR DESCRIPTION
Resolves the **CI test re-enable** item of tracking issue #531 — child issue #529. The tracker calls this out as gating the value of the other test work, so it goes first.

Closes #529

## Problem

The `unit-test` job's `--ignore` patterns were meant to skip *live-server* tests, but the directory-level ignores also dropped fully-mocked, network-free suites. Regressions in injection-adjacent code — lftp command construction, SSH quoting/shell-detect, remote-scan command building, and the local scanner — could land green.

Re-enabling immediately surfaced the rot the exclusion was hiding (two suites had drifted from the source and would have failed silently): see "Fixes" below.

## Acceptance criteria

| Criterion | Done |
|---|---|
| Directory-level ignores replaced with file-level ignores for only the live-server suites (`test_sshcp.py`, `test_lftp.py`) | ✅ |
| `test_lftp_queue_command.py`, `test_ssh/test_shell_detect.py`, `test_sshcp_remote_address.py`, `test_remote_scanner.py`, `test_system/` run in CI | ✅ |
| Live-server-only tests gated by a marker/skipif on the `seedsynctest` account | ✅ |
| Integration job includes the mock subset of `test_controller`/`test_lftp` **or documents why not** | ✅ documented (both are fully live; no mock subset) |

## Changes

**CI (`ci.yml`)** — the ignore list drops from 6 entries to 3 (only the two live files + the pre-existing, out-of-scope `test_multiprocessing_logger`). A comment explains each remaining exclusion, and the integration job documents why it runs only `test_web`.

**Live-server gating (`tests/utils.py`)** — new `requires_live_ssh` class decorator skips a suite unless `SEEDSYNC_LIVE_SSH_TESTS` is set. Applied to all four live suites (unit `TestSshcp`/`TestLftp`, integration `TestController`/`TestLftp`) so they skip cleanly instead of erroring under CI and `make test`, and can be opted into once the `seedsynctest` account exists. Documented in `doc/DeveloperReadme.md`.

**Fixes for rotted tests** (they were excluded from CI, so the drift went unnoticed):
- `test_lftp_queue_command.py` — `__init__` is stubbed in the test, so `queue()`'s logger call raised `AttributeError`; supply a mock logger. Also assert the current `--exclude-glob` flag (the source moved from `--exclude` (regex) to `--exclude-glob` (glob), with a code comment explaining the distinction).
- `test_system/test_file.py` — assert the current `"File size must be non-negative"` message (was `"...greater than zero"`).

## Test plan

Verified on Linux in `python:3.13-slim` (matching CI's `ubuntu-latest`):

- ✅ **Exact new CI command → `781 passed`** (`pytest tests/unittests` with the new ignore list).
- ✅ **Gate works**: with no env var, the live `TestLftp`/`TestSshcp` are **skipped** (59) with a clear reason, while the **97 mock tests** in those same packages run.
- ✅ Both live integration suites (`test_controller`, `test_lftp`) **skip** cleanly (50 skipped, 0 failures).
- ✅ `ruff check` + `ruff format --check` pass.
- ⚠️ Note: `test_system/test_scanner.py::test_scan_file_with_latin_chars` fails on **macOS/APFS** (which rejects non-UTF-8 filenames) but passes on Linux — CI is Linux, and this is pre-existing behavior of the suite.

No production code changed; pyright (which excludes `tests/`) is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced environment variable-based gating for live SSH/SFTP test suites to control execution.
  * Applied selective test execution gates to integration and unit test modules.
  * Updated CI workflow to exclude only live-server SSH/lftp transfer tests while running mock-based test suites.

* **Documentation**
  * Added developer documentation for live-server SSH test setup, prerequisites, and opt-in execution instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->