### PR TITLE
Tests: cover security-critical paths (#530)

### DIFF
--- a/src/python/common/config.py
+++ b/src/python/common/config.py
@@ -426,7 +426,11 @@ class Config(Persist):
     @classmethod
     @overrides(Persist)
     def from_str(cls: type["Config"], content: str) -> "Config":
-        config_parser = configparser.ConfigParser()
+        # interpolation=None: config values are opaque strings (passwords,
+        # exclude patterns, rate limits) that may legitimately contain '%'.
+        # The default BasicInterpolation would treat '%' as a format token and
+        # raise on read/write (see #507).
+        config_parser = configparser.ConfigParser(interpolation=None)
         try:
             config_parser.read_string(content)
         except (configparser.MissingSectionHeaderError, configparser.ParsingError) as e:
@@ -440,7 +444,9 @@ class Config(Persist):
 
     @overrides(Persist)
     def to_str(self) -> str:
-        config_parser = configparser.ConfigParser()
+        # interpolation=None: see from_str. A '%' in any value must survive the
+        # write/read round-trip verbatim rather than being treated as a token.
+        config_parser = configparser.ConfigParser(interpolation=None)
         config_dict = self.as_dict()
         for section in config_dict:
             config_parser.add_section(section)

--- a/src/python/tests/integration/test_web/test_handler/test_config.py
+++ b/src/python/tests/integration/test_web/test_handler/test_config.py
@@ -44,6 +44,22 @@ class TestConfigHandler(BaseTestWebApp):
         self.assertEqual(200, resp.status_int)
         self.assertEqual(8080, self.context.config.web.port)
 
+    def test_set_percent_value_persists_and_reloads(self):
+        """A config value containing '%' must set, persist, and reload cleanly.
+
+        Regression guard for #507: the persist path (to_file -> Config.to_str)
+        used configparser's default BasicInterpolation, which raised on '%'.
+        """
+        value = "100%secret"
+        uri = quote(quote(value, safe=""), safe="")
+        resp = self.test_app.get("/server/config/set/lftp/remote_password/" + uri)
+        self.assertEqual(200, resp.status_int)
+        self.assertEqual(value, self.context.config.lftp.remote_password)
+        # Reload from the persisted settings file to confirm the on-disk round trip.
+        with open(self.context.config_path) as f:
+            reloaded = Config.from_str(f.read())
+        self.assertEqual(value, reloaded.lftp.remote_password)
+
     def test_set_missing_section(self):
         self.assertFalse(self.context.config.has_section("bad_section"))
         resp = self.test_app.get("/server/config/set/bad_section/option/value", expect_errors=True)

--- a/src/python/tests/integration/test_web/test_handler/test_integrations.py
+++ b/src/python/tests/integration/test_web/test_handler/test_integrations.py
@@ -138,6 +138,18 @@ class TestIntegrationsHandler(BaseTestWebApp):
         )
         self.assertEqual(400, resp.status_int)
 
+    def test_create_persist_failure_returns_500(self):
+        """A disk error while persisting surfaces as a controlled 500 with a
+        stable JSON error body, not an unhandled traceback. The in-memory add
+        survives (mirrors the path_pairs/auto_queue contract)."""
+        data = {"name": "Sonarr", "kind": "sonarr", "url": "http://localhost:8989", "api_key": "abc"}
+        with patch.object(self.integrations_config, "to_file", side_effect=OSError("disk full")):
+            resp = self._post("/server/integrations", data, expect_errors=True)
+        self.assertEqual(500, resp.status_int)
+        self.assertEqual("failed to persist integrations", json.loads(resp.text)["error"])
+        # In-memory mutation survives the persist failure.
+        self.assertEqual(1, len(self.integrations_config.instances))
+
     # ------------------------------------------------------------------
     # PUT /server/integrations/<id>
     # ------------------------------------------------------------------
@@ -188,6 +200,21 @@ class TestIntegrationsHandler(BaseTestWebApp):
         self.assertEqual(409, resp.status_int)
         # Original a unchanged
         self.assertEqual("A", self.integrations_config.get_instance(a.id).name)
+
+    def test_update_persist_failure_returns_500(self):
+        """A disk error while persisting an update surfaces as a controlled 500
+        with a stable JSON error body. The in-memory update survives."""
+        inst = self._add_instance(name="Original", api_key="old")
+        with patch.object(self.integrations_config, "to_file", side_effect=OSError("disk full")):
+            resp = self._put(
+                f"/server/integrations/{inst.id}",
+                {"name": "Renamed", "kind": "sonarr", "url": "http://new", "api_key": "new"},
+                expect_errors=True,
+            )
+        self.assertEqual(500, resp.status_int)
+        self.assertEqual("failed to persist integrations", json.loads(resp.text)["error"])
+        # In-memory mutation survives the persist failure.
+        self.assertEqual("Renamed", self.integrations_config.get_instance(inst.id).name)
 
     # ------------------------------------------------------------------
     # DELETE /server/integrations/<id>

--- a/src/python/tests/integration/test_web/test_handler/test_integrations.py
+++ b/src/python/tests/integration/test_web/test_handler/test_integrations.py
@@ -282,6 +282,9 @@ class TestIntegrationsHandler(BaseTestWebApp):
         with patch.object(self.integrations_config, "to_file", side_effect=OSError("disk full")):
             resp = self.test_app.delete(f"/server/integrations/{inst.id}", expect_errors=True)
         self.assertEqual(500, resp.status_int)
+        # Same controlled JSON error shape as the create/update persist failures,
+        # not a raw Bottle 500 from an unhandled OSError.
+        self.assertEqual("failed to persist integrations", json.loads(resp.text)["error"])
 
         # path_pairs.json was written first, before the failing integrations write.
         with open(self.context.path_pairs_path) as f:

--- a/src/python/tests/unittests/test_common/test_config.py
+++ b/src/python/tests/unittests/test_common/test_config.py
@@ -839,6 +839,83 @@ class TestConfig(unittest.TestCase):
         config2 = Config.from_str(config_str)
         self.assertEqual(config.as_dict(), config2.as_dict())
 
+    def _full_config(self) -> Config:
+        """Build a complete, valid Config (all required fields set)."""
+        config = Config()
+        config.general.log_level = "INFO"
+        config.general.verbose = False
+        config.general.exclude_patterns = ""
+        config.lftp.remote_address = "addr"
+        config.lftp.remote_username = "user"
+        config.lftp.remote_password = "pass"
+        config.lftp.remote_port = 22
+        config.lftp.remote_path = "/remote"
+        config.lftp.local_path = "/local"
+        config.lftp.remote_path_to_scan_script = "/scan"
+        config.lftp.use_ssh_key = False
+        config.lftp.num_max_parallel_downloads = 1
+        config.lftp.num_max_parallel_files_per_download = 1
+        config.lftp.num_max_connections_per_root_file = 1
+        config.lftp.num_max_connections_per_dir_file = 1
+        config.lftp.num_max_total_connections = 0
+        config.lftp.use_temp_file = False
+        config.lftp.net_limit_rate = ""
+        config.lftp.net_socket_buffer = "8M"
+        config.lftp.pget_min_chunk_size = "100M"
+        config.lftp.mirror_parallel_directories = True
+        config.lftp.net_timeout = 20
+        config.lftp.net_max_retries = 2
+        config.lftp.net_reconnect_interval_base = 3
+        config.lftp.net_reconnect_interval_multiplier = 1
+        config.controller.interval_ms_remote_scan = 1000
+        config.controller.interval_ms_local_scan = 1000
+        config.controller.interval_ms_downloading_scan = 1000
+        config.controller.extract_path = "/tmp"
+        config.controller.use_local_path_as_extract_path = True
+        config.controller.use_staging = False
+        config.controller.staging_path = "/staging"
+        config.web.port = 8800
+        config.autoqueue.enabled = True
+        config.autoqueue.patterns_only = False
+        config.autoqueue.auto_extract = True
+        config.autoqueue.auto_delete_remote = False
+        return config
+
+    def test_special_char_values_round_trip(self):
+        """Values containing '%', quotes, and unicode must survive a
+        to_str/from_str round trip verbatim.
+
+        Regression guard for the '%' interpolation crash (#507): the default
+        configparser BasicInterpolation treats '%' as a format token and raises
+        on both write and read. These run across free-text and secret fields.
+        """
+        specials = [
+            "100%secret",
+            "%%escaped%%",
+            "rate=50%",
+            'has"double',
+            "has'single",
+            "mix'\"both",
+            "ünïcødé☃",
+            "$(whoami)`id`",
+        ]
+        for value in specials:
+            with self.subTest(value=value):
+                config = self._full_config()
+                config.lftp.remote_password = value  # sensitive free-text
+                config.general.exclude_patterns = value  # free-text
+                config.lftp.net_limit_rate = value  # free-text
+                config.notifications.webhook_url = value  # sensitive free-text
+
+                config2 = Config.from_str(config.to_str())
+
+                self.assertEqual(value, config2.lftp.remote_password)
+                self.assertEqual(value, config2.general.exclude_patterns)
+                self.assertEqual(value, config2.lftp.net_limit_rate)
+                self.assertEqual(value, config2.notifications.webhook_url)
+                # Full structural equality as a backstop.
+                self.assertEqual(config.as_dict(), config2.as_dict())
+
     def test_controller_staging_missing_keys_use_defaults(self):
         """Staging properties missing from config should use None defaults (backward compat)"""
         good_dict = {

--- a/src/python/tests/unittests/test_controller/test_controller_persist.py
+++ b/src/python/tests/unittests/test_controller/test_controller_persist.py
@@ -1,7 +1,10 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
 import json
+import threading
 import unittest
+
+import timeout_decorator
 
 from common import PersistError
 from controller import ControllerPersist
@@ -217,3 +220,46 @@ class TestControllerPersist(unittest.TestCase):
             {f"{uuid1}{sep}bad.mkv"},
             persist.corrupt_file_names,
         )
+
+    @timeout_decorator.timeout(30)
+    def test_to_str_safe_during_concurrent_mutation(self):
+        """to_str() must not raise while another thread mutates the file-name
+        sets, and its output must always parse back via from_str().
+
+        to_str snapshots each set with list(set), which is atomic under the GIL,
+        so the serialize-while-mutate "set changed size during iteration"
+        RuntimeError cannot occur (main-thread persist vs controller-thread
+        mutation). This pins that contract against a regression to, e.g., a
+        Python-level loop over the live set.
+        """
+        persist = ControllerPersist()
+        stop = threading.Event()
+        errors: list[BaseException] = []
+
+        def mutate():
+            # Keep both sets bounded so each snapshot stays small; the point is
+            # churn (add/remove) concurrent with serialization, not size.
+            i = 0
+            try:
+                while not stop.is_set():
+                    persist.downloaded_file_names.add(f"file{i}")
+                    persist.extracted_file_names.add(f"ex{i}")
+                    i += 1
+                    if i % 64 == 0:
+                        persist.downloaded_file_names.difference_update({f"file{j}" for j in range(i - 64, i)})
+                        persist.extracted_file_names.difference_update({f"ex{j}" for j in range(i - 64, i)})
+            except Exception as e:  # surface any thread error to the test
+                errors.append(e)
+
+        thread = threading.Thread(target=mutate)
+        thread.start()
+        try:
+            for _ in range(2000):
+                content = persist.to_str()
+                # Output is always valid and round-trips through from_str().
+                ControllerPersist.from_str(content)
+        finally:
+            stop.set()
+            thread.join()
+
+        self.assertEqual([], errors)

--- a/src/python/tests/unittests/test_controller/test_extract/test_extract.py
+++ b/src/python/tests/unittests/test_controller/test_extract/test_extract.py
@@ -291,3 +291,58 @@ class TestExtractErrorCases(unittest.TestCase):
 
         self.assertTrue(os.path.isfile(os.path.join(self.out_dir, "file_a.txt")))
         self.assertTrue(os.path.isfile(os.path.join(self.out_dir, "file_b.txt")))
+
+
+class TestExtractPathValidation(unittest.TestCase):
+    """Post-extraction path-validation guard (extract.py): symlinks in the
+    output are stripped, and any extracted path whose realpath escapes the
+    output directory raises ExtractError. Archive contents are attacker-
+    controlled when the seedbox is hostile, so this walk is the only barrier."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="test_extract_pathval_")
+        self.out_dir = os.path.join(self.temp_dir, "output")
+        os.makedirs(self.out_dir)
+        # A file whose ZIP magic bytes make _detect_format report "ZIP" so we
+        # reach the validation walk; extraction itself (_run_7z) is mocked.
+        self.zip_path = os.path.join(self.temp_dir, "archive.zip")
+        with open(self.zip_path, "wb") as f:
+            f.write(b"PK\x03\x04" + b"\x00" * 64)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_planted_symlink_is_removed(self):
+        """A symlink planted in the extracted output is removed; real files
+        survive and extraction succeeds (no error)."""
+        target = os.path.join(self.temp_dir, "outside_target.txt")
+        with open(target, "wb") as f:
+            f.write(b"sensitive")
+
+        def fake_run_7z(_archive_path, out_dir_path):
+            with open(os.path.join(out_dir_path, "real.txt"), "wb") as f:
+                f.write(b"ok")
+            os.symlink(target, os.path.join(out_dir_path, "evil_link"))
+
+        with patch.object(Extract, "_run_7z", side_effect=fake_run_7z):
+            Extract.extract_archive(self.zip_path, self.out_dir)
+
+        # lexists() checks the link itself, not its target.
+        self.assertFalse(os.path.lexists(os.path.join(self.out_dir, "evil_link")))
+        self.assertTrue(os.path.isfile(os.path.join(self.out_dir, "real.txt")))
+        # Target outside the output dir is untouched.
+        self.assertTrue(os.path.isfile(target))
+
+    def test_escaping_path_raises_extract_error(self):
+        """An extracted entry whose realpath escapes the output directory raises
+        ExtractError. os.walk is stubbed to simulate 7z emitting a '../'
+        traversal entry (the classic zip-slip vector)."""
+        real_out = os.path.realpath(self.out_dir)
+        fake_walk = [(real_out, [], ["../../escaped_payload"])]
+        with (
+            patch.object(Extract, "_run_7z"),
+            patch("os.walk", return_value=fake_walk),
+        ):
+            with self.assertRaises(ExtractError) as ctx:
+                Extract.extract_archive(self.zip_path, self.out_dir)
+        self.assertIn("escapes target directory", str(ctx.exception))

--- a/src/python/tests/unittests/test_controller/test_notifier.py
+++ b/src/python/tests/unittests/test_controller/test_notifier.py
@@ -314,5 +314,37 @@ class TestWebhookNotifierDownloadStart(unittest.TestCase):
             mock.assert_not_called()
 
 
+class TestWebhookNotifierSchemeGuard(unittest.TestCase):
+    """_send_post's http/https allowlist is the SSRF/scheme guard for the
+    generic webhook and Discord/Telegram egress. Other tests patch _send_post
+    (or _fire_raw) itself, so the rejection branch and the urlopen call are
+    otherwise never executed."""
+
+    _LOGGER_NAME = "test_notifier_scheme"
+
+    def _make_notifier(self) -> WebhookNotifier:
+        return WebhookNotifier(MagicMock(), logging.getLogger(self._LOGGER_NAME))
+
+    def test_send_post_rejects_non_http_schemes(self):
+        for url in ("file:///etc/passwd", "ftp://example.com/payload", "gopher://example.com"):
+            with self.subTest(url=url):
+                notifier = self._make_notifier()
+                with (
+                    patch("urllib.request.urlopen") as mock_urlopen,
+                    self.assertLogs(self._LOGGER_NAME, level="WARNING") as logs,
+                ):
+                    notifier._send_post("Webhook", url, {}, b"payload")
+                mock_urlopen.assert_not_called()
+                self.assertTrue(any("rejected" in line for line in logs.output))
+
+    def test_send_post_allows_http_scheme(self):
+        """Sanity check that the guard isn't rejecting everything: a valid
+        http:// URL does reach urlopen."""
+        notifier = self._make_notifier()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            notifier._send_post("Webhook", "http://example.com/hook", {}, b"payload")
+        mock_urlopen.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/python/tests/unittests/test_ssh/test_sshcp_shell.py
+++ b/src/python/tests/unittests/test_ssh/test_sshcp_shell.py
@@ -1,0 +1,62 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import unittest
+from unittest.mock import MagicMock
+
+from ssh import Sshcp
+
+
+# noinspection SpellCheckingInspection
+class TestSshcpShellQuoting(unittest.TestCase):
+    """Offline unit tests for Sshcp.shell() command quoting.
+
+    shell() builds the string handed to the remote ssh command line. Its
+    hand-rolled quoting (not shlex.quote) is the local-side barrier for remote
+    command transport, so the exact quoted output must be pinned. These tests
+    patch _run_command so no live SSH server is needed.
+    """
+
+    def _make_sshcp(self) -> Sshcp:
+        sshcp = Sshcp.__new__(Sshcp)
+        sshcp._Sshcp__port = 22
+        # shell() calls self._remote_address(); shadow it with a fixed value.
+        sshcp._remote_address = MagicMock(return_value="user@host")
+        sshcp._Sshcp__run_command = MagicMock(return_value=b"")
+        return sshcp
+
+    def _args(self, sshcp: Sshcp) -> str:
+        """The 'args' string passed to _run_command: '<remote_address> <quoted_command>'."""
+        return sshcp._Sshcp__run_command.call_args.kwargs["args"]
+
+    def test_no_quotes_wrapped_in_double_quotes(self):
+        sshcp = self._make_sshcp()
+        sshcp.shell("ls -la")
+        self.assertEqual('user@host "ls -la"', self._args(sshcp))
+
+    def test_double_quotes_wrapped_in_single_quotes(self):
+        sshcp = self._make_sshcp()
+        sshcp.shell('echo "hi"')
+        self.assertEqual("user@host 'echo \"hi\"'", self._args(sshcp))
+
+    def test_single_quote_uses_shell_escape_trick(self):
+        sshcp = self._make_sshcp()
+        sshcp.shell("don't")
+        # ' -> '"'"'  (end quote, double-quoted literal quote, reopen quote)
+        self.assertEqual("user@host 'don'\"'\"'t'", self._args(sshcp))
+
+    def test_mixed_single_and_double_quotes(self):
+        sshcp = self._make_sshcp()
+        sshcp.shell("a'b\"c")
+        self.assertEqual("user@host 'a'\"'\"'b\"c'", self._args(sshcp))
+
+    def test_command_and_flags_are_passed(self):
+        sshcp = self._make_sshcp()
+        sshcp.shell("ls")
+        kwargs = sshcp._Sshcp__run_command.call_args.kwargs
+        self.assertEqual("ssh", kwargs["command"])
+        self.assertEqual("-p 22", kwargs["flags"])
+
+    def test_empty_command_raises(self):
+        sshcp = self._make_sshcp()
+        with self.assertRaises(ValueError):
+            sshcp.shell("")

--- a/src/python/tests/unittests/test_system/test_scanner.py
+++ b/src/python/tests/unittests/test_system/test_scanner.py
@@ -7,6 +7,8 @@ import unittest
 from datetime import datetime
 from threading import Thread
 
+import timeout_decorator
+
 from system import SystemScanner, SystemScannerError
 
 
@@ -649,3 +651,37 @@ class TestSystemScanner(unittest.TestCase):
         self.assertEqual("dir�dir", folder.name)
         self.assertEqual("file�file", file.name)
         self.assertEqual(128, file.size)
+
+    def test_symlink_to_outside_directory_is_traversed(self):
+        """Pins current behavior: the scanner follows directory symlinks
+        (DirEntry.is_dir defaults to follow_symlinks=True) and recurses into the
+        target, even when it points outside the scan root. path_to_scan comes
+        from config (untrusted when no api_key is set), so this guards against a
+        silent change in traversal behavior."""
+        outside = tempfile.mkdtemp(prefix="test_scanner_outside")
+        try:
+            with open(os.path.join(outside, "secret.txt"), "wb") as f:
+                f.write(b"x" * 100)
+            os.symlink(outside, os.path.join(TestSystemScanner.temp_dir, "link_to_outside"))
+
+            files = SystemScanner(TestSystemScanner.temp_dir).scan()
+
+            by_name = {f.name: f for f in files}
+            self.assertIn("link_to_outside", by_name)
+            link = by_name["link_to_outside"]
+            self.assertTrue(link.is_dir)
+            self.assertEqual(100, link.size)
+            self.assertEqual(["secret.txt"], [c.name for c in link.children])
+        finally:
+            shutil.rmtree(outside)
+
+    @timeout_decorator.timeout(15)
+    def test_cyclic_symlink_terminates_with_error(self):
+        """A self-referential directory symlink must not hang the scan. Symlink
+        resolution is bounded by the OS (ELOOP), so the scan terminates by
+        raising OSError rather than recursing forever. The timeout guards
+        against a regression to an unbounded loop; pinning OSError documents
+        that cycles are not silently swallowed."""
+        os.symlink(TestSystemScanner.temp_dir, os.path.join(TestSystemScanner.temp_dir, "loop"))
+        with self.assertRaises(OSError):
+            SystemScanner(TestSystemScanner.temp_dir).scan()

--- a/src/python/web/handler/integrations.py
+++ b/src/python/web/handler/integrations.py
@@ -134,7 +134,9 @@ class IntegrationsHandler(IHandler):
         # referenced) is recoverable; a dangling arr_target_id (instance gone,
         # path pair still references it) is rejected by cross-validation on load.
         self.__path_pairs_config.to_file(self.__path_pairs_path)
-        self.__config.to_file(self.__integrations_path)
+        err = self._persist_or_500(f"deleting instance {instance_id!r}")
+        if err is not None:
+            return err
         return HTTPResponse(status=204)
 
     def __handle_test(self, instance_id: str):

--- a/src/python/web/handler/integrations.py
+++ b/src/python/web/handler/integrations.py
@@ -30,6 +30,19 @@ class IntegrationsHandler(IHandler):
         self.__path_pairs_path = path_pairs_path
         self._logger = logging.getLogger(self.__class__.__name__)
 
+    def _persist_or_500(self, action: str) -> HTTPResponse | None:
+        """Persist the integrations config; return a 500 response on OSError, else None."""
+        try:
+            self.__config.to_file(self.__integrations_path)
+        except OSError:
+            self._logger.exception("Failed to persist integrations after %s", action)
+            return HTTPResponse(
+                body=json.dumps({"error": "failed to persist integrations"}),
+                status=500,
+                headers={"Content-Type": "application/json"},
+            )
+        return None
+
     @overrides(IHandler)
     def add_routes(self, web_app: WebApp):
         web_app.add_handler("/server/integrations", self.__handle_list)
@@ -57,7 +70,9 @@ class IntegrationsHandler(IHandler):
             self.__config.add_instance(instance)
         except ValueError as e:
             return HTTPResponse(body=str(e), status=409)
-        self.__config.to_file(self.__integrations_path)
+        err = self._persist_or_500(f"creating instance {instance.id!r}")
+        if err is not None:
+            return err
         return HTTPResponse(
             body=json.dumps(self._redact(instance.to_dict())),
             status=201,
@@ -99,7 +114,9 @@ class IntegrationsHandler(IHandler):
             if "not found" in msg:
                 return HTTPResponse(body="Integration not found", status=404)
             return HTTPResponse(body=msg, status=400)
-        self.__config.to_file(self.__integrations_path)
+        err = self._persist_or_500(f"updating instance {instance_id!r}")
+        if err is not None:
+            return err
         return HTTPResponse(
             body=json.dumps(self._redact(updated.to_dict())),
             headers={"Content-Type": "application/json"},


### PR DESCRIPTION
Resolves the **test-coverage** child issue #530 from tracking issue #531. Adds the missing tests on security- and reliability-critical paths, each pinning a contract. Two small production fixes are included where a contract test needs a defined target (the audit explicitly designed #530 to "lock in the contract" alongside such fixes).

Closes #530

> [!NOTE]
> **Depends on #529 (PR #533).** Two suites (`test_ssh/test_sshcp_shell.py`, `test_system/test_scanner.py`) live in directories that develop's CI still `--ignore`s; they run in CI only once #529 un-ignores them. Everything was validated locally on Linux (see test plan). The other 5 items land in suites that already run in CI.

## Acceptance criteria

| Audit item | Done |
|---|---|
| Extraction: planted symlink removed + escaping `_run_7z` output raises `ExtractError` | ✅ |
| `Sshcp.shell()`: offline test of exact quoting for no/double/single/mixed quotes | ✅ |
| `ControllerPersist`: mutate-while-`to_str()` test → no `RuntimeError` + clean round trip | ✅ (no fix needed — see below) |
| `Config`: round-trips for `%`/quotes/unicode in secret values + handler integration test | ✅ |
| Local scanner: escaping symlink + cyclic symlink (no infinite loop) | ✅ |
| `WebhookNotifier._fire_raw`: `urlopen` not called for `file://`/`ftp://` | ✅ (guard now lives in `_send_post`; tested there) |
| Integrations create/update: persist-failure tests mirroring path_pairs (wrap `to_file` first) | ✅ |

## Tests added
- **Extraction** — symlink stripped + extraction succeeds; `../`-escaping entry raises `ExtractError` (os.walk stubbed to simulate the zip-slip vector, since real symlinks are stripped before the escape check).
- **Sshcp.shell()** — new mock-based `test_sshcp_shell.py`; asserts the exact quoted string incl. the `'"'"'` single-quote-escape trick.
- **ControllerPersist** — concurrent mutate/`to_str()` stress test (bounded, `timeout_decorator`-guarded).
- **Config** — unit round-trips across secret + free-text fields; integration test posts a `%` value through the config handler and reloads it from disk.
- **Scanner** — escaping symlink is traversed (pins current follow-symlinks behavior); cyclic symlink raises `OSError` under a timeout (no hang).
- **Notifier** — `_send_post` rejects `file://`/`ftp://`/`gopher://` (no `urlopen`, warning logged) and allows `http://`.
- **Integrations** — create/update persist-failure → controlled `{"error": "failed to persist integrations"}` 500 + in-memory mutation survives.

## Production fixes (minimal, required by the contract tests)
- **`config.py`** — `ConfigParser(interpolation=None)` in `from_str`/`to_str`. Confirmed: a `%` in any value currently crashes `to_str` with `ValueError: invalid interpolation syntax`. This is the core of #507; the round-trip test locks it in.
- **`integrations.py`** — `_persist_or_500` helper (mirrors `path_pairs.py`) wrapping create/update `to_file`, so a disk error returns a controlled 500 instead of an unhandled traceback.

## Verified against current code
- **Item 3 needs no fix**: a 5000-iteration concurrent stress test showed `to_str()` never raises — `list(set)` is atomic under the GIL. The added test is a regression guard, not a paired fix.
- **Item 6 location drifted**: the scheme guard is in `_send_post` (synchronous), not the threaded `_fire_raw`; tested directly there (non-flaky).
- **Skipped**: the `remote_path_utils` double-quote escaper test from the audit — depends on a separate escaper fix, out of scope here.

## Test plan
Validated on Linux (`python:3.13-slim`, matching CI's `ubuntu-latest` + Python 3.13):
- ✅ Exact develop CI unit command → **708 passed** (includes the extract/config/persist/notifier additions).
- ✅ Web integration suite → **145 passed** (includes the config-`%` handler + integrations 500 tests).
- ✅ The #529-dependent suites validated explicitly: `test_sshcp_shell.py` + the new scanner symlink tests pass. (`test_system/test_file.py::test_size` fails on this branch only because it carries develop's pre-existing message rot, which **#529 fixes**; `test_system` is `--ignore`d in this PR's CI so it's unaffected.)
- ✅ `ruff check` + `ruff format --check` clean; `pyright` clean on the two changed production files (`tests/` is excluded from typecheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration values containing `%` characters being incorrectly interpreted as interpolation tokens during save and reload operations.
  * Improved error handling for configuration persistence failures, ensuring stable HTTP 500 error responses when persistence operations fail.

* **Tests**
  * Added comprehensive test coverage for special character handling, concurrent operations, path validation, webhook scheme verification, SSH command quoting, and directory symlink behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->