### PR TITLE
Fix frontend bugs/UX bucket from audit (#531)

### DIFF
--- a/src/angular/src/app/common/storage-keys.ts
+++ b/src/angular/src/app/common/storage-keys.ts
@@ -3,4 +3,5 @@ export class StorageKeys {
     public static readonly VIEW_OPTION_SORT_METHOD = "view-option-sort-method";
     public static readonly VIEW_OPTION_PIN = "view-option-pin";
     public static readonly THEME = "theme";
+    public static readonly API_KEY = "api-key";
 }

--- a/src/angular/src/app/common/storage-keys.ts
+++ b/src/angular/src/app/common/storage-keys.ts
@@ -3,5 +3,4 @@ export class StorageKeys {
     public static readonly VIEW_OPTION_SORT_METHOD = "view-option-sort-method";
     public static readonly VIEW_OPTION_PIN = "view-option-pin";
     public static readonly THEME = "theme";
-    public static readonly API_KEY = "api-key";
 }

--- a/src/angular/src/app/pages/files/bulk-action-bar.component.spec.ts
+++ b/src/angular/src/app/pages/files/bulk-action-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { BulkActionBarComponent } from './bulk-action-bar.component';
 
@@ -65,24 +65,32 @@ describe('BulkActionBarComponent', () => {
     expect(emitted).toBe(true);
   });
 
-  it('should emit deleteLocalEvent when Delete Local button is clicked', () => {
-    let emitted = false;
-    component.deleteLocalEvent.subscribe(() => (emitted = true));
+  it('should emit deleteLocalEvent only on the second Delete Local click', () => {
+    let emitCount = 0;
+    component.deleteLocalEvent.subscribe(() => (emitCount += 1));
 
-    const btn = findButtonByText('Delete Local');
-    btn.click();
+    // First click arms the confirm, does NOT emit
+    findButtonByText('Delete Local').click();
+    expect(emitCount).toBe(0);
 
-    expect(emitted).toBe(true);
+    // Second click emits
+    fixture.detectChanges();
+    findButtonByText('Confirm?').click();
+    expect(emitCount).toBe(1);
   });
 
-  it('should emit deleteRemoteEvent when Delete Remote button is clicked', () => {
-    let emitted = false;
-    component.deleteRemoteEvent.subscribe(() => (emitted = true));
+  it('should emit deleteRemoteEvent only on the second Delete Remote click', () => {
+    let emitCount = 0;
+    component.deleteRemoteEvent.subscribe(() => (emitCount += 1));
 
-    const btn = findButtonByText('Delete Remote');
-    btn.click();
+    // First click arms the confirm, does NOT emit
+    findButtonByText('Delete Remote').click();
+    expect(emitCount).toBe(0);
 
-    expect(emitted).toBe(true);
+    // Second click emits
+    fixture.detectChanges();
+    findButtonByText('Confirm?').click();
+    expect(emitCount).toBe(1);
   });
 
   it('should emit clearEvent when Clear button is clicked', () => {
@@ -98,5 +106,113 @@ describe('BulkActionBarComponent', () => {
   it('should render exactly five buttons', () => {
     const buttons = fixture.nativeElement.querySelectorAll('button');
     expect(buttons.length).toBe(5);
+  });
+});
+
+describe('BulkActionBarComponent inline bulk delete confirmation', () => {
+  let fixture: ComponentFixture<BulkActionBarComponent>;
+  let component: BulkActionBarComponent;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+
+    await TestBed.configureTestingModule({
+      imports: [BulkActionBarComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BulkActionBarComponent);
+    fixture.componentRef.setInput('count', 3);
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function findButtonByText(text: string): HTMLButtonElement {
+    const buttons = Array.from(
+      fixture.nativeElement.querySelectorAll('button'),
+    ) as HTMLButtonElement[];
+    const btn = buttons.find((el) => el.textContent?.includes(text));
+    expect(btn).toBeTruthy();
+    return btn!;
+  }
+
+  it('first click on Delete Local sets confirming state and does not emit', () => {
+    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+
+    component.onDeleteLocal();
+
+    expect(component.confirmingDelete).toBe('local');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('second click on Delete Local emits event and clears state', () => {
+    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+
+    component.onDeleteLocal();
+    expect(component.confirmingDelete).toBe('local');
+
+    component.onDeleteLocal();
+    expect(component.confirmingDelete).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('first click on Delete Remote sets confirming state and does not emit', () => {
+    const spy = vi.spyOn(component.deleteRemoteEvent, 'emit');
+
+    component.onDeleteRemote();
+
+    expect(component.confirmingDelete).toBe('remote');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('second click on Delete Remote emits event and clears state', () => {
+    const spy = vi.spyOn(component.deleteRemoteEvent, 'emit');
+
+    component.onDeleteRemote();
+    expect(component.confirmingDelete).toBe('remote');
+
+    component.onDeleteRemote();
+    expect(component.confirmingDelete).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('confirming state auto-resets after 3 seconds', () => {
+    component.onDeleteLocal();
+    expect(component.confirmingDelete).toBe('local');
+
+    vi.advanceTimersByTime(3000);
+    expect(component.confirmingDelete).toBeNull();
+  });
+
+  it('clicking Delete Local while confirming remote switches to local', () => {
+    component.onDeleteRemote();
+    expect(component.confirmingDelete).toBe('remote');
+
+    component.onDeleteLocal();
+    expect(component.confirmingDelete).toBe('local');
+  });
+
+  it("button label switches to 'Confirm?' after first Delete Local click", () => {
+    // Drive through a real DOM click so OnPush marks the view dirty.
+    findButtonByText('Delete Local').click();
+    fixture.detectChanges();
+
+    expect(component.confirmingDelete).toBe('local');
+    const btn = findButtonByText('Confirm?');
+    expect(btn.textContent).toContain('Confirm?');
+  });
+
+  it('ngOnDestroy clears the confirm timer so no reset fires', () => {
+    component.onDeleteLocal();
+    expect(component.confirmingDelete).toBe('local');
+
+    component.ngOnDestroy();
+    vi.advanceTimersByTime(5000);
+
+    // State stays as-is (timer was cleared, no reset happened)
+    expect(component.confirmingDelete).toBe('local');
   });
 });

--- a/src/angular/src/app/pages/files/bulk-action-bar.component.ts
+++ b/src/angular/src/app/pages/files/bulk-action-bar.component.ts
@@ -1,4 +1,6 @@
-import { Component, ChangeDetectionStrategy, input, output } from '@angular/core';
+import {
+    Component, ChangeDetectionStrategy, ChangeDetectorRef, OnDestroy, input, output, inject
+} from '@angular/core';
 
 @Component({
     selector: 'app-bulk-action-bar',
@@ -8,8 +10,16 @@ import { Component, ChangeDetectionStrategy, input, output } from '@angular/core
             <span class="count">{{ count() }} selected</span>
             <button class="btn btn-sm btn-outline-primary" (click)="queueEvent.emit()">Queue</button>
             <button class="btn btn-sm btn-outline-warning" (click)="stopEvent.emit()">Stop</button>
-            <button class="btn btn-sm btn-outline-danger" (click)="deleteLocalEvent.emit()">Delete Local</button>
-            <button class="btn btn-sm btn-outline-danger" (click)="deleteRemoteEvent.emit()">Delete Remote</button>
+            <button class="btn btn-sm btn-outline-danger"
+                    [class.confirming]="confirmingDelete === 'local'"
+                    (click)="onDeleteLocal()">
+                {{ confirmingDelete === 'local' ? 'Confirm?' : 'Delete Local' }}
+            </button>
+            <button class="btn btn-sm btn-outline-danger"
+                    [class.confirming]="confirmingDelete === 'remote'"
+                    (click)="onDeleteRemote()">
+                {{ confirmingDelete === 'remote' ? 'Confirm?' : 'Delete Remote' }}
+            </button>
             <button class="btn btn-sm btn-outline-secondary" (click)="clearEvent.emit()">Clear</button>
         </div>
     `,
@@ -26,10 +36,16 @@ import { Component, ChangeDetectionStrategy, input, output } from '@angular/core
             font-weight: bold;
             margin-right: 8px;
         }
+        .btn.confirming {
+            background-color: var(--bs-danger);
+            color: #fff;
+        }
     `],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BulkActionBarComponent {
+export class BulkActionBarComponent implements OnDestroy {
+    private readonly cdr = inject(ChangeDetectorRef);
+
     count = input.required<number>();
 
     queueEvent = output<void>();
@@ -37,4 +53,49 @@ export class BulkActionBarComponent {
     deleteLocalEvent = output<void>();
     deleteRemoteEvent = output<void>();
     clearEvent = output<void>();
+
+    // Inline double-click delete confirmation state
+    confirmingDelete: 'local' | 'remote' | null = null;
+    private confirmResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+    ngOnDestroy(): void {
+        this.clearConfirmTimer();
+    }
+
+    onDeleteLocal(): void {
+        if (this.confirmingDelete === 'local') {
+            this.clearConfirmTimer();
+            this.confirmingDelete = null;
+            this.deleteLocalEvent.emit();
+        } else {
+            this.setConfirming('local');
+        }
+    }
+
+    onDeleteRemote(): void {
+        if (this.confirmingDelete === 'remote') {
+            this.clearConfirmTimer();
+            this.confirmingDelete = null;
+            this.deleteRemoteEvent.emit();
+        } else {
+            this.setConfirming('remote');
+        }
+    }
+
+    private setConfirming(type: 'local' | 'remote'): void {
+        this.clearConfirmTimer();
+        this.confirmingDelete = type;
+        this.confirmResetTimer = setTimeout(() => {
+            this.confirmingDelete = null;
+            this.confirmResetTimer = null;
+            this.cdr.markForCheck();
+        }, 3000);
+    }
+
+    private clearConfirmTimer(): void {
+        if (this.confirmResetTimer !== null) {
+            clearTimeout(this.confirmResetTimer);
+            this.confirmResetTimer = null;
+        }
+    }
 }

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -1,15 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { BehaviorSubject, Observable, of, EMPTY } from 'rxjs';
+import { BehaviorSubject, Observable, of, EMPTY, throwError } from 'rxjs';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 
 import { FileListComponent } from './file-list.component';
 import { ViewFileService } from '../../services/files/view-file.service';
 import { ViewFileOptionsService } from '../../services/files/view-file-options.service';
 import { LoggerService } from '../../services/utils/logger.service';
+import { NotificationService } from '../../services/utils/notification.service';
+import { NotificationLevel } from '../../models/notification';
 import { ViewFile, ViewFileStatus } from '../../models/view-file';
 import { ViewFileOptions, SortMethod } from '../../models/view-file-options';
 import { fileKey } from '../../services/files/file-key';
+import { FileActionEvent } from './file.component';
 
 interface MockViewFileService {
   filteredFiles$: Observable<ViewFile[]>;
@@ -30,6 +33,15 @@ interface MockViewFileService {
   bulkStop: ReturnType<typeof vi.fn>;
   bulkDeleteLocal: ReturnType<typeof vi.fn>;
   bulkDeleteRemote: ReturnType<typeof vi.fn>;
+}
+
+interface MockNotificationService {
+  show: ReturnType<typeof vi.fn>;
+  hide: ReturnType<typeof vi.fn>;
+}
+
+function makeActionEvent(file: ViewFile): FileActionEvent {
+  return { file, clearActiveAction: vi.fn() };
 }
 
 function makeViewFile(overrides: Partial<ViewFile> = {}): ViewFile {
@@ -71,6 +83,7 @@ describe('FileListComponent', () => {
   let checkedSubject: BehaviorSubject<Set<string>>;
   let optionsSubject: BehaviorSubject<ViewFileOptions>;
   let mockViewFileService: MockViewFileService;
+  let mockNotifService: MockNotificationService;
 
   beforeEach(async () => {
     filteredFilesSubject = new BehaviorSubject<ViewFile[]>([]);
@@ -104,12 +117,15 @@ describe('FileListComponent', () => {
       bulkDeleteRemote: vi.fn().mockReturnValue(EMPTY),
     };
 
+    mockNotifService = { show: vi.fn(), hide: vi.fn() };
+
     await TestBed.configureTestingModule({
       imports: [FileListComponent, ScrollingModule],
       providers: [
         { provide: ViewFileService, useValue: mockViewFileService },
         { provide: ViewFileOptionsService, useValue: { options$: optionsSubject.asObservable() } },
         { provide: LoggerService, useValue: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+        { provide: NotificationService, useValue: mockNotifService },
       ],
     }).compileComponents();
 
@@ -269,7 +285,7 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'queue-me.txt' });
     mockViewFileService.queue.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onQueue(file);
+    component.onQueue(makeActionEvent(file));
 
     expect(mockViewFileService.queue).toHaveBeenCalledWith(file);
   });
@@ -278,7 +294,7 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'stop-me.txt' });
     mockViewFileService.stop.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onStop(file);
+    component.onStop(makeActionEvent(file));
 
     expect(mockViewFileService.stop).toHaveBeenCalledWith(file);
   });
@@ -287,7 +303,7 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'extract-me.txt' });
     mockViewFileService.extract.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onExtract(file);
+    component.onExtract(makeActionEvent(file));
 
     expect(mockViewFileService.extract).toHaveBeenCalledWith(file);
   });
@@ -296,7 +312,7 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'validate-me.txt' });
     mockViewFileService.validate.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onValidate(file);
+    component.onValidate(makeActionEvent(file));
 
     expect(mockViewFileService.validate).toHaveBeenCalledWith(file);
   });
@@ -305,7 +321,7 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'del-local.txt' });
     mockViewFileService.deleteLocal.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onDeleteLocal(file);
+    component.onDeleteLocal(makeActionEvent(file));
 
     expect(mockViewFileService.deleteLocal).toHaveBeenCalledWith(file);
   });
@@ -314,9 +330,67 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'del-remote.txt' });
     mockViewFileService.deleteRemote.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onDeleteRemote(file);
+    component.onDeleteRemote(makeActionEvent(file));
 
     expect(mockViewFileService.deleteRemote).toHaveBeenCalledWith(file);
+  });
+
+  // --- Single-file action error surfacing (#513) ---
+
+  it('shows a DANGER banner and clears activeAction when an action fails', () => {
+    const file = makeViewFile({ name: 'fail-me.txt' });
+    const event = makeActionEvent(file);
+    mockViewFileService.queue.mockReturnValue(
+      of({ success: false, data: null, errorMessage: 'Boom' }),
+    );
+
+    component.onQueue(event);
+
+    expect(mockNotifService.show).toHaveBeenCalledTimes(1);
+    const notif = mockNotifService.show.mock.calls[0][0];
+    expect(notif.level).toBe(NotificationLevel.DANGER);
+    expect(notif.text).toContain('Boom');
+    expect(event.clearActiveAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a generic message when a failed reaction has no errorMessage', () => {
+    const event = makeActionEvent(makeViewFile());
+    mockViewFileService.stop.mockReturnValue(
+      of({ success: false, data: null, errorMessage: null }),
+    );
+
+    component.onStop(event);
+
+    expect(mockNotifService.show).toHaveBeenCalledTimes(1);
+    expect(mockNotifService.show.mock.calls[0][0].text).toBe('Action failed');
+    expect(event.clearActiveAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show a banner or clear activeAction on a successful action', () => {
+    const logger = TestBed.inject(LoggerService);
+    const event = makeActionEvent(makeViewFile());
+    mockViewFileService.validate.mockReturnValue(
+      of({ success: true, data: 'ok', errorMessage: null }),
+    );
+
+    component.onValidate(event);
+
+    expect(mockNotifService.show).not.toHaveBeenCalled();
+    expect(event.clearActiveAction).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('ok');
+  });
+
+  it('shows a DANGER banner and clears activeAction when the action stream errors', () => {
+    const event = makeActionEvent(makeViewFile());
+    mockViewFileService.deleteRemote.mockReturnValue(
+      throwError(() => new Error('net')),
+    );
+
+    component.onDeleteRemote(event);
+
+    expect(mockNotifService.show).toHaveBeenCalledTimes(1);
+    expect(mockNotifService.show.mock.calls[0][0].level).toBe(NotificationLevel.DANGER);
+    expect(event.clearActiveAction).toHaveBeenCalledTimes(1);
   });
 
   // --- Bulk actions ---
@@ -367,7 +441,7 @@ describe('FileListComponent', () => {
 
   // --- Bulk response handling ---
 
-  it('should log failures from bulk action responses', () => {
+  it('should log failures and show a DANGER banner from bulk action responses', () => {
     const logger = TestBed.inject(LoggerService);
     mockViewFileService.bulkQueue.mockReturnValue(of([
       { success: true, data: 'ok', errorMessage: null },
@@ -378,6 +452,21 @@ describe('FileListComponent', () => {
 
     expect(logger.error).toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalled();
+    expect(mockNotifService.show).toHaveBeenCalledTimes(1);
+    const notif = mockNotifService.show.mock.calls[0][0];
+    expect(notif.level).toBe(NotificationLevel.DANGER);
+    expect(notif.text).toBe('1 of 2 items failed');
+  });
+
+  it('should not show a banner when all bulk items succeed', () => {
+    mockViewFileService.bulkDeleteLocal.mockReturnValue(of([
+      { success: true, data: 'ok', errorMessage: null },
+      { success: true, data: 'ok2', errorMessage: null },
+    ]));
+
+    component.onBulkDeleteLocal();
+
+    expect(mockNotifService.show).not.toHaveBeenCalled();
   });
 
   it('should log info for successful bulk items', () => {

--- a/src/angular/src/app/pages/files/file-list.component.ts
+++ b/src/angular/src/app/pages/files/file-list.component.ts
@@ -20,8 +20,10 @@ import { ViewFile } from '../../models/view-file';
 import { ViewFileOptions } from '../../models/view-file-options';
 import { ViewFileOptionsService } from '../../services/files/view-file-options.service';
 import { LoggerService } from '../../services/utils/logger.service';
+import { NotificationService } from '../../services/utils/notification.service';
+import { NotificationLevel, createNotification } from '../../models/notification';
 import { fileKey } from '../../services/files/file-key';
-import { FileComponent } from './file.component';
+import { FileComponent, FileActionEvent } from './file.component';
 import { BulkActionBarComponent } from './bulk-action-bar.component';
 
 @Component({
@@ -38,6 +40,7 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
   private readonly logger = inject(LoggerService);
   private readonly viewFileService = inject(ViewFileService);
   private readonly viewFileOptionsService = inject(ViewFileOptionsService);
+  private readonly notifService = inject(NotificationService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly elRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly zone = inject(NgZone);
@@ -121,52 +124,80 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  onQueue(file: ViewFile): void {
-    this.viewFileService.queue(file).pipe(
+  onQueue(event: FileActionEvent): void {
+    this.viewFileService.queue(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
   }
 
-  onStop(file: ViewFile): void {
-    this.viewFileService.stop(file).pipe(
+  onStop(event: FileActionEvent): void {
+    this.viewFileService.stop(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
   }
 
-  onExtract(file: ViewFile): void {
-    this.viewFileService.extract(file).pipe(
+  onExtract(event: FileActionEvent): void {
+    this.viewFileService.extract(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
   }
 
-  onValidate(file: ViewFile): void {
-    this.viewFileService.validate(file).pipe(
+  onValidate(event: FileActionEvent): void {
+    this.viewFileService.validate(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
   }
 
-  onDeleteLocal(file: ViewFile): void {
-    this.viewFileService.deleteLocal(file).pipe(
+  onDeleteLocal(event: FileActionEvent): void {
+    this.viewFileService.deleteLocal(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
   }
 
-  onDeleteRemote(file: ViewFile): void {
-    this.viewFileService.deleteRemote(file).pipe(
+  onDeleteRemote(event: FileActionEvent): void {
+    this.viewFileService.deleteRemote(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
+  }
+
+  private handleActionResponse(reaction: WebReaction, event: FileActionEvent): void {
+    if (reaction.success) {
+      this.logger.info(reaction.data);
+    } else {
+      this.failAction(reaction.errorMessage ?? 'Action failed', event);
+    }
+  }
+
+  private handleActionError(err: unknown, event: FileActionEvent): void {
+    this.failAction('Action failed', event);
+    this.logger.error('Action failed:', err);
+  }
+
+  // A backend rejection leaves the file model unchanged, so the child's
+  // ngOnChanges can't recover the row. Surface the error and clear the child's
+  // activeAction so the buttons re-enable and the spinner stops without a reload.
+  private failAction(text: string, event: FileActionEvent): void {
+    this.notifService.show(createNotification(NotificationLevel.DANGER, text, true));
+    event.clearActiveAction();
+    this.logger.error(text);
   }
 
   onCheck(event: {file: ViewFile, shiftKey: boolean}): void {
@@ -206,6 +237,11 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
         });
         if (failures > 0) {
           this.logger.warn(`Bulk action: ${failures} of ${reactions.length} items failed`);
+          this.notifService.show(createNotification(
+            NotificationLevel.DANGER,
+            `${failures} of ${reactions.length} items failed`,
+            true,
+          ));
         }
       },
       error: (err) => this.logger.error('Bulk action failed:', err),

--- a/src/angular/src/app/pages/files/file.component.spec.ts
+++ b/src/angular/src/app/pages/files/file.component.spec.ts
@@ -175,7 +175,7 @@ describe('FileComponent inline delete confirmation', () => {
     component.onDeleteLocal(file);
     expect(component.confirmingDelete).toBeNull();
     expect(component.activeAction).toBe(FileAction.DELETE_LOCAL);
-    expect(spy).toHaveBeenCalledWith(file);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ file }));
   });
 
   it('first click on delete remote sets confirming state', () => {
@@ -193,7 +193,7 @@ describe('FileComponent inline delete confirmation', () => {
 
     expect(component.confirmingDelete).toBeNull();
     expect(component.activeAction).toBe(FileAction.DELETE_REMOTE);
-    expect(spy).toHaveBeenCalledWith(file);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ file }));
   });
 
   it('confirming state auto-resets after 3 seconds', () => {
@@ -254,5 +254,68 @@ describe('FileComponent inline delete confirmation', () => {
     vi.advanceTimersByTime(5000);
     // State stays as-is (timer was cleared, no reset happened)
     expect(component.confirmingDelete).toBe('local');
+  });
+});
+
+describe('FileComponent action events', () => {
+  let fixture: ComponentFixture<FileComponent>;
+  let component: FileComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FileComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FileComponent);
+    fixture.componentRef.setInput('file', makeViewFile());
+    fixture.componentRef.setInput('options', of({ nameFilter: '', statusFilter: '' }));
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+  });
+
+  it('clearActiveAction resets activeAction to null', () => {
+    component.activeAction = FileAction.QUEUE;
+    component.clearActiveAction();
+    expect(component.activeAction).toBeNull();
+  });
+
+  it.each([
+    ['onQueue', 'queueEvent'],
+    ['onStop', 'stopEvent'],
+    ['onExtract', 'extractEvent'],
+    ['onValidate', 'validateEvent'],
+  ] as const)(
+    '%s emits an event carrying the file and a clearActiveAction callback',
+    (method, eventName) => {
+      const file = makeViewFile();
+      const spy = vi.spyOn(component[eventName], 'emit');
+
+      component[method](file);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const payload = spy.mock.calls[0][0];
+      expect(payload.file).toBe(file);
+      expect(typeof payload.clearActiveAction).toBe('function');
+
+      // Action is active until the callback fires.
+      expect(component.activeAction).not.toBeNull();
+      payload.clearActiveAction();
+      expect(component.activeAction).toBeNull();
+    },
+  );
+
+  it('delete emits a clearActiveAction callback that resets activeAction', () => {
+    const file = makeViewFile();
+    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+
+    // Double-click to confirm and emit.
+    component.onDeleteLocal(file);
+    component.onDeleteLocal(file);
+
+    expect(component.activeAction).toBe(FileAction.DELETE_LOCAL);
+    const payload = spy.mock.calls[0][0];
+    expect(payload.file).toBe(file);
+    payload.clearActiveAction();
+    expect(component.activeAction).toBeNull();
   });
 });

--- a/src/angular/src/app/pages/files/file.component.ts
+++ b/src/angular/src/app/pages/files/file.component.ts
@@ -21,6 +21,17 @@ export enum FileAction {
   DELETE_REMOTE
 }
 
+// Payload emitted for each single-file action. Carries the target file plus a
+// callback the parent invokes to clear this child's activeAction when the
+// backend rejects the request — the file model never changes on failure, so
+// ngOnChanges cannot recover the row on its own. The callback is necessary
+// because <app-file> is rendered inside *cdkVirtualFor, which recycles
+// instances and prevents the parent from keying a @ViewChildren to a file.
+export interface FileActionEvent {
+  file: ViewFile;
+  clearActiveAction: () => void;
+}
+
 @Component({
   selector: 'app-file',
   standalone: true,
@@ -48,12 +59,12 @@ export class FileComponent implements OnChanges, OnDestroy {
   options = input.required<Observable<ViewFileOptions>>();
 
   checkEvent = output<{file: ViewFile, shiftKey: boolean}>();
-  queueEvent = output<ViewFile>();
-  stopEvent = output<ViewFile>();
-  extractEvent = output<ViewFile>();
-  deleteLocalEvent = output<ViewFile>();
-  validateEvent = output<ViewFile>();
-  deleteRemoteEvent = output<ViewFile>();
+  queueEvent = output<FileActionEvent>();
+  stopEvent = output<FileActionEvent>();
+  extractEvent = output<FileActionEvent>();
+  deleteLocalEvent = output<FileActionEvent>();
+  validateEvent = output<FileActionEvent>();
+  deleteRemoteEvent = output<FileActionEvent>();
 
   activeAction: FileAction | null = null;
 
@@ -128,24 +139,36 @@ export class FileComponent implements OnChanges, OnDestroy {
     return this.activeAction == null && this.file().isRemotelyDeletable;
   }
 
+  // Cleared by the parent when an action's backend request fails or errors.
+  // Runs inside the parent's async subscribe callback, so OnPush needs an
+  // explicit markForCheck to re-enable the buttons and stop the spinner.
+  clearActiveAction(): void {
+    this.activeAction = null;
+    this.cdr.markForCheck();
+  }
+
+  private actionEvent(file: ViewFile): FileActionEvent {
+    return { file, clearActiveAction: () => this.clearActiveAction() };
+  }
+
   onQueue(file: ViewFile): void {
     this.activeAction = FileAction.QUEUE;
-    this.queueEvent.emit(file);
+    this.queueEvent.emit(this.actionEvent(file));
   }
 
   onStop(file: ViewFile): void {
     this.activeAction = FileAction.STOP;
-    this.stopEvent.emit(file);
+    this.stopEvent.emit(this.actionEvent(file));
   }
 
   onExtract(file: ViewFile): void {
     this.activeAction = FileAction.EXTRACT;
-    this.extractEvent.emit(file);
+    this.extractEvent.emit(this.actionEvent(file));
   }
 
   onValidate(file: ViewFile): void {
     this.activeAction = FileAction.VALIDATE;
-    this.validateEvent.emit(file);
+    this.validateEvent.emit(this.actionEvent(file));
   }
 
   onDeleteLocal(file: ViewFile): void {
@@ -153,7 +176,7 @@ export class FileComponent implements OnChanges, OnDestroy {
       this.clearConfirmTimer();
       this.confirmingDelete = null;
       this.activeAction = FileAction.DELETE_LOCAL;
-      this.deleteLocalEvent.emit(file);
+      this.deleteLocalEvent.emit(this.actionEvent(file));
     } else {
       this.setConfirming('local');
     }
@@ -164,7 +187,7 @@ export class FileComponent implements OnChanges, OnDestroy {
       this.clearConfirmTimer();
       this.confirmingDelete = null;
       this.activeAction = FileAction.DELETE_REMOTE;
-      this.deleteRemoteEvent.emit(file);
+      this.deleteRemoteEvent.emit(this.actionEvent(file));
     } else {
       this.setConfirming('remote');
     }

--- a/src/angular/src/app/pages/logs/logs-page.component.html
+++ b/src/angular/src/app/pages/logs/logs-page.component.html
@@ -26,7 +26,7 @@
   @if (historyLoaded && historyLoadFailed) {
     <div class="history-section">
       <div class="history-header">Log History</div>
-      <p class="history-load-error">Failed to load log history. Check the connection and try again.</p>
+      <p class="history-load-error" role="alert">Failed to load log history. Check the connection and try again.</p>
     </div>
     <hr class="log-divider" />
   } @else if (historyLoaded && historyRecords.length > 0) {

--- a/src/angular/src/app/pages/logs/logs-page.component.html
+++ b/src/angular/src/app/pages/logs/logs-page.component.html
@@ -23,7 +23,13 @@
     </select>
   </div>
 
-  @if (historyLoaded && historyRecords.length > 0) {
+  @if (historyLoaded && historyLoadFailed) {
+    <div class="history-section">
+      <div class="history-header">Log History</div>
+      <p class="record error">Failed to load log history. Check the connection and try again.</p>
+    </div>
+    <hr class="log-divider" />
+  } @else if (historyLoaded && historyRecords.length > 0) {
     <div class="history-section">
       <div class="history-header">Log History</div>
       @for (entry of historyRecords; track $index) {

--- a/src/angular/src/app/pages/logs/logs-page.component.html
+++ b/src/angular/src/app/pages/logs/logs-page.component.html
@@ -26,7 +26,7 @@
   @if (historyLoaded && historyLoadFailed) {
     <div class="history-section">
       <div class="history-header">Log History</div>
-      <p class="record error">Failed to load log history. Check the connection and try again.</p>
+      <p class="history-load-error">Failed to load log history. Check the connection and try again.</p>
     </div>
     <hr class="log-divider" />
   } @else if (historyLoaded && historyRecords.length > 0) {

--- a/src/angular/src/app/pages/logs/logs-page.component.scss
+++ b/src/angular/src/app/pages/logs/logs-page.component.scss
@@ -35,6 +35,13 @@
             color: var(--ss-text-muted);
             margin-bottom: 5px;
         }
+
+        // Distinct from p.record so log-record queries never match this banner.
+        .history-load-error {
+            color: var(--ss-log-error-text);
+            font-size: 90%;
+            margin: 0;
+        }
     }
 
     .log-divider {

--- a/src/angular/src/app/pages/logs/logs-page.component.spec.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Subject, of } from 'rxjs';
+
+import { LogsPageComponent } from './logs-page.component';
+import { LogService } from '../../services/logs/log.service';
+import { DomService } from '../../services/utils/dom.service';
+
+/**
+ * Covers #516: a log-history fetch failure must render a distinct "failed to
+ * load" state, not be indistinguishable from an empty (successful) result.
+ * The debounced search pipe is not exercised here (the failure flag is set by
+ * its catchError); these tests verify the template renders each state.
+ */
+describe('LogsPageComponent history failure state (#516)', () => {
+  let fixture: ComponentFixture<LogsPageComponent>;
+  let component: LogsPageComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [LogsPageComponent],
+      providers: [
+        {
+          provide: LogService,
+          useValue: { logs$: new Subject(), fetchHistory: vi.fn().mockReturnValue(of([])) },
+        },
+        { provide: DomService, useValue: { headerHeight$: of(0) } },
+      ],
+    });
+    fixture = TestBed.createComponent(LogsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    vi.restoreAllMocks();
+  });
+
+  function renderedText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('renders a distinct failure message when the history fetch failed', () => {
+    component.historyLoaded = true;
+    component.historyLoadFailed = true;
+    component.historyRecords = [];
+    fixture.detectChanges();
+
+    expect(renderedText()).toContain('Failed to load log history');
+  });
+
+  it('shows no failure message for an empty (successful) result', () => {
+    component.historyLoaded = true;
+    component.historyLoadFailed = false;
+    component.historyRecords = [];
+    fixture.detectChanges();
+
+    expect(renderedText()).not.toContain('Failed to load log history');
+  });
+});

--- a/src/angular/src/app/pages/logs/logs-page.component.spec.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.spec.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { Subject, of } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 
 import { LogsPageComponent } from './logs-page.component';
 import { LogService } from '../../services/logs/log.service';
 import { DomService } from '../../services/utils/dom.service';
+import { LoggerService } from '../../services/utils/logger.service';
+
+function loggerMock() {
+  return { error: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
+}
 
 /**
  * Covers #516: a log-history fetch failure must render a distinct "failed to
@@ -25,6 +30,7 @@ describe('LogsPageComponent history failure state (#516)', () => {
           useValue: { logs$: new Subject(), fetchHistory: vi.fn().mockReturnValue(of([])) },
         },
         { provide: DomService, useValue: { headerHeight$: of(0) } },
+        { provide: LoggerService, useValue: loggerMock() },
       ],
     });
     fixture = TestBed.createComponent(LogsPageComponent);
@@ -57,5 +63,47 @@ describe('LogsPageComponent history failure state (#516)', () => {
     fixture.detectChanges();
 
     expect(renderedText()).not.toContain('Failed to load log history');
+  });
+});
+
+/**
+ * Exercises the real debounced search pipe so the test fails if catchError stops
+ * setting the failure flag (not just the rendered template). Uses fake timers to
+ * flush the 300ms debounce deterministically.
+ */
+describe('LogsPageComponent history fetch failure (real pipe, #516)', () => {
+  let fixture: ComponentFixture<LogsPageComponent>;
+  let component: LogsPageComponent;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestBed.configureTestingModule({
+      imports: [LogsPageComponent],
+      providers: [
+        {
+          provide: LogService,
+          useValue: { logs$: new Subject(), fetchHistory: vi.fn().mockReturnValue(throwError(() => new Error('boom'))) },
+        },
+        { provide: DomService, useValue: { headerHeight$: of(0) } },
+        { provide: LoggerService, useValue: loggerMock() },
+      ],
+    });
+    fixture = TestBed.createComponent(LogsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges(); // ngOnInit -> initial searchChange$.next() schedules the debounce
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('flips into the failure state when fetchHistory errors', () => {
+    vi.advanceTimersByTime(300); // flush debounce -> fetchHistory errors -> catchError
+    fixture.detectChanges();
+
+    expect(component.historyLoadFailed).toBe(true);
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Failed to load log history');
   });
 });

--- a/src/angular/src/app/pages/logs/logs-page.component.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.ts
@@ -21,6 +21,7 @@ import { of } from 'rxjs';
 import { LogService, LogHistoryEntry } from '../../services/logs/log.service';
 import { LogRecord, LogLevel } from '../../models/log-record';
 import { DomService } from '../../services/utils/dom.service';
+import { LoggerService } from '../../services/utils/logger.service';
 
 @Component({
   selector: 'app-logs-page',
@@ -38,6 +39,7 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   private readonly logService = inject(LogService);
   private readonly domService = inject(DomService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly logger = inject(LoggerService);
 
   readonly headerHeight$ = this.domService.headerHeight$;
 
@@ -46,6 +48,7 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   searchQuery = '';
   levelFilter = '';
   historyLoaded = false;
+  historyLoadFailed = false;
 
   showScrollToTopButton = false;
   showScrollToBottomButton = false;
@@ -78,13 +81,23 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
 
     this.searchChange$.pipe(
       debounceTime(300),
-      switchMap(() => this.logService.fetchHistory({
-        search: this.searchQuery || undefined,
-        level: this.levelFilter || undefined,
-        limit: 500,
-      }).pipe(
-        catchError(() => of([] as LogHistoryEntry[]))
-      )),
+      switchMap(() => {
+        // Reset the failure flag per search; catchError sets it on a real fetch
+        // failure so the template can distinguish "failed to load" from "no
+        // matching history" (both otherwise yield an empty list).
+        this.historyLoadFailed = false;
+        return this.logService.fetchHistory({
+          search: this.searchQuery || undefined,
+          level: this.levelFilter || undefined,
+          limit: 500,
+        }).pipe(
+          catchError((err) => {
+            this.logger.error('Failed to load log history: %O', err);
+            this.historyLoadFailed = true;
+            return of([] as LogHistoryEntry[]);
+          })
+        );
+      }),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((entries) => {
       this.historyRecords = entries;

--- a/src/angular/src/app/pages/settings/path-pairs.component.spec.ts
+++ b/src/angular/src/app/pages/settings/path-pairs.component.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 
 import { PathPair } from '../../models/path-pair';
 import { ArrInstance } from '../../models/arr-instance';
@@ -8,6 +8,7 @@ interface PathPairsServiceLike {
   create(pair: Omit<PathPair, 'id'>): Observable<PathPair | null>;
   update(pair: PathPair): Observable<PathPair | null>;
   remove(pairId: string): Observable<boolean>;
+  refresh(): void;
 }
 
 function makePair(overrides: Partial<PathPair> = {}): PathPair {
@@ -47,6 +48,7 @@ class PathPairsLogic {
   addForm: Omit<PathPair, 'id'> = this.emptyForm();
   confirmingDeleteId: string | null = null;
   arrPickerPairId: string | null = null;
+  errorMessage: string | null = null;
   private confirmResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private service: PathPairsServiceLike) {}
@@ -110,11 +112,27 @@ class PathPairsLogic {
   }
 
   onToggleEnabled(pair: PathPair, enabled: boolean): void {
-    this.service.update({ ...pair, enabled }).subscribe();
+    this.applyToggle({ ...pair, enabled });
   }
 
   onToggleAutoQueue(pair: PathPair, autoQueue: boolean): void {
-    this.service.update({ ...pair, auto_queue: autoQueue }).subscribe();
+    this.applyToggle({ ...pair, auto_queue: autoQueue });
+  }
+
+  private applyToggle(updated: PathPair): void {
+    this.errorMessage = null;
+    this.service.update(updated).subscribe({
+      next: (result) => {
+        if (!result) {
+          this.errorMessage = 'Failed to update path pair. Please try again.';
+          this.service.refresh();
+        }
+      },
+      error: () => {
+        this.errorMessage = 'Failed to update path pair. Please try again.';
+        this.service.refresh();
+      },
+    });
   }
 
   // --- Arr targets ---
@@ -200,6 +218,7 @@ describe('PathPairsComponent logic', () => {
     create: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     remove: ReturnType<typeof vi.fn>;
+    refresh: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -207,6 +226,7 @@ describe('PathPairsComponent logic', () => {
       create: vi.fn().mockReturnValue(of(makePair({ id: '2', name: 'New' }))),
       update: vi.fn().mockReturnValue(of(makePair({ enabled: false }))),
       remove: vi.fn().mockReturnValue(of(true)),
+      refresh: vi.fn(),
     };
     component = new PathPairsLogic(mockService as unknown as PathPairsServiceLike);
   });
@@ -286,6 +306,36 @@ describe('PathPairsComponent logic', () => {
     component.onSaveEdit();
     expect(mockService.update).toHaveBeenCalled();
     expect(component.editingId).toBe('p1');
+  });
+
+  describe('toggle enable / auto-queue (#516)', () => {
+    it('clears the error and does not refresh on a successful toggle', () => {
+      mockService.update.mockReturnValue(of(makePair({ enabled: false })));
+
+      component.onToggleEnabled(makePair(), false);
+
+      expect(mockService.update).toHaveBeenCalled();
+      expect(component.errorMessage).toBeNull();
+      expect(mockService.refresh).not.toHaveBeenCalled();
+    });
+
+    it('sets an error and refreshes to reconcile when a toggle returns null', () => {
+      mockService.update.mockReturnValue(of(null));
+
+      component.onToggleAutoQueue(makePair(), true);
+
+      expect(component.errorMessage).toBe('Failed to update path pair. Please try again.');
+      expect(mockService.refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets an error and refreshes when a toggle errors (e.g. network failure)', () => {
+      mockService.update.mockReturnValue(throwError(() => new Error('network')));
+
+      component.onToggleEnabled(makePair(), true);
+
+      expect(component.errorMessage).toBe('Failed to update path pair. Please try again.');
+      expect(mockService.refresh).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('arr target attachment', () => {

--- a/src/angular/src/app/pages/settings/path-pairs.component.ts
+++ b/src/angular/src/app/pages/settings/path-pairs.component.ts
@@ -154,15 +154,34 @@ export class PathPairsComponent implements OnDestroy {
   // --- Toggle fields ---
 
   onToggleEnabled(pair: PathPair, enabled: boolean): void {
-    this.pathPairsService.update({ ...pair, enabled }).pipe(
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe();
+    this.applyToggle({ ...pair, enabled });
   }
 
   onToggleAutoQueue(pair: PathPair, autoQueue: boolean): void {
-    this.pathPairsService.update({ ...pair, auto_queue: autoQueue }).pipe(
+    this.applyToggle({ ...pair, auto_queue: autoQueue });
+  }
+
+  private applyToggle(updated: PathPair): void {
+    // The checkbox is bound one-way ([checked]="pair.enabled") with a (change)
+    // handler, so a failed update leaves it visually flipped vs the server.
+    // Surface an error and refresh() to reconcile the UI on any failure.
+    this.errorMessage = null;
+    this.pathPairsService.update(updated).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe();
+    ).subscribe({
+      next: (result) => {
+        if (!result) {
+          this.errorMessage = 'Failed to update path pair. Please try again.';
+          this.pathPairsService.refresh();
+        }
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.errorMessage = 'Failed to update path pair. Please try again.';
+        this.pathPairsService.refresh();
+        this.cdr.markForCheck();
+      },
+    });
   }
 
   // --- Arr targets ---

--- a/src/angular/src/app/services/autoqueue/autoqueue.service.spec.ts
+++ b/src/angular/src/app/services/autoqueue/autoqueue.service.spec.ts
@@ -53,6 +53,18 @@ describe('AutoQueueService', () => {
     expect(snapshot()).toEqual([{ pattern: '*.mkv' }]);
   });
 
+  it('should fall back to an empty list (and not throw) on malformed pattern JSON', () => {
+    mockRestService.sendRequest.mockReturnValue(
+      of(makeReaction({ success: true, data: 'not-json{' })),
+    );
+    const logger = TestBed.inject(LoggerService);
+
+    expect(() => connectedSubject.next(true)).not.toThrow();
+
+    expect(snapshot()).toEqual([]);
+    expect(vi.mocked(logger.error)).toHaveBeenCalled();
+  });
+
   it('should clear patterns when disconnected', () => {
     mockRestService.sendRequest.mockReturnValue(
       of(makeReaction({ success: true, data: JSON.stringify([{ pattern: '*.mkv' }]) })),

--- a/src/angular/src/app/services/autoqueue/autoqueue.service.ts
+++ b/src/angular/src/app/services/autoqueue/autoqueue.service.ts
@@ -105,11 +105,18 @@ export class AutoQueueService {
     this.logger.debug('Getting autoqueue patterns...');
     this.restService.sendRequest(this.AUTOQUEUE_GET_URL).subscribe({
       next: (reaction) => {
-        if (reaction.success) {
+        if (!reaction.success) {
+          this.patternsSubject.next([]);
+          return;
+        }
+        try {
           const parsed: AutoQueuePatternJson[] = JSON.parse(reaction.data!);
           const newPatterns: AutoQueuePattern[] = parsed.map((p) => ({ pattern: p.pattern }));
           this.patternsSubject.next(newPatterns);
-        } else {
+        } catch (e) {
+          // Malformed response must not throw inside the subscribe callback;
+          // log and fall back to an empty list (mirrors the SSE-handler guards).
+          this.logger.error('Failed to parse autoqueue patterns: %O', e);
           this.patternsSubject.next([]);
         }
       },

--- a/src/angular/src/app/services/base/stream-dispatch.service.spec.ts
+++ b/src/angular/src/app/services/base/stream-dispatch.service.spec.ts
@@ -82,6 +82,7 @@ describe("StreamDispatchService", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     (globalThis as unknown as { EventSource: typeof EventSource }).EventSource = originalEventSource;
   });
 
@@ -186,27 +187,99 @@ describe("StreamDispatchService", () => {
 
   // --- Reconnection ---
 
-  it("should reconnect after error with retry delay", () => {
+  it("should reconnect after error with the base backoff delay", () => {
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0); // no jitter
     service.start();
     expect(MockEventSource.instances.length).toBe(1);
 
     latestEventSource().simulateError();
     expect(MockEventSource.instances.length).toBe(1);
 
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(1000);
     expect(MockEventSource.instances.length).toBe(2);
-
   });
 
-  it("should not reconnect before retry interval", () => {
+  it("should not reconnect before the base backoff interval", () => {
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0); // no jitter
     service.start();
     latestEventSource().simulateError();
 
-    vi.advanceTimersByTime(2999);
+    vi.advanceTimersByTime(999);
     expect(MockEventSource.instances.length).toBe(1);
+  });
 
+  it("should use exponential backoff across successive errors", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0); // no jitter
+    service.start();
+
+    // First error -> reconnect after ~base (1000ms)
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(1000);
+    expect(MockEventSource.instances.length).toBe(2);
+
+    // Second error -> backoff doubles to ~2*base (2000ms)
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(1000);
+    // base alone is not enough to reconnect now
+    expect(MockEventSource.instances.length).toBe(2);
+    vi.advanceTimersByTime(1000);
+    expect(MockEventSource.instances.length).toBe(3);
+  });
+
+  it("should cap the backoff at the maximum interval", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0); // no jitter
+    service.start();
+
+    // Fail many times so the exponential term would far exceed the cap.
+    for (let i = 0; i < 10; i++) {
+      latestEventSource().simulateError();
+      vi.advanceTimersByTime(30000); // advance by the max each time
+    }
+    const countAfterCapping = MockEventSource.instances.length;
+
+    // One more error: even advancing only by the max must reconnect (capped).
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(30000);
+    expect(MockEventSource.instances.length).toBe(countAfterCapping + 1);
+  });
+
+  it("should reset backoff to base after a successful open", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0); // no jitter
+    service.start();
+
+    // Fail a few times to grow the backoff.
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(1000); // attempt 1: base
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(2000); // attempt 2: 2*base
+    expect(MockEventSource.instances.length).toBe(3);
+
+    // A successful open resets the backoff counter.
+    latestEventSource().simulateOpen();
+
+    // A fresh error should now reconnect after ~base again.
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(1000);
+    expect(MockEventSource.instances.length).toBe(4);
+  });
+
+  it("should add jitter to the backoff delay", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(1); // max jitter (1000ms)
+    service.start();
+
+    latestEventSource().simulateError();
+
+    // base (1000) + jitter (1000) = 2000ms; base alone is not enough.
+    vi.advanceTimersByTime(1999);
+    expect(MockEventSource.instances.length).toBe(1);
+    vi.advanceTimersByTime(1);
+    expect(MockEventSource.instances.length).toBe(2);
   });
 
   // --- API key ---

--- a/src/angular/src/app/services/base/stream-dispatch.service.spec.ts
+++ b/src/angular/src/app/services/base/stream-dispatch.service.spec.ts
@@ -270,13 +270,14 @@ describe("StreamDispatchService", () => {
 
   it("should add jitter to the backoff delay", () => {
     vi.useFakeTimers();
-    vi.spyOn(Math, "random").mockReturnValue(1); // max jitter (1000ms)
+    // Math.random() returns [0, 1); use a value just below 1 (impossible: exactly 1).
+    vi.spyOn(Math, "random").mockReturnValue(0.999); // jitter ~999ms
     service.start();
 
     latestEventSource().simulateError();
 
-    // base (1000) + jitter (1000) = 2000ms; base alone is not enough.
-    vi.advanceTimersByTime(1999);
+    // base (1000) + jitter (~999) = ~1999ms; base alone is not enough.
+    vi.advanceTimersByTime(1998);
     expect(MockEventSource.instances.length).toBe(1);
     vi.advanceTimersByTime(1);
     expect(MockEventSource.instances.length).toBe(2);

--- a/src/angular/src/app/services/base/stream-dispatch.service.ts
+++ b/src/angular/src/app/services/base/stream-dispatch.service.ts
@@ -23,7 +23,12 @@ export interface StreamEventHandler {
 @Injectable({ providedIn: 'root' })
 export class StreamDispatchService {
   private readonly STREAM_URL = '/server/stream';
-  private readonly RETRY_INTERVAL_MS = 3000;
+  /** Base delay for the first reconnect attempt. */
+  private readonly RETRY_BASE_MS = 1000;
+  /** Upper bound on the exponential backoff delay. */
+  private readonly RETRY_MAX_MS = 30000;
+  /** Maximum random jitter added to each backoff delay. */
+  private readonly RETRY_JITTER_MS = 1000;
 
   private readonly logger = inject(LoggerService);
   private readonly zone = inject(NgZone);
@@ -45,6 +50,7 @@ export class StreamDispatchService {
   private apiKey: string | null = null;
   private eventSource: EventSource | null = null;
   private retryTimeout: ReturnType<typeof setTimeout> | null = null;
+  private retryAttempt = 0;
 
   setApiKey(key: string | null): void {
     if (key === this.apiKey) {
@@ -53,6 +59,8 @@ export class StreamDispatchService {
     this.apiKey = key;
     // Reconnect with the new key if we have an active connection or pending retry
     if (this.eventSource || this.retryTimeout) {
+      // A key change should retry promptly, not wait out the current backoff.
+      this.retryAttempt = 0;
       this.closeAndCancelRetry();
       this.connectStream();
     }
@@ -86,6 +94,8 @@ export class StreamDispatchService {
 
     eventSource.onopen = () => {
       this.logger.info('Connected to server stream');
+      // A successful connection resets the backoff so the next drop retries fast.
+      this.retryAttempt = 0;
       for (const handler of this.handlers) {
         this.zone.run(() => handler.onConnected());
       }
@@ -105,10 +115,23 @@ export class StreamDispatchService {
         this.zone.run(() => handler.onDisconnected());
       }
 
+      const delay = this.nextRetryDelayMs();
+      this.retryAttempt += 1;
       this.retryTimeout = setTimeout(() => {
         this.retryTimeout = null;
         this.connectStream();
-      }, this.RETRY_INTERVAL_MS);
+      }, delay);
     };
+  }
+
+  /**
+   * Capped exponential backoff with jitter. Prevents a tight reconnect loop
+   * (e.g. when the server keeps returning 401 for a bad/missing API key) from
+   * hammering the backend on a fixed cadence.
+   */
+  private nextRetryDelayMs(): number {
+    const exponential = Math.min(this.RETRY_MAX_MS, this.RETRY_BASE_MS * 2 ** this.retryAttempt);
+    const jitter = Math.random() * this.RETRY_JITTER_MS;
+    return exponential + jitter;
   }
 }

--- a/src/angular/src/app/services/files/model-file.service.spec.ts
+++ b/src/angular/src/app/services/files/model-file.service.spec.ts
@@ -300,5 +300,28 @@ describe("ModelFileService", () => {
       expect(result!.has("file1")).toBe(true);
       expect(result!.has("file2")).toBe(true);
     });
+
+    // Valid JSON, wrong shape: parses fine but the mapping below would throw.
+    // The dispatch (not just JSON.parse) must be guarded — log and skip.
+    it("should not throw on a valid-JSON-but-wrong-shape model-init (not an array)", () => {
+      expect(() => service.onEvent("model-init", "{}")).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(0);
+    });
+
+    it("should not throw on a wrong-shape model-added (missing new_file)", () => {
+      service.onEvent("model-init", JSON.stringify([makeFileJson("file1")]));
+
+      expect(() => service.onEvent("model-added", "{}")).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(1);
+      expect(result!.has("file1")).toBe(true);
+    });
   });
 });

--- a/src/angular/src/app/services/files/model-file.service.spec.ts
+++ b/src/angular/src/app/services/files/model-file.service.spec.ts
@@ -30,23 +30,27 @@ describe("ModelFileService", () => {
   let service: ModelFileService;
   let mockStreamDispatch: { registerHandler: ReturnType<typeof vi.fn> };
   let mockRestService: { sendRequest: ReturnType<typeof vi.fn> };
+  let mockLogger: {
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     mockStreamDispatch = { registerHandler: vi.fn() };
     mockRestService = { sendRequest: vi.fn() };
+    mockLogger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
     TestBed.configureTestingModule({
       providers: [
         ModelFileService,
         { provide: StreamDispatchService, useValue: mockStreamDispatch },
-        {
-          provide: LoggerService,
-          useValue: {
-            debug: vi.fn(),
-            error: vi.fn(),
-            info: vi.fn(),
-            warn: vi.fn(),
-          },
-        },
+        { provide: LoggerService, useValue: mockLogger },
         { provide: RestService, useValue: mockRestService },
       ],
     });
@@ -224,5 +228,77 @@ describe("ModelFileService", () => {
     expect(mockRestService.sendRequest).toHaveBeenCalledWith(
       "/server/command/delete_remote/" + encoded,
     );
+  });
+
+  describe("malformed SSE payloads (issue #516)", () => {
+    const malformed = "{not valid json";
+
+    it("should not throw and should log on a malformed model-init event", () => {
+      expect(() => service.onEvent("model-init", malformed)).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      // Existing (empty) state is preserved — no silent clear/poison.
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(0);
+    });
+
+    it("should not throw and should preserve the map on a malformed model-added event", () => {
+      service.onEvent("model-init", JSON.stringify([makeFileJson("file1")]));
+
+      expect(() => service.onEvent("model-added", malformed)).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(1);
+      expect(result!.has("file1")).toBe(true);
+    });
+
+    it("should not throw and should preserve the map on a malformed model-updated event", () => {
+      service.onEvent(
+        "model-init",
+        JSON.stringify([makeFileJson("file1", "DEFAULT")]),
+      );
+
+      expect(() => service.onEvent("model-updated", malformed)).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(1);
+      expect(result!.get("file1")!.state).toBe("default");
+    });
+
+    it("should not throw and should preserve the map on a malformed model-removed event", () => {
+      service.onEvent(
+        "model-init",
+        JSON.stringify([makeFileJson("file1"), makeFileJson("file2")]),
+      );
+
+      expect(() => service.onEvent("model-removed", malformed)).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(2);
+      expect(result!.has("file1")).toBe(true);
+      expect(result!.has("file2")).toBe(true);
+    });
+
+    it("should still parse a valid event after a malformed one (no poisoned state)", () => {
+      service.onEvent("model-init", malformed);
+      // A subsequent valid init must replace state normally.
+      service.onEvent(
+        "model-init",
+        JSON.stringify([makeFileJson("file1"), makeFileJson("file2")]),
+      );
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(2);
+      expect(result!.has("file1")).toBe(true);
+      expect(result!.has("file2")).toBe(true);
+    });
   });
 });

--- a/src/angular/src/app/services/files/model-file.service.ts
+++ b/src/angular/src/app/services/files/model-file.service.ts
@@ -95,56 +95,64 @@ export class ModelFileService implements StreamEventHandler {
       return;
     }
 
-    if (name === this.EVENT_INIT) {
-      const init = parsed as ModelFileJson[];
-      const t0 = performance.now();
-      const newMap = new Map<string, ModelFile>();
-      for (const file of init) {
-        const modelFile = modelFileFromJson(file);
-        newMap.set(fileKey(modelFile.pair_id, modelFile.name), modelFile);
-      }
-      const t1 = performance.now();
-      this.logger.debug('ModelFile map creation took', (t1 - t0).toFixed(0), 'ms');
+    // The payload parsed, but a valid-JSON-but-wrong-shape event (e.g. model-init
+    // not an array, or model-added missing new_file) would throw in the mapping
+    // below; guard the dispatch too so one bad event is logged and skipped, not
+    // fatal to the listener.
+    try {
+      if (name === this.EVENT_INIT) {
+        const init = parsed as ModelFileJson[];
+        const t0 = performance.now();
+        const newMap = new Map<string, ModelFile>();
+        for (const file of init) {
+          const modelFile = modelFileFromJson(file);
+          newMap.set(fileKey(modelFile.pair_id, modelFile.name), modelFile);
+        }
+        const t1 = performance.now();
+        this.logger.debug('ModelFile map creation took', (t1 - t0).toFixed(0), 'ms');
 
-      this.filesSubject.next(newMap);
-    } else if (name === this.EVENT_ADDED) {
-      const added = parsed as { new_file: ModelFileJson };
-      const file = modelFileFromJson(added.new_file);
-      const key = fileKey(file.pair_id, file.name);
-      if (currentFiles.has(key)) {
-        this.logger.error('ModelFile named ' + key + ' already exists');
+        this.filesSubject.next(newMap);
+      } else if (name === this.EVENT_ADDED) {
+        const added = parsed as { new_file: ModelFileJson };
+        const file = modelFileFromJson(added.new_file);
+        const key = fileKey(file.pair_id, file.name);
+        if (currentFiles.has(key)) {
+          this.logger.error('ModelFile named ' + key + ' already exists');
+        } else {
+          const updated = new Map(currentFiles);
+          updated.set(key, file);
+          this.filesSubject.next(updated);
+          this.logger.debug('Added file: %O', file);
+        }
+      } else if (name === this.EVENT_REMOVED) {
+        const removed = parsed as { old_file: ModelFileJson };
+        const file = modelFileFromJson(removed.old_file);
+        const key = fileKey(file.pair_id, file.name);
+        if (currentFiles.has(key)) {
+          const updated = new Map(currentFiles);
+          updated.delete(key);
+          this.filesSubject.next(updated);
+          this.logger.debug('Removed file: %O', file);
+        } else {
+          this.logger.error('Failed to find ModelFile named ' + key);
+        }
+      } else if (name === this.EVENT_UPDATED) {
+        const updatedFile = parsed as { new_file: ModelFileJson };
+        const file = modelFileFromJson(updatedFile.new_file);
+        const key = fileKey(file.pair_id, file.name);
+        if (currentFiles.has(key)) {
+          const updated = new Map(currentFiles);
+          updated.set(key, file);
+          this.filesSubject.next(updated);
+          this.logger.debug('Updated file: %O', file);
+        } else {
+          this.logger.error('Failed to find ModelFile named ' + key);
+        }
       } else {
-        const updated = new Map(currentFiles);
-        updated.set(key, file);
-        this.filesSubject.next(updated);
-        this.logger.debug('Added file: %O', file);
+        this.logger.error('Unrecognized event:', name);
       }
-    } else if (name === this.EVENT_REMOVED) {
-      const removed = parsed as { old_file: ModelFileJson };
-      const file = modelFileFromJson(removed.old_file);
-      const key = fileKey(file.pair_id, file.name);
-      if (currentFiles.has(key)) {
-        const updated = new Map(currentFiles);
-        updated.delete(key);
-        this.filesSubject.next(updated);
-        this.logger.debug('Removed file: %O', file);
-      } else {
-        this.logger.error('Failed to find ModelFile named ' + key);
-      }
-    } else if (name === this.EVENT_UPDATED) {
-      const updatedFile = parsed as { new_file: ModelFileJson };
-      const file = modelFileFromJson(updatedFile.new_file);
-      const key = fileKey(file.pair_id, file.name);
-      if (currentFiles.has(key)) {
-        const updated = new Map(currentFiles);
-        updated.set(key, file);
-        this.filesSubject.next(updated);
-        this.logger.debug('Updated file: %O', file);
-      } else {
-        this.logger.error('Failed to find ModelFile named ' + key);
-      }
-    } else {
-      this.logger.error('Unrecognized event:', name);
+    } catch (e) {
+      this.logger.error('Failed to handle %s event (unexpected shape): %O', name, e);
     }
   }
 }

--- a/src/angular/src/app/services/files/model-file.service.ts
+++ b/src/angular/src/app/services/files/model-file.service.ts
@@ -84,28 +84,32 @@ export class ModelFileService implements StreamEventHandler {
   private parseEvent(name: string, data: string): void {
     const currentFiles = this.filesSubject.getValue();
 
+    // Guard the parse of server-controlled SSE payloads: a malformed/truncated
+    // event must not throw inside the listener callback. Log and skip the bad
+    // event, leaving existing state untouched (mirrors ConfigService.getConfig).
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data);
+    } catch (e) {
+      this.logger.error('Failed to parse %s event: %O', name, e);
+      return;
+    }
+
     if (name === this.EVENT_INIT) {
-      let t0: number;
-      let t1: number;
-
-      t0 = performance.now();
-      const parsed: ModelFileJson[] = JSON.parse(data);
-      t1 = performance.now();
-      this.logger.debug('Parsing took', (t1 - t0).toFixed(0), 'ms');
-
-      t0 = performance.now();
+      const init = parsed as ModelFileJson[];
+      const t0 = performance.now();
       const newMap = new Map<string, ModelFile>();
-      for (const file of parsed) {
+      for (const file of init) {
         const modelFile = modelFileFromJson(file);
         newMap.set(fileKey(modelFile.pair_id, modelFile.name), modelFile);
       }
-      t1 = performance.now();
+      const t1 = performance.now();
       this.logger.debug('ModelFile map creation took', (t1 - t0).toFixed(0), 'ms');
 
       this.filesSubject.next(newMap);
     } else if (name === this.EVENT_ADDED) {
-      const parsed: { new_file: ModelFileJson } = JSON.parse(data);
-      const file = modelFileFromJson(parsed.new_file);
+      const added = parsed as { new_file: ModelFileJson };
+      const file = modelFileFromJson(added.new_file);
       const key = fileKey(file.pair_id, file.name);
       if (currentFiles.has(key)) {
         this.logger.error('ModelFile named ' + key + ' already exists');
@@ -116,8 +120,8 @@ export class ModelFileService implements StreamEventHandler {
         this.logger.debug('Added file: %O', file);
       }
     } else if (name === this.EVENT_REMOVED) {
-      const parsed: { old_file: ModelFileJson } = JSON.parse(data);
-      const file = modelFileFromJson(parsed.old_file);
+      const removed = parsed as { old_file: ModelFileJson };
+      const file = modelFileFromJson(removed.old_file);
       const key = fileKey(file.pair_id, file.name);
       if (currentFiles.has(key)) {
         const updated = new Map(currentFiles);
@@ -128,8 +132,8 @@ export class ModelFileService implements StreamEventHandler {
         this.logger.error('Failed to find ModelFile named ' + key);
       }
     } else if (name === this.EVENT_UPDATED) {
-      const parsed: { new_file: ModelFileJson } = JSON.parse(data);
-      const file = modelFileFromJson(parsed.new_file);
+      const updatedFile = parsed as { new_file: ModelFileJson };
+      const file = modelFileFromJson(updatedFile.new_file);
       const key = fileKey(file.pair_id, file.name);
       if (currentFiles.has(key)) {
         const updated = new Map(currentFiles);

--- a/src/angular/src/app/services/logs/log.service.spec.ts
+++ b/src/angular/src/app/services/logs/log.service.spec.ts
@@ -2,18 +2,32 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import { LogService } from "./log.service";
 import { StreamDispatchService } from "../base/stream-dispatch.service";
+import { LoggerService } from "../utils/logger.service";
 import { LogRecord, LogRecordJson } from "../../models/log-record";
 
 describe("LogService", () => {
   let service: LogService;
   let mockStreamDispatch: { registerHandler: ReturnType<typeof vi.fn> };
+  let mockLogger: {
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     mockStreamDispatch = { registerHandler: vi.fn() };
+    mockLogger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
     TestBed.configureTestingModule({
       providers: [
         LogService,
         { provide: StreamDispatchService, useValue: mockStreamDispatch },
+        { provide: LoggerService, useValue: mockLogger },
       ],
     });
     service = TestBed.inject(LogService);
@@ -69,5 +83,32 @@ describe("LogService", () => {
     expect(results.length).toBe(2);
     expect(results[0].message).toBe("First");
     expect(results[1].message).toBe("Second");
+  });
+
+  it("should not throw and should emit nothing on a malformed log-record event (issue #516)", () => {
+    const results: LogRecord[] = [];
+    service.logs$.subscribe((r) => results.push(r));
+
+    expect(() => service.onEvent("log-record", "not json")).not.toThrow();
+    expect(mockLogger.error).toHaveBeenCalled();
+    expect(results.length).toBe(0);
+  });
+
+  it("should still emit a valid log-record after a malformed one (issue #516)", () => {
+    const results: LogRecord[] = [];
+    service.logs$.subscribe((r) => results.push(r));
+
+    service.onEvent("log-record", "not json");
+    const logJson: LogRecordJson = {
+      time: 1700000000,
+      level_name: "INFO",
+      logger_name: "test.logger",
+      message: "After malformed",
+      exc_tb: "",
+    };
+    service.onEvent("log-record", JSON.stringify(logJson));
+
+    expect(results.length).toBe(1);
+    expect(results[0].message).toBe("After malformed");
   });
 });

--- a/src/angular/src/app/services/logs/log.service.ts
+++ b/src/angular/src/app/services/logs/log.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 
 import { StreamEventHandler, StreamDispatchService } from '../base/stream-dispatch.service';
+import { LoggerService } from '../utils/logger.service';
 import { LogRecord, logRecordFromJson } from '../../models/log-record';
 
 export interface LogHistoryParams {
@@ -25,6 +26,7 @@ export interface LogHistoryEntry {
 export class LogService implements StreamEventHandler {
     private readonly streamDispatch = inject(StreamDispatchService);
     private readonly http = inject(HttpClient);
+    private readonly logger = inject(LoggerService);
 
     private readonly logsSubject = new Subject<LogRecord>();
 
@@ -39,7 +41,14 @@ export class LogService implements StreamEventHandler {
     }
 
     onEvent(_eventName: string, data: string): void {
-        this.logsSubject.next(logRecordFromJson(JSON.parse(data)));
+        // Guard the parse of server-controlled SSE payloads: a malformed/truncated
+        // event must not throw inside the listener callback. Log and skip the bad
+        // record, emitting nothing (mirrors ConfigService.getConfig).
+        try {
+            this.logsSubject.next(logRecordFromJson(JSON.parse(data)));
+        } catch (e) {
+            this.logger.error('Failed to parse log-record event: %O', e);
+        }
     }
 
     onConnected(): void {

--- a/src/angular/src/app/services/server/server-status.service.spec.ts
+++ b/src/angular/src/app/services/server/server-status.service.spec.ts
@@ -2,19 +2,33 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import { ServerStatusService } from "./server-status.service";
 import { StreamDispatchService } from "../base/stream-dispatch.service";
+import { LoggerService } from "../utils/logger.service";
 import { ServerStatus, ServerStatusJson } from "../../models/server-status";
 import { Localization } from "../../models/localization";
 
 describe("ServerStatusService", () => {
   let service: ServerStatusService;
   let mockStreamDispatch: { registerHandler: ReturnType<typeof vi.fn> };
+  let mockLogger: {
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     mockStreamDispatch = { registerHandler: vi.fn() };
+    mockLogger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
     TestBed.configureTestingModule({
       providers: [
         ServerStatusService,
         { provide: StreamDispatchService, useValue: mockStreamDispatch },
+        { provide: LoggerService, useValue: mockLogger },
       ],
     });
     service = TestBed.inject(ServerStatusService);
@@ -88,5 +102,48 @@ describe("ServerStatusService", () => {
     expect(result!.controller.latestRemoteScanTime).toBeNull();
     expect(result!.controller.latestRemoteScanFailed).toBe(false);
     expect(result!.controller.latestRemoteScanError).toBeNull();
+  });
+
+  it("should not throw and should keep last-good status on a malformed status event (issue #516)", () => {
+    // Seed a valid connected status.
+    const statusJson: ServerStatusJson = {
+      server: { up: true, error_msg: "" },
+      controller: {
+        latest_local_scan_time: "1700000000",
+        latest_remote_scan_time: null,
+        latest_remote_scan_failed: false,
+        latest_remote_scan_error: null,
+        no_enabled_pairs: false,
+      },
+    };
+    service.onEvent("status", JSON.stringify(statusJson));
+
+    // A malformed payload must not throw and must not degrade the status.
+    expect(() => service.onEvent("status", "garbage")).not.toThrow();
+    expect(mockLogger.error).toHaveBeenCalled();
+
+    let result: ServerStatus | undefined;
+    service.status$.subscribe((s) => (result = s));
+    expect(result!.server.up).toBe(true);
+  });
+
+  it("should still parse a valid status event after a malformed one (issue #516)", () => {
+    service.onEvent("status", "garbage");
+
+    const statusJson: ServerStatusJson = {
+      server: { up: true, error_msg: "" },
+      controller: {
+        latest_local_scan_time: null,
+        latest_remote_scan_time: null,
+        latest_remote_scan_failed: false,
+        latest_remote_scan_error: null,
+        no_enabled_pairs: false,
+      },
+    };
+    service.onEvent("status", JSON.stringify(statusJson));
+
+    let result: ServerStatus | undefined;
+    service.status$.subscribe((s) => (result = s));
+    expect(result!.server.up).toBe(true);
   });
 });

--- a/src/angular/src/app/services/server/server-status.service.ts
+++ b/src/angular/src/app/services/server/server-status.service.ts
@@ -2,12 +2,14 @@ import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 import { StreamEventHandler, StreamDispatchService } from '../base/stream-dispatch.service';
+import { LoggerService } from '../utils/logger.service';
 import { Localization } from '../../models/localization';
 import { ServerStatus, ServerStatusJson, serverStatusFromJson } from '../../models/server-status';
 
 @Injectable({ providedIn: 'root' })
 export class ServerStatusService implements StreamEventHandler {
   private readonly streamDispatch = inject(StreamDispatchService);
+  private readonly logger = inject(LoggerService);
 
   private readonly statusSubject = new BehaviorSubject<ServerStatus>({
     server: {
@@ -34,8 +36,15 @@ export class ServerStatusService implements StreamEventHandler {
   }
 
   onEvent(_eventName: string, data: string): void {
-    const statusJson: ServerStatusJson = JSON.parse(data);
-    this.statusSubject.next(serverStatusFromJson(statusJson));
+    // Guard the parse of server-controlled SSE payloads: a malformed/truncated
+    // event must not throw inside the listener callback. Log and skip the bad
+    // event, leaving the last-good status in place (mirrors ConfigService).
+    try {
+      const statusJson: ServerStatusJson = JSON.parse(data);
+      this.statusSubject.next(serverStatusFromJson(statusJson));
+    } catch (e) {
+      this.logger.error('Failed to parse status event: %O', e);
+    }
   }
 
   onConnected(): void {

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -8,7 +8,7 @@ import { ConnectedService } from "../utils/connected.service";
 import { LoggerService } from "../utils/logger.service";
 import { RestService, WebReaction } from "../utils/rest.service";
 import { StreamDispatchService } from "../base/stream-dispatch.service";
-import { Config } from "../../models/config";
+import { Config, REDACTED_SENTINEL } from "../../models/config";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
@@ -201,16 +201,38 @@ describe("ConfigService", () => {
   });
 
   it("should NOT push the redacted sentinel from /server/config/get to the stream", () => {
-    const config = makeConfig({ web: { port: 8080, api_key: "********" } });
+    const config = makeConfig({ web: { port: 8080, api_key: REDACTED_SENTINEL } });
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
 
     createService();
 
-    // The redacted '********' returned by the auth-exempt config endpoint must
+    // The redacted sentinel returned by the auth-exempt config endpoint must
     // never be pushed to the stream as a credential.
-    expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalledWith("********");
+    expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalledWith(REDACTED_SENTINEL);
+  });
+
+  it("preserves the real api_key in the snapshot when a refresh returns the redacted sentinel", () => {
+    // Init with a web section so set() has an existing option to update.
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(makeConfig({ web: { port: 8080, api_key: "" } })), errorMessage: null }),
+    );
+    createService();
+
+    // The user enters the real key in Settings.
+    mockRestService.sendRequest.mockReturnValueOnce(of({ success: true, data: null, errorMessage: null }));
+    service.set("web", "api_key", "new-key");
+    expect(service.configSnapshot?.web?.api_key).toBe("new-key");
+
+    // A later config refresh returns the redacted sentinel. It must NOT clobber
+    // the real key the apiKeyInterceptor relies on for REST auth this session.
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(makeConfig({ web: { port: 8080, api_key: REDACTED_SENTINEL } })), errorMessage: null }),
+    );
+    connectedSubject.next(true);
+
+    expect(service.configSnapshot?.web?.api_key).toBe("new-key");
   });
 
   // --- Disconnect ---

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 // Injector not needed — TestBed handles DI
 import { BehaviorSubject, of } from "rxjs";
@@ -8,6 +8,7 @@ import { ConnectedService } from "../utils/connected.service";
 import { LoggerService } from "../utils/logger.service";
 import { RestService, WebReaction } from "../utils/rest.service";
 import { StreamDispatchService } from "../base/stream-dispatch.service";
+import { StorageKeys } from "../../common/storage-keys";
 import { Config } from "../../models/config";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
@@ -80,11 +81,50 @@ describe("ConfigService", () => {
   let connectedSubject: BehaviorSubject<boolean>;
   let mockRestService: { sendRequest: ReturnType<typeof vi.fn> };
   let mockStreamDispatch: { setApiKey: ReturnType<typeof vi.fn> };
+  let store: Record<string, string>;
+  let mockSessionStorage: {
+    getItem: ReturnType<typeof vi.fn>;
+    setItem: ReturnType<typeof vi.fn>;
+    removeItem: ReturnType<typeof vi.fn>;
+  };
+  let originalSessionStorage: Storage;
+
+  /**
+   * Lazily construct the service. The constructor fetches config and
+   * rehydrates the persisted API key, so each test configures its mocks
+   * (sendRequest return values, seeded sessionStorage) BEFORE calling this.
+   */
+  function createService(): ConfigService {
+    service = TestBed.inject(ConfigService);
+    return service;
+  }
 
   beforeEach(() => {
     connectedSubject = new BehaviorSubject<boolean>(false);
-    mockRestService = { sendRequest: vi.fn() };
+    // Safe default so the constructor's init fetch never crashes on undefined.
+    mockRestService = {
+      sendRequest: vi.fn().mockReturnValue(
+        of({ success: false, data: null, errorMessage: "not configured" }),
+      ),
+    };
     mockStreamDispatch = { setApiKey: vi.fn() };
+
+    store = {};
+    mockSessionStorage = {
+      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+    };
+    originalSessionStorage = globalThis.sessionStorage;
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: mockSessionStorage,
+      configurable: true,
+      writable: true,
+    });
 
     TestBed.configureTestingModule({
       providers: [
@@ -109,18 +149,28 @@ describe("ConfigService", () => {
         },
       ],
     });
-    service = TestBed.inject(ConfigService);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: originalSessionStorage,
+      configurable: true,
+      writable: true,
+    });
   });
 
   // --- Initial state ---
 
   it("should emit null as the initial config", () => {
+    // Default mock returns a failure reaction, so the init fetch leaves config null.
+    createService();
     let result: Config | null | undefined;
     service.config$.subscribe((c) => (result = c));
     expect(result).toBeNull();
   });
 
   it("should return null from configSnapshot initially", () => {
+    createService();
     expect(service.configSnapshot).toBeNull();
   });
 
@@ -132,6 +182,7 @@ describe("ConfigService", () => {
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
 
+    createService();
     connectedSubject.next(true);
 
     let result: Config | null | undefined;
@@ -148,6 +199,7 @@ describe("ConfigService", () => {
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
 
+    createService();
     connectedSubject.next(true);
     expect(service.configSnapshot).toEqual(config);
   });
@@ -158,36 +210,99 @@ describe("ConfigService", () => {
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
 
+    createService();
     connectedSubject.next(true);
     expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("my-key");
   });
 
-  // --- Disconnect ---
+  // --- Init-ordering deadlock fix (#514) ---
 
-  it("should emit null config when disconnected", () => {
+  it("should fetch config at init independent of connected$", () => {
     const config = makeConfig();
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
+
+    // connected$ is still false (never emits true)
+    createService();
+
+    let result: Config | null | undefined;
+    service.config$.subscribe((c) => (result = c));
+    expect(result).toEqual(config);
+    expect(mockRestService.sendRequest).toHaveBeenCalledWith(
+      "/server/config/get",
+    );
+  });
+
+  it("should rehydrate persisted api_key from sessionStorage at init and push it to the stream before any connect", () => {
+    store[StorageKeys.API_KEY] = "real-key";
+
+    // connected$ stays false; the key must reach the stream during construction
+    createService();
+
+    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("real-key");
+  });
+
+  it("should NOT push the redacted sentinel to the stream and should keep the persisted key", () => {
+    store[StorageKeys.API_KEY] = "real-key";
+    const config = makeConfig({ web: { port: 8080, api_key: "********" } });
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+    );
+
+    createService();
+
+    // The persisted real key is pushed at init, but the redacted '********'
+    // returned by /server/config/get must never reach the stream.
+    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("real-key");
+    expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalledWith("********");
+    expect(store[StorageKeys.API_KEY]).toBe("real-key");
+  });
+
+  it("should tolerate sessionStorage throwing during init (private browsing)", () => {
+    mockSessionStorage.getItem.mockImplementation(() => {
+      throw new Error("denied");
+    });
+    const config = makeConfig();
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+    );
+
+    expect(() => createService()).not.toThrow();
+  });
+
+  // --- Disconnect ---
+
+  it("should retain config on disconnect so the UI keeps working", () => {
+    const config = makeConfig();
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+    );
+    createService();
     connectedSubject.next(true);
 
     connectedSubject.next(false);
 
+    // Config is fetched at init independent of the stream, so a transient
+    // disconnect must not wipe it out (and trigger a deadlock-prone refetch loop).
     let result: Config | null | undefined;
     service.config$.subscribe((c) => (result = c));
-    expect(result).toBeNull();
+    expect(result).toEqual(config);
   });
 
-  it("should sync null API key when disconnected", () => {
-    const config = makeConfig();
+  it("should NOT clear the api key on disconnect so the next reconnect can authenticate", () => {
+    const config = makeConfig({ web: { port: 8080, api_key: "my-key" } });
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
+    createService();
     connectedSubject.next(true);
     mockStreamDispatch.setApiKey.mockClear();
 
     connectedSubject.next(false);
-    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith(null);
+
+    // The key must stay on the stream so the backoff-driven reconnect carries it.
+    expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalledWith(null);
   });
 
   // --- Error handling ---
@@ -201,6 +316,7 @@ describe("ConfigService", () => {
       }),
     );
 
+    createService();
     connectedSubject.next(true);
 
     let result: Config | null | undefined;
@@ -213,6 +329,7 @@ describe("ConfigService", () => {
       of({ success: true, data: "not valid json {{{", errorMessage: null }),
     );
 
+    createService();
     connectedSubject.next(true);
 
     let result: Config | null | undefined;
@@ -227,6 +344,7 @@ describe("ConfigService", () => {
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
+    createService();
     connectedSubject.next(true);
 
     let result: WebReaction | undefined;
@@ -241,6 +359,7 @@ describe("ConfigService", () => {
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
+    createService();
     connectedSubject.next(true);
 
     let result: WebReaction | undefined;
@@ -251,7 +370,8 @@ describe("ConfigService", () => {
   });
 
   it("should return error when config is null", () => {
-    // Config is null by default (not connected)
+    // Default mock returns failure, so config stays null after init.
+    createService();
     let result: WebReaction | undefined;
     service.set("web", "port", "9090").subscribe((r: WebReaction) => (result = r));
 
@@ -260,13 +380,18 @@ describe("ConfigService", () => {
 
   it("should call REST with double-encoded value", () => {
     const config = makeConfig();
+    // init fetch -> connect fetch -> set response
     mockRestService.sendRequest
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
       .mockReturnValueOnce(
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("web", "api_key", "my/key");
@@ -284,8 +409,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("web", "api_key", "");
@@ -297,6 +426,76 @@ describe("ConfigService", () => {
     expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith(null);
   });
 
+  it("should remove persisted api_key from sessionStorage when set empty", () => {
+    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
+    store[StorageKeys.API_KEY] = "old";
+    mockRestService.sendRequest
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: null, errorMessage: null }),
+      );
+    createService();
+    connectedSubject.next(true);
+
+    service.set("web", "api_key", "");
+
+    expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(StorageKeys.API_KEY);
+    expect(store[StorageKeys.API_KEY]).toBeUndefined();
+    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith(null);
+  });
+
+  it("should persist the real api_key to sessionStorage on successful set", () => {
+    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
+    mockRestService.sendRequest
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: null, errorMessage: null }),
+      );
+    createService();
+    connectedSubject.next(true);
+
+    service.set("web", "api_key", "new-key");
+
+    expect(mockSessionStorage.setItem).toHaveBeenCalledWith(
+      StorageKeys.API_KEY,
+      "new-key",
+    );
+    expect(store[StorageKeys.API_KEY]).toBe("new-key");
+  });
+
+  it("should not throw when sessionStorage throws during set", () => {
+    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
+    mockRestService.sendRequest
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: null, errorMessage: null }),
+      );
+    createService();
+    connectedSubject.next(true);
+    mockSessionStorage.setItem.mockImplementation(() => {
+      throw new Error("denied");
+    });
+
+    expect(() => service.set("web", "api_key", "new-key")).not.toThrow();
+    // Stream still receives the key even if persistence failed.
+    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("new-key");
+  });
+
   it("should update BehaviorSubject on successful set", () => {
     const config = makeConfig({ web: { port: 8080, api_key: "old" } });
     mockRestService.sendRequest
@@ -304,8 +503,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("web", "api_key", "new-key");
@@ -320,8 +523,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: false, data: null, errorMessage: "fail" }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("web", "api_key", "new-key");
@@ -336,8 +543,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
     mockStreamDispatch.setApiKey.mockClear();
 
@@ -353,8 +564,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("autoqueue", "enabled", true);
@@ -373,8 +588,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("autoqueue", "enabled", false);
@@ -393,8 +612,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("lftp", "net_limit_rate", null);
@@ -411,8 +634,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
     mockStreamDispatch.setApiKey.mockClear();
 

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 // Injector not needed — TestBed handles DI
 import { BehaviorSubject, of } from "rxjs";
@@ -8,7 +8,6 @@ import { ConnectedService } from "../utils/connected.service";
 import { LoggerService } from "../utils/logger.service";
 import { RestService, WebReaction } from "../utils/rest.service";
 import { StreamDispatchService } from "../base/stream-dispatch.service";
-import { StorageKeys } from "../../common/storage-keys";
 import { Config } from "../../models/config";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
@@ -81,18 +80,10 @@ describe("ConfigService", () => {
   let connectedSubject: BehaviorSubject<boolean>;
   let mockRestService: { sendRequest: ReturnType<typeof vi.fn> };
   let mockStreamDispatch: { setApiKey: ReturnType<typeof vi.fn> };
-  let store: Record<string, string>;
-  let mockSessionStorage: {
-    getItem: ReturnType<typeof vi.fn>;
-    setItem: ReturnType<typeof vi.fn>;
-    removeItem: ReturnType<typeof vi.fn>;
-  };
-  let originalSessionStorage: Storage;
 
   /**
-   * Lazily construct the service. The constructor fetches config and
-   * rehydrates the persisted API key, so each test configures its mocks
-   * (sendRequest return values, seeded sessionStorage) BEFORE calling this.
+   * Lazily construct the service. The constructor fetches config, so each test
+   * configures its mocks (sendRequest return values) BEFORE calling this.
    */
   function createService(): ConfigService {
     service = TestBed.inject(ConfigService);
@@ -108,23 +99,6 @@ describe("ConfigService", () => {
       ),
     };
     mockStreamDispatch = { setApiKey: vi.fn() };
-
-    store = {};
-    mockSessionStorage = {
-      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
-      setItem: vi.fn((key: string, value: string) => {
-        store[key] = value;
-      }),
-      removeItem: vi.fn((key: string) => {
-        delete store[key];
-      }),
-    };
-    originalSessionStorage = globalThis.sessionStorage;
-    Object.defineProperty(globalThis, "sessionStorage", {
-      value: mockSessionStorage,
-      configurable: true,
-      writable: true,
-    });
 
     TestBed.configureTestingModule({
       providers: [
@@ -148,14 +122,6 @@ describe("ConfigService", () => {
           useValue: mockStreamDispatch,
         },
       ],
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(globalThis, "sessionStorage", {
-      value: originalSessionStorage,
-      configurable: true,
-      writable: true,
     });
   });
 
@@ -234,17 +200,7 @@ describe("ConfigService", () => {
     );
   });
 
-  it("should rehydrate persisted api_key from sessionStorage at init and push it to the stream before any connect", () => {
-    store[StorageKeys.API_KEY] = "real-key";
-
-    // connected$ stays false; the key must reach the stream during construction
-    createService();
-
-    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("real-key");
-  });
-
-  it("should NOT push the redacted sentinel to the stream and should keep the persisted key", () => {
-    store[StorageKeys.API_KEY] = "real-key";
+  it("should NOT push the redacted sentinel from /server/config/get to the stream", () => {
     const config = makeConfig({ web: { port: 8080, api_key: "********" } });
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
@@ -252,23 +208,9 @@ describe("ConfigService", () => {
 
     createService();
 
-    // The persisted real key is pushed at init, but the redacted '********'
-    // returned by /server/config/get must never reach the stream.
-    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("real-key");
+    // The redacted '********' returned by the auth-exempt config endpoint must
+    // never be pushed to the stream as a credential.
     expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalledWith("********");
-    expect(store[StorageKeys.API_KEY]).toBe("real-key");
-  });
-
-  it("should tolerate sessionStorage throwing during init (private browsing)", () => {
-    mockSessionStorage.getItem.mockImplementation(() => {
-      throw new Error("denied");
-    });
-    const config = makeConfig();
-    mockRestService.sendRequest.mockReturnValue(
-      of({ success: true, data: JSON.stringify(config), errorMessage: null }),
-    );
-
-    expect(() => createService()).not.toThrow();
   });
 
   // --- Disconnect ---
@@ -426,30 +368,7 @@ describe("ConfigService", () => {
     expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith(null);
   });
 
-  it("should remove persisted api_key from sessionStorage when set empty", () => {
-    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
-    store[StorageKeys.API_KEY] = "old";
-    mockRestService.sendRequest
-      .mockReturnValueOnce(
-        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
-      )
-      .mockReturnValueOnce(
-        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
-      )
-      .mockReturnValueOnce(
-        of({ success: true, data: null, errorMessage: null }),
-      );
-    createService();
-    connectedSubject.next(true);
-
-    service.set("web", "api_key", "");
-
-    expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(StorageKeys.API_KEY);
-    expect(store[StorageKeys.API_KEY]).toBeUndefined();
-    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith(null);
-  });
-
-  it("should persist the real api_key to sessionStorage on successful set", () => {
+  it("should push the real api_key to the stream on successful set", () => {
     const config = makeConfig({ web: { port: 8080, api_key: "old" } });
     mockRestService.sendRequest
       .mockReturnValueOnce(
@@ -466,33 +385,8 @@ describe("ConfigService", () => {
 
     service.set("web", "api_key", "new-key");
 
-    expect(mockSessionStorage.setItem).toHaveBeenCalledWith(
-      StorageKeys.API_KEY,
-      "new-key",
-    );
-    expect(store[StorageKeys.API_KEY]).toBe("new-key");
-  });
-
-  it("should not throw when sessionStorage throws during set", () => {
-    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
-    mockRestService.sendRequest
-      .mockReturnValueOnce(
-        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
-      )
-      .mockReturnValueOnce(
-        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
-      )
-      .mockReturnValueOnce(
-        of({ success: true, data: null, errorMessage: null }),
-      );
-    createService();
-    connectedSubject.next(true);
-    mockSessionStorage.setItem.mockImplementation(() => {
-      throw new Error("denied");
-    });
-
-    expect(() => service.set("web", "api_key", "new-key")).not.toThrow();
-    // Stream still receives the key even if persistence failed.
+    // set() is the only place the real key is available client-side; it is
+    // pushed to the stream (but not persisted anywhere).
     expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("new-key");
   });
 

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -6,7 +6,6 @@ import { LoggerService } from '../utils/logger.service';
 import { RestService, WebReaction } from '../utils/rest.service';
 import { StreamDispatchService } from '../base/stream-dispatch.service';
 import { Config, REDACTED_SENTINEL } from '../../models/config';
-import { StorageKeys } from '../../common/storage-keys';
 
 /** Value a config field may take (matches OptionComponent's value shape). */
 export type ConfigValue = string | number | boolean | null;
@@ -42,26 +41,16 @@ export class ConfigService {
   }
 
   constructor() {
-    // Rehydrate any persisted API key BEFORE the stream connects, so the
-    // first connection on an auth-enabled instance carries the key. This is
-    // the only client-side data that can re-authenticate after a reload —
-    // /server/config/get redacts web.api_key, so it cannot supply the key.
-    const persistedKey = this.readPersistedApiKey();
-    if (persistedKey) {
-      this.setStreamApiKey(persistedKey);
-    }
-
     // Fetch config at init independent of the stream connection.
     // /server/config/get is auth-exempt, so config$ can populate for the UI
     // even before (and without) an authenticated stream connection. This
     // breaks the init-ordering deadlock where the config fetch was gated
-    // behind a stream that could never connect without the key.
+    // behind a stream that could never connect without the key. The key itself
+    // is NOT persisted client-side; after a reload on an auth-enabled instance
+    // the user re-enters it in Settings (which re-pushes it to the stream).
     this.getConfig();
 
     this.connectedService.connected$.subscribe((connected) => {
-      // The connected$ subscription now only refreshes config on (re)connect;
-      // bootstrap is handled above. On disconnect, leave any persisted key in
-      // place so the next connect attempt can still authenticate.
       if (connected) {
         this.getConfig();
       }
@@ -93,12 +82,10 @@ export class ConfigService {
             const configRecord = config as unknown as ConfigRecord;
             const newConfig = { ...config, [section]: { ...configRecord[section], [option]: value } };
             this.configSubject.next(newConfig);
-            // Propagate API key changes to the SSE stream immediately. This is
-            // the only place the real (un-redacted) key is available, so it is
-            // also where we persist it for recovery after a reload.
+            // Propagate API key changes to the SSE stream immediately. set() is
+            // the only place the real (un-redacted) key is available client-side.
             if (section === 'web' && option === 'api_key') {
               const realKey = String(value ?? '') || null;
-              this.writePersistedApiKey(realKey);
               this.setStreamApiKey(realKey);
             }
           }
@@ -148,26 +135,5 @@ export class ConfigService {
     // StreamDispatchService -> ConnectedService -> ConfigService
     const streamDispatch = this.injector.get(StreamDispatchService);
     streamDispatch.setApiKey(apiKey);
-  }
-
-  private readPersistedApiKey(): string | null {
-    try {
-      return sessionStorage.getItem(StorageKeys.API_KEY);
-    } catch {
-      // sessionStorage may be unavailable (private browsing, test environments)
-      return null;
-    }
-  }
-
-  private writePersistedApiKey(apiKey: string | null): void {
-    try {
-      if (apiKey) {
-        sessionStorage.setItem(StorageKeys.API_KEY, apiKey);
-      } else {
-        sessionStorage.removeItem(StorageKeys.API_KEY);
-      }
-    } catch {
-      // sessionStorage may be unavailable (private browsing, test environments)
-    }
   }
 }

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -101,7 +101,7 @@ export class ConfigService {
       next: (reaction) => {
         if (reaction.success) {
           try {
-            const configJson: Config = JSON.parse(reaction.data!);
+            const configJson: Config = this.preserveRealApiKey(JSON.parse(reaction.data!));
             this.configSubject.next(configJson);
             this.syncStreamApiKey(configJson);
           } catch (e) {
@@ -122,6 +122,25 @@ export class ConfigService {
    * which would fail auth and clobber a good persisted key, so a redacted
    * value is treated as "no change" and never overwrites the stream's key.
    */
+  /**
+   * /server/config/get redacts web.api_key to the sentinel. A refresh must not
+   * clobber a real key the user entered this session — the apiKeyInterceptor
+   * reads configSnapshot.web.api_key for REST auth, so overwriting it with the
+   * sentinel would break authenticated REST calls until the next set(). Keep the
+   * existing real key when the incoming value is redacted.
+   */
+  private preserveRealApiKey(incoming: Config): Config {
+    const currentKey = this.configSubject.getValue()?.web?.api_key;
+    if (
+      incoming.web?.api_key === REDACTED_SENTINEL &&
+      currentKey &&
+      currentKey !== REDACTED_SENTINEL
+    ) {
+      return { ...incoming, web: { ...incoming.web, api_key: currentKey } };
+    }
+    return incoming;
+  }
+
   private syncStreamApiKey(config: Config | null): void {
     const apiKey = config?.web?.api_key || null;
     if (apiKey === REDACTED_SENTINEL) {

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -5,7 +5,7 @@ import { ConnectedService } from '../utils/connected.service';
 import { LoggerService } from '../utils/logger.service';
 import { RestService, WebReaction } from '../utils/rest.service';
 import { StreamDispatchService } from '../base/stream-dispatch.service';
-import { Config } from '../../models/config';
+import { Config, REDACTED_SENTINEL } from '../../models/config';
 import { StorageKeys } from '../../common/storage-keys';
 
 /** Value a config field may take (matches OptionComponent's value shape). */
@@ -17,13 +17,10 @@ type ConfigRecord = Record<string, Record<string, ConfigValue>>;
 /** Sentinel value sent to the backend when the user clears a text field. */
 export const EMPTY_VALUE_SENTINEL = '__empty__';
 
-/**
- * Value the backend substitutes for web.api_key in /server/config/get
- * responses (see common/config.py). It must never be treated as a real
- * key — pushing it to the stream would fail auth and could clobber a
- * good persisted key.
- */
-const REDACTED_SENTINEL = '********';
+// REDACTED_SENTINEL (imported from models/config) is the value the backend
+// substitutes for web.api_key in /server/config/get responses. It must never be
+// treated as a real key — pushing it to the stream would fail auth and could
+// clobber a good persisted key.
 
 @Injectable({ providedIn: 'root' })
 export class ConfigService {

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -6,6 +6,7 @@ import { LoggerService } from '../utils/logger.service';
 import { RestService, WebReaction } from '../utils/rest.service';
 import { StreamDispatchService } from '../base/stream-dispatch.service';
 import { Config } from '../../models/config';
+import { StorageKeys } from '../../common/storage-keys';
 
 /** Value a config field may take (matches OptionComponent's value shape). */
 export type ConfigValue = string | number | boolean | null;
@@ -15,6 +16,14 @@ type ConfigRecord = Record<string, Record<string, ConfigValue>>;
 
 /** Sentinel value sent to the backend when the user clears a text field. */
 export const EMPTY_VALUE_SENTINEL = '__empty__';
+
+/**
+ * Value the backend substitutes for web.api_key in /server/config/get
+ * responses (see common/config.py). It must never be treated as a real
+ * key — pushing it to the stream would fail auth and could clobber a
+ * good persisted key.
+ */
+const REDACTED_SENTINEL = '********';
 
 @Injectable({ providedIn: 'root' })
 export class ConfigService {
@@ -36,12 +45,28 @@ export class ConfigService {
   }
 
   constructor() {
+    // Rehydrate any persisted API key BEFORE the stream connects, so the
+    // first connection on an auth-enabled instance carries the key. This is
+    // the only client-side data that can re-authenticate after a reload —
+    // /server/config/get redacts web.api_key, so it cannot supply the key.
+    const persistedKey = this.readPersistedApiKey();
+    if (persistedKey) {
+      this.setStreamApiKey(persistedKey);
+    }
+
+    // Fetch config at init independent of the stream connection.
+    // /server/config/get is auth-exempt, so config$ can populate for the UI
+    // even before (and without) an authenticated stream connection. This
+    // breaks the init-ordering deadlock where the config fetch was gated
+    // behind a stream that could never connect without the key.
+    this.getConfig();
+
     this.connectedService.connected$.subscribe((connected) => {
+      // The connected$ subscription now only refreshes config on (re)connect;
+      // bootstrap is handled above. On disconnect, leave any persisted key in
+      // place so the next connect attempt can still authenticate.
       if (connected) {
         this.getConfig();
-      } else {
-        this.configSubject.next(null);
-        this.syncStreamApiKey(null);
       }
     });
   }
@@ -71,9 +96,13 @@ export class ConfigService {
             const configRecord = config as unknown as ConfigRecord;
             const newConfig = { ...config, [section]: { ...configRecord[section], [option]: value } };
             this.configSubject.next(newConfig);
-            // Propagate API key changes to the SSE stream immediately
+            // Propagate API key changes to the SSE stream immediately. This is
+            // the only place the real (un-redacted) key is available, so it is
+            // also where we persist it for recovery after a reload.
             if (section === 'web' && option === 'api_key') {
-              this.syncStreamApiKey(newConfig);
+              const realKey = String(value ?? '') || null;
+              this.writePersistedApiKey(realKey);
+              this.setStreamApiKey(realKey);
             }
           }
         }
@@ -94,22 +123,54 @@ export class ConfigService {
           } catch (e) {
             this.logger.error('Failed to parse config: %O', e);
             this.configSubject.next(null);
-            this.syncStreamApiKey(null);
           }
         } else {
           this.logger.error('Failed to get config: %s', reaction.errorMessage);
           this.configSubject.next(null);
-          this.syncStreamApiKey(null);
         }
       },
     });
   }
 
+  /**
+   * Push an API key from a fetched config to the stream, guarding against the
+   * redacted sentinel. /server/config/get redacts web.api_key to '********',
+   * which would fail auth and clobber a good persisted key, so a redacted
+   * value is treated as "no change" and never overwrites the stream's key.
+   */
   private syncStreamApiKey(config: Config | null): void {
     const apiKey = config?.web?.api_key || null;
+    if (apiKey === REDACTED_SENTINEL) {
+      return;
+    }
+    this.setStreamApiKey(apiKey);
+  }
+
+  private setStreamApiKey(apiKey: string | null): void {
     // Use injector.get() to break circular dependency:
     // StreamDispatchService -> ConnectedService -> ConfigService
     const streamDispatch = this.injector.get(StreamDispatchService);
     streamDispatch.setApiKey(apiKey);
+  }
+
+  private readPersistedApiKey(): string | null {
+    try {
+      return sessionStorage.getItem(StorageKeys.API_KEY);
+    } catch {
+      // sessionStorage may be unavailable (private browsing, test environments)
+      return null;
+    }
+  }
+
+  private writePersistedApiKey(apiKey: string | null): void {
+    try {
+      if (apiKey) {
+        sessionStorage.setItem(StorageKeys.API_KEY, apiKey);
+      } else {
+        sessionStorage.removeItem(StorageKeys.API_KEY);
+      }
+    } catch {
+      // sessionStorage may be unavailable (private browsing, test environments)
+    }
   }
 }

--- a/src/angular/src/app/services/utils/api-key.interceptor.spec.ts
+++ b/src/angular/src/app/services/utils/api-key.interceptor.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import {
   provideHttpClient,
@@ -12,6 +12,7 @@ import {
 
 import { apiKeyInterceptor } from "./api-key.interceptor";
 import { ConfigService } from "../settings/config.service";
+import { StorageKeys } from "../../common/storage-keys";
 import { Web } from "../../models/config";
 
 // Shape used by the interceptor's partial-config tests. The interceptor only
@@ -23,9 +24,33 @@ describe("apiKeyInterceptor", () => {
   let http: HttpClient;
   let httpTesting: HttpTestingController;
   let mockConfigService: { configSnapshot: MockConfigSnapshot };
+  let store: Record<string, string>;
+  let mockSessionStorage: {
+    getItem: ReturnType<typeof vi.fn>;
+    setItem: ReturnType<typeof vi.fn>;
+    removeItem: ReturnType<typeof vi.fn>;
+  };
+  let originalSessionStorage: Storage;
 
   beforeEach(() => {
     mockConfigService = { configSnapshot: null };
+
+    store = {};
+    mockSessionStorage = {
+      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+    };
+    originalSessionStorage = globalThis.sessionStorage;
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: mockSessionStorage,
+      configurable: true,
+      writable: true,
+    });
 
     TestBed.configureTestingModule({
       providers: [
@@ -41,6 +66,11 @@ describe("apiKeyInterceptor", () => {
 
   afterEach(() => {
     httpTesting.verify();
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: originalSessionStorage,
+      configurable: true,
+      writable: true,
+    });
   });
 
   // --- API key added to /server/* requests ---
@@ -146,6 +176,66 @@ describe("apiKeyInterceptor", () => {
 
     const req = httpTesting.expectOne("/serverExtra");
     expect(req.request.headers.has("X-Api-Key")).toBe(false);
+    req.flush("");
+  });
+
+  // --- Persisted real key recovery (#514) ---
+
+  it("should use the persisted sessionStorage key when the snapshot is redacted", () => {
+    // /server/config/get redacts the key to '********'; the persisted real key
+    // must be used so REST requests authenticate after a reload.
+    store[StorageKeys.API_KEY] = "real-key";
+    mockConfigService.configSnapshot = { web: { api_key: "********" } };
+
+    http.get("/server/config/get", { responseType: "text" }).subscribe();
+
+    const req = httpTesting.expectOne("/server/config/get");
+    expect(req.request.headers.get("X-Api-Key")).toBe("real-key");
+    req.flush("");
+  });
+
+  it("should prefer the persisted key over the snapshot key", () => {
+    store[StorageKeys.API_KEY] = "persisted-key";
+    mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
+
+    http.get("/server/config/get", { responseType: "text" }).subscribe();
+
+    const req = httpTesting.expectOne("/server/config/get");
+    expect(req.request.headers.get("X-Api-Key")).toBe("persisted-key");
+    req.flush("");
+  });
+
+  it("should never send the redacted sentinel as a credential", () => {
+    // No persisted key, and the snapshot only holds the redacted sentinel.
+    mockConfigService.configSnapshot = { web: { api_key: "********" } };
+
+    http.get("/server/config/get", { responseType: "text" }).subscribe();
+
+    const req = httpTesting.expectOne("/server/config/get");
+    expect(req.request.headers.has("X-Api-Key")).toBe(false);
+    req.flush("");
+  });
+
+  it("should fall back to the snapshot key when nothing is persisted", () => {
+    mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
+
+    http.get("/server/config/get", { responseType: "text" }).subscribe();
+
+    const req = httpTesting.expectOne("/server/config/get");
+    expect(req.request.headers.get("X-Api-Key")).toBe("snapshot-key");
+    req.flush("");
+  });
+
+  it("should tolerate sessionStorage throwing and fall back to the snapshot", () => {
+    mockSessionStorage.getItem.mockImplementation(() => {
+      throw new Error("denied");
+    });
+    mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
+
+    http.get("/server/config/get", { responseType: "text" }).subscribe();
+
+    const req = httpTesting.expectOne("/server/config/get");
+    expect(req.request.headers.get("X-Api-Key")).toBe("snapshot-key");
     req.flush("");
   });
 });

--- a/src/angular/src/app/services/utils/api-key.interceptor.spec.ts
+++ b/src/angular/src/app/services/utils/api-key.interceptor.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import {
   provideHttpClient,
@@ -12,7 +12,6 @@ import {
 
 import { apiKeyInterceptor } from "./api-key.interceptor";
 import { ConfigService } from "../settings/config.service";
-import { StorageKeys } from "../../common/storage-keys";
 import { Web } from "../../models/config";
 
 // Shape used by the interceptor's partial-config tests. The interceptor only
@@ -24,33 +23,9 @@ describe("apiKeyInterceptor", () => {
   let http: HttpClient;
   let httpTesting: HttpTestingController;
   let mockConfigService: { configSnapshot: MockConfigSnapshot };
-  let store: Record<string, string>;
-  let mockSessionStorage: {
-    getItem: ReturnType<typeof vi.fn>;
-    setItem: ReturnType<typeof vi.fn>;
-    removeItem: ReturnType<typeof vi.fn>;
-  };
-  let originalSessionStorage: Storage;
 
   beforeEach(() => {
     mockConfigService = { configSnapshot: null };
-
-    store = {};
-    mockSessionStorage = {
-      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
-      setItem: vi.fn((key: string, value: string) => {
-        store[key] = value;
-      }),
-      removeItem: vi.fn((key: string) => {
-        delete store[key];
-      }),
-    };
-    originalSessionStorage = globalThis.sessionStorage;
-    Object.defineProperty(globalThis, "sessionStorage", {
-      value: mockSessionStorage,
-      configurable: true,
-      writable: true,
-    });
 
     TestBed.configureTestingModule({
       providers: [
@@ -66,11 +41,6 @@ describe("apiKeyInterceptor", () => {
 
   afterEach(() => {
     httpTesting.verify();
-    Object.defineProperty(globalThis, "sessionStorage", {
-      value: originalSessionStorage,
-      configurable: true,
-      writable: true,
-    });
   });
 
   // --- API key added to /server/* requests ---
@@ -179,34 +149,11 @@ describe("apiKeyInterceptor", () => {
     req.flush("");
   });
 
-  // --- Persisted real key recovery (#514) ---
-
-  it("should use the persisted sessionStorage key when the snapshot is redacted", () => {
-    // /server/config/get redacts the key to '********'; the persisted real key
-    // must be used so REST requests authenticate after a reload.
-    store[StorageKeys.API_KEY] = "real-key";
-    mockConfigService.configSnapshot = { web: { api_key: "********" } };
-
-    http.get("/server/config/get", { responseType: "text" }).subscribe();
-
-    const req = httpTesting.expectOne("/server/config/get");
-    expect(req.request.headers.get("X-Api-Key")).toBe("real-key");
-    req.flush("");
-  });
-
-  it("should prefer the persisted key over the snapshot key", () => {
-    store[StorageKeys.API_KEY] = "persisted-key";
-    mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
-
-    http.get("/server/config/get", { responseType: "text" }).subscribe();
-
-    const req = httpTesting.expectOne("/server/config/get");
-    expect(req.request.headers.get("X-Api-Key")).toBe("persisted-key");
-    req.flush("");
-  });
+  // --- Redacted sentinel guard (#514) ---
 
   it("should never send the redacted sentinel as a credential", () => {
-    // No persisted key, and the snapshot only holds the redacted sentinel.
+    // /server/config/get redacts the key to '********'; that must never be
+    // sent as a credential.
     mockConfigService.configSnapshot = { web: { api_key: "********" } };
 
     http.get("/server/config/get", { responseType: "text" }).subscribe();
@@ -216,20 +163,7 @@ describe("apiKeyInterceptor", () => {
     req.flush("");
   });
 
-  it("should fall back to the snapshot key when nothing is persisted", () => {
-    mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
-
-    http.get("/server/config/get", { responseType: "text" }).subscribe();
-
-    const req = httpTesting.expectOne("/server/config/get");
-    expect(req.request.headers.get("X-Api-Key")).toBe("snapshot-key");
-    req.flush("");
-  });
-
-  it("should tolerate sessionStorage throwing and fall back to the snapshot", () => {
-    mockSessionStorage.getItem.mockImplementation(() => {
-      throw new Error("denied");
-    });
+  it("should send the real snapshot key (present during the session it was set)", () => {
     mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
 
     http.get("/server/config/get", { responseType: "text" }).subscribe();

--- a/src/angular/src/app/services/utils/api-key.interceptor.ts
+++ b/src/angular/src/app/services/utils/api-key.interceptor.ts
@@ -3,14 +3,11 @@ import { inject } from '@angular/core';
 
 import { ConfigService } from '../settings/config.service';
 import { StorageKeys } from '../../common/storage-keys';
+import { REDACTED_SENTINEL } from '../../models/config';
 
-/**
- * Value the backend substitutes for web.api_key in /server/config/get
- * responses (see common/config.py). /server/config/get is auth-exempt, so the
- * config snapshot can hold this sentinel before the real key is known — it
- * must never be sent as a credential.
- */
-const REDACTED_SENTINEL = '********';
+// REDACTED_SENTINEL is the value the backend substitutes for web.api_key in the
+// auth-exempt /server/config/get response, so the config snapshot can hold it
+// before the real key is known — it must never be sent as a credential.
 
 function readPersistedApiKey(): string | null {
   try {

--- a/src/angular/src/app/services/utils/api-key.interceptor.ts
+++ b/src/angular/src/app/services/utils/api-key.interceptor.ts
@@ -2,21 +2,7 @@ import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 
 import { ConfigService } from '../settings/config.service';
-import { StorageKeys } from '../../common/storage-keys';
 import { REDACTED_SENTINEL } from '../../models/config';
-
-// REDACTED_SENTINEL is the value the backend substitutes for web.api_key in the
-// auth-exempt /server/config/get response, so the config snapshot can hold it
-// before the real key is known — it must never be sent as a credential.
-
-function readPersistedApiKey(): string | null {
-  try {
-    return sessionStorage.getItem(StorageKeys.API_KEY);
-  } catch {
-    // sessionStorage may be unavailable (private browsing, test environments)
-    return null;
-  }
-}
 
 export const apiKeyInterceptor: HttpInterceptorFn = (req, next) => {
   // Only attach the API key to internal backend /server/* requests
@@ -25,17 +11,13 @@ export const apiKeyInterceptor: HttpInterceptorFn = (req, next) => {
     return next(req);
   }
 
-  // Prefer the persisted real key: /server/config/get redacts web.api_key to
-  // '********', so on an auth-enabled instance the config snapshot cannot
-  // supply a usable credential after a reload. The persisted key (written by
-  // ConfigService when the user saves it) is the only client-side source of
-  // the real key, so REST requests can re-authenticate after a reload.
-  const persistedKey = readPersistedApiKey();
   const configService = inject(ConfigService);
   const snapshotKey = configService.configSnapshot?.web?.api_key;
 
-  // Never send the redacted sentinel as a credential.
-  const apiKey = persistedKey || (snapshotKey === REDACTED_SENTINEL ? null : snapshotKey);
+  // /server/config/get redacts web.api_key to '********'; never send the
+  // redacted sentinel as a credential. The real key is only present in the
+  // snapshot during the session in which the user entered it in Settings.
+  const apiKey = snapshotKey === REDACTED_SENTINEL ? null : snapshotKey;
 
   if (apiKey) {
     const authReq = req.clone({

--- a/src/angular/src/app/services/utils/api-key.interceptor.ts
+++ b/src/angular/src/app/services/utils/api-key.interceptor.ts
@@ -2,6 +2,24 @@ import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 
 import { ConfigService } from '../settings/config.service';
+import { StorageKeys } from '../../common/storage-keys';
+
+/**
+ * Value the backend substitutes for web.api_key in /server/config/get
+ * responses (see common/config.py). /server/config/get is auth-exempt, so the
+ * config snapshot can hold this sentinel before the real key is known — it
+ * must never be sent as a credential.
+ */
+const REDACTED_SENTINEL = '********';
+
+function readPersistedApiKey(): string | null {
+  try {
+    return sessionStorage.getItem(StorageKeys.API_KEY);
+  } catch {
+    // sessionStorage may be unavailable (private browsing, test environments)
+    return null;
+  }
+}
 
 export const apiKeyInterceptor: HttpInterceptorFn = (req, next) => {
   // Only attach the API key to internal backend /server/* requests
@@ -10,9 +28,17 @@ export const apiKeyInterceptor: HttpInterceptorFn = (req, next) => {
     return next(req);
   }
 
+  // Prefer the persisted real key: /server/config/get redacts web.api_key to
+  // '********', so on an auth-enabled instance the config snapshot cannot
+  // supply a usable credential after a reload. The persisted key (written by
+  // ConfigService when the user saves it) is the only client-side source of
+  // the real key, so REST requests can re-authenticate after a reload.
+  const persistedKey = readPersistedApiKey();
   const configService = inject(ConfigService);
-  const config = configService.configSnapshot;
-  const apiKey = config?.web?.api_key;
+  const snapshotKey = configService.configSnapshot?.web?.api_key;
+
+  // Never send the redacted sentinel as a credential.
+  const apiKey = persistedKey || (snapshotKey === REDACTED_SENTINEL ? null : snapshotKey);
 
   if (apiKey) {
     const authReq = req.clone({


### PR DESCRIPTION
Fixes the **🖥️ Frontend bugs / UX** bucket of tracking issue #531 (4 issues) in one branch, the sibling to the backend bucket (#537). Each fix has its own commit and Vitest tests.

> [!NOTE]
> **Intentional grouping.** This bundles 4 issues, deviating from CLAUDE.md's "one concern per branch" rule — done deliberately at the maintainer's request for a single grouped review. Commits are one-per-issue (plus review-polish commits).

## How this was built
A multi-agent workflow: **parallel investigation** (one agent per issue, re-verifying each finding against current Angular code), **sequential implementation** (ordered so the two issues sharing `file-list.component.ts` — #513, #515 — ran adjacently and conflict-free; each = fix + Vitest tests + its own commit, validated with `ng test` + `ng lint --max-warnings 0`), then **parallel adversarial review**. The review surfaced gaps, which were then addressed (below).

## Issues fixed

| # | Sev | Fix |
|---|-----|-----|
| **#513** | High | Single-file actions (Queue/Stop/Extract/Validate/Delete) now surface backend failures as a `NotificationService` DANGER banner, and a failed action no longer leaves the row's buttons/spinner stuck (`activeAction` is reset). |
| **#514** | High | Auth-enabled init deadlock fixed: config is bootstrapped independent of the SSE stream (the UI renders instead of hanging on "connecting"), the redacted sentinel is never sent as a credential, and reconnect uses capped exponential backoff. (The key is **not** persisted client-side — see the review note below; after a reload the user re-enters it in Settings.) |
| **#515** | Medium | Bulk Delete Local/Remote now require the same two-click confirm (3s reset) as the per-file action — no more one-misclick data loss off the seedbox. |
| **#516** | Low | `JSON.parse` guarded across the SSE/autoqueue handlers; log-history fetch failure shows a distinct "failed to load" state (not an empty result); path-pair enable/auto-queue toggle failures set an error banner and `refresh()` to reconcile the UI. |

## Review findings → resolution
Adversarial review flagged two items, both **resolved in this PR** (no follow-ups):

- **#516 (was `acMet=false`): scope gap.** The initial commit covered only the SSE-handler `JSON.parse`. Completed the issue's other acceptance criteria — autoqueue parse guard, the log-history failure state, and path-pair toggle error handling + `refresh()` — each with tests.
- **#514 (minor): DRY.** The fix had introduced two local copies of the `'********'` sentinel; now imports the existing exported `REDACTED_SENTINEL` from `models/config`.

#513 and #515 passed review with all acceptance criteria met.

## Test plan
- ✅ Full Angular unit suite (Vitest): **464 passed** (37 files), up from 430 on develop.
- ✅ `npx ng lint --max-warnings 0`: clean.
- New Vitest tests accompany every fix (happy path + failure/edge paths), including deterministic error-surfacing, reconnect backoff, the redacted-sentinel guard, two-click confirm, malformed-JSON fallback, and the distinct log-history failure state.

## Security review (CodeQL)
CodeQL flagged an initial #514 approach that persisted `web.api_key` in `sessionStorage` as high-severity clear-text storage of a credential. Since there is no safe way to auto-recover the key after a reload (the auth-exempt `/server/config/get` redacts it, and an authenticated endpoint recreates the deadlock), the client-side persistence was **dropped**. #514 still fixes the core deadlock (the UI renders rather than hanging forever); a reload on an auth-enabled instance simply needs the key re-entered in Settings. No credential is stored client-side.

Closes #513. Closes #514. Closes #515. Closes #516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inline delete confirmation to bulk actions—click once to arm confirmation, click again to execute deletion.
  * Added visual error banner when log history fails to load.

* **Bug Fixes**
  * Actions now display error notifications when they fail; UI buttons reset appropriately on errors.
  * Improved network reconnection with exponential backoff and jitter.
  * App now gracefully handles malformed data from the server without crashing; errors are logged for troubleshooting.

* **Improvements**
  * Better error recovery for settings updates with automatic state reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
