### PR TITLE
Performance bucket from audit (#531): O(n²) model build, SSE rebuild thrash, log buffer

### DIFF
--- a/src/angular/src/app/app.config.ts
+++ b/src/angular/src/app/app.config.ts
@@ -13,6 +13,7 @@ import { ModelFileService } from './services/files/model-file.service';
 import { LogService } from './services/logs/log.service';
 import { ViewFileFilterService } from './services/files/view-file-filter.service';
 import { ViewFileSortService } from './services/files/view-file-sort.service';
+import { VIEW_FILE_COALESCE_MS } from './services/files/view-file.service';
 import { ThemeService } from './services/utils/theme.service';
 import { ConfigService } from './services/settings/config.service';
 import { AutoQueueService } from './services/autoqueue/autoqueue.service';
@@ -46,6 +47,10 @@ export const appConfig: ApplicationConfig = {
     provideRouter(ROUTES),
     provideHttpClient(withInterceptors([apiKeyInterceptor])),
     { provide: RouteReuseStrategy, useClass: CachedReuseStrategy },
+    // Coalesce the per-file SSE fan-out into one view rebuild per ~100ms window
+    // (issue #521). The backend controller loop ticks every ~0.5s, so this batches
+    // a burst of per-file model events without any user-perceivable delay.
+    { provide: VIEW_FILE_COALESCE_MS, useValue: 100 },
     {
       provide: APP_INITIALIZER,
       useFactory: initializeStreaming,

--- a/src/angular/src/app/common/storage-keys.ts
+++ b/src/angular/src/app/common/storage-keys.ts
@@ -3,4 +3,5 @@ export class StorageKeys {
     public static readonly VIEW_OPTION_SORT_METHOD = "view-option-sort-method";
     public static readonly VIEW_OPTION_PIN = "view-option-pin";
     public static readonly THEME = "theme";
+    public static readonly API_KEY = "api-key";
 }

--- a/src/angular/src/app/common/storage-keys.ts
+++ b/src/angular/src/app/common/storage-keys.ts
@@ -3,5 +3,4 @@ export class StorageKeys {
     public static readonly VIEW_OPTION_SORT_METHOD = "view-option-sort-method";
     public static readonly VIEW_OPTION_PIN = "view-option-pin";
     public static readonly THEME = "theme";
-    public static readonly API_KEY = "api-key";
 }

--- a/src/angular/src/app/pages/files/bulk-action-bar.component.spec.ts
+++ b/src/angular/src/app/pages/files/bulk-action-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { BulkActionBarComponent } from './bulk-action-bar.component';
 
@@ -65,24 +65,32 @@ describe('BulkActionBarComponent', () => {
     expect(emitted).toBe(true);
   });
 
-  it('should emit deleteLocalEvent when Delete Local button is clicked', () => {
-    let emitted = false;
-    component.deleteLocalEvent.subscribe(() => (emitted = true));
+  it('should emit deleteLocalEvent only on the second Delete Local click', () => {
+    let emitCount = 0;
+    component.deleteLocalEvent.subscribe(() => (emitCount += 1));
 
-    const btn = findButtonByText('Delete Local');
-    btn.click();
+    // First click arms the confirm, does NOT emit
+    findButtonByText('Delete Local').click();
+    expect(emitCount).toBe(0);
 
-    expect(emitted).toBe(true);
+    // Second click emits
+    fixture.detectChanges();
+    findButtonByText('Confirm?').click();
+    expect(emitCount).toBe(1);
   });
 
-  it('should emit deleteRemoteEvent when Delete Remote button is clicked', () => {
-    let emitted = false;
-    component.deleteRemoteEvent.subscribe(() => (emitted = true));
+  it('should emit deleteRemoteEvent only on the second Delete Remote click', () => {
+    let emitCount = 0;
+    component.deleteRemoteEvent.subscribe(() => (emitCount += 1));
 
-    const btn = findButtonByText('Delete Remote');
-    btn.click();
+    // First click arms the confirm, does NOT emit
+    findButtonByText('Delete Remote').click();
+    expect(emitCount).toBe(0);
 
-    expect(emitted).toBe(true);
+    // Second click emits
+    fixture.detectChanges();
+    findButtonByText('Confirm?').click();
+    expect(emitCount).toBe(1);
   });
 
   it('should emit clearEvent when Clear button is clicked', () => {
@@ -98,5 +106,113 @@ describe('BulkActionBarComponent', () => {
   it('should render exactly five buttons', () => {
     const buttons = fixture.nativeElement.querySelectorAll('button');
     expect(buttons.length).toBe(5);
+  });
+});
+
+describe('BulkActionBarComponent inline bulk delete confirmation', () => {
+  let fixture: ComponentFixture<BulkActionBarComponent>;
+  let component: BulkActionBarComponent;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+
+    await TestBed.configureTestingModule({
+      imports: [BulkActionBarComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BulkActionBarComponent);
+    fixture.componentRef.setInput('count', 3);
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function findButtonByText(text: string): HTMLButtonElement {
+    const buttons = Array.from(
+      fixture.nativeElement.querySelectorAll('button'),
+    ) as HTMLButtonElement[];
+    const btn = buttons.find((el) => el.textContent?.includes(text));
+    expect(btn).toBeTruthy();
+    return btn!;
+  }
+
+  it('first click on Delete Local sets confirming state and does not emit', () => {
+    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+
+    component.onDeleteLocal();
+
+    expect(component.confirmingDelete).toBe('local');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('second click on Delete Local emits event and clears state', () => {
+    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+
+    component.onDeleteLocal();
+    expect(component.confirmingDelete).toBe('local');
+
+    component.onDeleteLocal();
+    expect(component.confirmingDelete).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('first click on Delete Remote sets confirming state and does not emit', () => {
+    const spy = vi.spyOn(component.deleteRemoteEvent, 'emit');
+
+    component.onDeleteRemote();
+
+    expect(component.confirmingDelete).toBe('remote');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('second click on Delete Remote emits event and clears state', () => {
+    const spy = vi.spyOn(component.deleteRemoteEvent, 'emit');
+
+    component.onDeleteRemote();
+    expect(component.confirmingDelete).toBe('remote');
+
+    component.onDeleteRemote();
+    expect(component.confirmingDelete).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('confirming state auto-resets after 3 seconds', () => {
+    component.onDeleteLocal();
+    expect(component.confirmingDelete).toBe('local');
+
+    vi.advanceTimersByTime(3000);
+    expect(component.confirmingDelete).toBeNull();
+  });
+
+  it('clicking Delete Local while confirming remote switches to local', () => {
+    component.onDeleteRemote();
+    expect(component.confirmingDelete).toBe('remote');
+
+    component.onDeleteLocal();
+    expect(component.confirmingDelete).toBe('local');
+  });
+
+  it("button label switches to 'Confirm?' after first Delete Local click", () => {
+    // Drive through a real DOM click so OnPush marks the view dirty.
+    findButtonByText('Delete Local').click();
+    fixture.detectChanges();
+
+    expect(component.confirmingDelete).toBe('local');
+    const btn = findButtonByText('Confirm?');
+    expect(btn.textContent).toContain('Confirm?');
+  });
+
+  it('ngOnDestroy clears the confirm timer so no reset fires', () => {
+    component.onDeleteLocal();
+    expect(component.confirmingDelete).toBe('local');
+
+    component.ngOnDestroy();
+    vi.advanceTimersByTime(5000);
+
+    // State stays as-is (timer was cleared, no reset happened)
+    expect(component.confirmingDelete).toBe('local');
   });
 });

--- a/src/angular/src/app/pages/files/bulk-action-bar.component.ts
+++ b/src/angular/src/app/pages/files/bulk-action-bar.component.ts
@@ -1,4 +1,6 @@
-import { Component, ChangeDetectionStrategy, input, output } from '@angular/core';
+import {
+    Component, ChangeDetectionStrategy, ChangeDetectorRef, OnDestroy, input, output, inject
+} from '@angular/core';
 
 @Component({
     selector: 'app-bulk-action-bar',
@@ -8,8 +10,16 @@ import { Component, ChangeDetectionStrategy, input, output } from '@angular/core
             <span class="count">{{ count() }} selected</span>
             <button class="btn btn-sm btn-outline-primary" (click)="queueEvent.emit()">Queue</button>
             <button class="btn btn-sm btn-outline-warning" (click)="stopEvent.emit()">Stop</button>
-            <button class="btn btn-sm btn-outline-danger" (click)="deleteLocalEvent.emit()">Delete Local</button>
-            <button class="btn btn-sm btn-outline-danger" (click)="deleteRemoteEvent.emit()">Delete Remote</button>
+            <button class="btn btn-sm btn-outline-danger"
+                    [class.confirming]="confirmingDelete === 'local'"
+                    (click)="onDeleteLocal()">
+                {{ confirmingDelete === 'local' ? 'Confirm?' : 'Delete Local' }}
+            </button>
+            <button class="btn btn-sm btn-outline-danger"
+                    [class.confirming]="confirmingDelete === 'remote'"
+                    (click)="onDeleteRemote()">
+                {{ confirmingDelete === 'remote' ? 'Confirm?' : 'Delete Remote' }}
+            </button>
             <button class="btn btn-sm btn-outline-secondary" (click)="clearEvent.emit()">Clear</button>
         </div>
     `,
@@ -26,10 +36,16 @@ import { Component, ChangeDetectionStrategy, input, output } from '@angular/core
             font-weight: bold;
             margin-right: 8px;
         }
+        .btn.confirming {
+            background-color: var(--bs-danger);
+            color: #fff;
+        }
     `],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BulkActionBarComponent {
+export class BulkActionBarComponent implements OnDestroy {
+    private readonly cdr = inject(ChangeDetectorRef);
+
     count = input.required<number>();
 
     queueEvent = output<void>();
@@ -37,4 +53,49 @@ export class BulkActionBarComponent {
     deleteLocalEvent = output<void>();
     deleteRemoteEvent = output<void>();
     clearEvent = output<void>();
+
+    // Inline double-click delete confirmation state
+    confirmingDelete: 'local' | 'remote' | null = null;
+    private confirmResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+    ngOnDestroy(): void {
+        this.clearConfirmTimer();
+    }
+
+    onDeleteLocal(): void {
+        if (this.confirmingDelete === 'local') {
+            this.clearConfirmTimer();
+            this.confirmingDelete = null;
+            this.deleteLocalEvent.emit();
+        } else {
+            this.setConfirming('local');
+        }
+    }
+
+    onDeleteRemote(): void {
+        if (this.confirmingDelete === 'remote') {
+            this.clearConfirmTimer();
+            this.confirmingDelete = null;
+            this.deleteRemoteEvent.emit();
+        } else {
+            this.setConfirming('remote');
+        }
+    }
+
+    private setConfirming(type: 'local' | 'remote'): void {
+        this.clearConfirmTimer();
+        this.confirmingDelete = type;
+        this.confirmResetTimer = setTimeout(() => {
+            this.confirmingDelete = null;
+            this.confirmResetTimer = null;
+            this.cdr.markForCheck();
+        }, 3000);
+    }
+
+    private clearConfirmTimer(): void {
+        if (this.confirmResetTimer !== null) {
+            clearTimeout(this.confirmResetTimer);
+            this.confirmResetTimer = null;
+        }
+    }
 }

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -1,15 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { BehaviorSubject, Observable, of, EMPTY } from 'rxjs';
+import { BehaviorSubject, Observable, of, EMPTY, throwError } from 'rxjs';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 
 import { FileListComponent } from './file-list.component';
 import { ViewFileService } from '../../services/files/view-file.service';
 import { ViewFileOptionsService } from '../../services/files/view-file-options.service';
 import { LoggerService } from '../../services/utils/logger.service';
+import { NotificationService } from '../../services/utils/notification.service';
+import { NotificationLevel } from '../../models/notification';
 import { ViewFile, ViewFileStatus } from '../../models/view-file';
 import { ViewFileOptions, SortMethod } from '../../models/view-file-options';
 import { fileKey } from '../../services/files/file-key';
+import { FileActionEvent } from './file.component';
 
 interface MockViewFileService {
   filteredFiles$: Observable<ViewFile[]>;
@@ -30,6 +33,15 @@ interface MockViewFileService {
   bulkStop: ReturnType<typeof vi.fn>;
   bulkDeleteLocal: ReturnType<typeof vi.fn>;
   bulkDeleteRemote: ReturnType<typeof vi.fn>;
+}
+
+interface MockNotificationService {
+  show: ReturnType<typeof vi.fn>;
+  hide: ReturnType<typeof vi.fn>;
+}
+
+function makeActionEvent(file: ViewFile): FileActionEvent {
+  return { file, clearActiveAction: vi.fn() };
 }
 
 function makeViewFile(overrides: Partial<ViewFile> = {}): ViewFile {
@@ -71,6 +83,7 @@ describe('FileListComponent', () => {
   let checkedSubject: BehaviorSubject<Set<string>>;
   let optionsSubject: BehaviorSubject<ViewFileOptions>;
   let mockViewFileService: MockViewFileService;
+  let mockNotifService: MockNotificationService;
 
   beforeEach(async () => {
     filteredFilesSubject = new BehaviorSubject<ViewFile[]>([]);
@@ -104,12 +117,15 @@ describe('FileListComponent', () => {
       bulkDeleteRemote: vi.fn().mockReturnValue(EMPTY),
     };
 
+    mockNotifService = { show: vi.fn(), hide: vi.fn() };
+
     await TestBed.configureTestingModule({
       imports: [FileListComponent, ScrollingModule],
       providers: [
         { provide: ViewFileService, useValue: mockViewFileService },
         { provide: ViewFileOptionsService, useValue: { options$: optionsSubject.asObservable() } },
         { provide: LoggerService, useValue: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+        { provide: NotificationService, useValue: mockNotifService },
       ],
     }).compileComponents();
 
@@ -269,7 +285,7 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'queue-me.txt' });
     mockViewFileService.queue.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onQueue(file);
+    component.onQueue(makeActionEvent(file));
 
     expect(mockViewFileService.queue).toHaveBeenCalledWith(file);
   });
@@ -278,7 +294,7 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'stop-me.txt' });
     mockViewFileService.stop.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onStop(file);
+    component.onStop(makeActionEvent(file));
 
     expect(mockViewFileService.stop).toHaveBeenCalledWith(file);
   });
@@ -287,7 +303,7 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'extract-me.txt' });
     mockViewFileService.extract.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onExtract(file);
+    component.onExtract(makeActionEvent(file));
 
     expect(mockViewFileService.extract).toHaveBeenCalledWith(file);
   });
@@ -296,7 +312,7 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'validate-me.txt' });
     mockViewFileService.validate.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onValidate(file);
+    component.onValidate(makeActionEvent(file));
 
     expect(mockViewFileService.validate).toHaveBeenCalledWith(file);
   });
@@ -305,7 +321,7 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'del-local.txt' });
     mockViewFileService.deleteLocal.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onDeleteLocal(file);
+    component.onDeleteLocal(makeActionEvent(file));
 
     expect(mockViewFileService.deleteLocal).toHaveBeenCalledWith(file);
   });
@@ -314,9 +330,67 @@ describe('FileListComponent', () => {
     const file = makeViewFile({ name: 'del-remote.txt' });
     mockViewFileService.deleteRemote.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onDeleteRemote(file);
+    component.onDeleteRemote(makeActionEvent(file));
 
     expect(mockViewFileService.deleteRemote).toHaveBeenCalledWith(file);
+  });
+
+  // --- Single-file action error surfacing (#513) ---
+
+  it('shows a DANGER banner and clears activeAction when an action fails', () => {
+    const file = makeViewFile({ name: 'fail-me.txt' });
+    const event = makeActionEvent(file);
+    mockViewFileService.queue.mockReturnValue(
+      of({ success: false, data: null, errorMessage: 'Boom' }),
+    );
+
+    component.onQueue(event);
+
+    expect(mockNotifService.show).toHaveBeenCalledTimes(1);
+    const notif = mockNotifService.show.mock.calls[0][0];
+    expect(notif.level).toBe(NotificationLevel.DANGER);
+    expect(notif.text).toContain('Boom');
+    expect(event.clearActiveAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a generic message when a failed reaction has no errorMessage', () => {
+    const event = makeActionEvent(makeViewFile());
+    mockViewFileService.stop.mockReturnValue(
+      of({ success: false, data: null, errorMessage: null }),
+    );
+
+    component.onStop(event);
+
+    expect(mockNotifService.show).toHaveBeenCalledTimes(1);
+    expect(mockNotifService.show.mock.calls[0][0].text).toBe('Action failed');
+    expect(event.clearActiveAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show a banner or clear activeAction on a successful action', () => {
+    const logger = TestBed.inject(LoggerService);
+    const event = makeActionEvent(makeViewFile());
+    mockViewFileService.validate.mockReturnValue(
+      of({ success: true, data: 'ok', errorMessage: null }),
+    );
+
+    component.onValidate(event);
+
+    expect(mockNotifService.show).not.toHaveBeenCalled();
+    expect(event.clearActiveAction).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('ok');
+  });
+
+  it('shows a DANGER banner and clears activeAction when the action stream errors', () => {
+    const event = makeActionEvent(makeViewFile());
+    mockViewFileService.deleteRemote.mockReturnValue(
+      throwError(() => new Error('net')),
+    );
+
+    component.onDeleteRemote(event);
+
+    expect(mockNotifService.show).toHaveBeenCalledTimes(1);
+    expect(mockNotifService.show.mock.calls[0][0].level).toBe(NotificationLevel.DANGER);
+    expect(event.clearActiveAction).toHaveBeenCalledTimes(1);
   });
 
   // --- Bulk actions ---
@@ -367,7 +441,7 @@ describe('FileListComponent', () => {
 
   // --- Bulk response handling ---
 
-  it('should log failures from bulk action responses', () => {
+  it('should log failures and show a DANGER banner from bulk action responses', () => {
     const logger = TestBed.inject(LoggerService);
     mockViewFileService.bulkQueue.mockReturnValue(of([
       { success: true, data: 'ok', errorMessage: null },
@@ -378,6 +452,21 @@ describe('FileListComponent', () => {
 
     expect(logger.error).toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalled();
+    expect(mockNotifService.show).toHaveBeenCalledTimes(1);
+    const notif = mockNotifService.show.mock.calls[0][0];
+    expect(notif.level).toBe(NotificationLevel.DANGER);
+    expect(notif.text).toBe('1 of 2 items failed');
+  });
+
+  it('should not show a banner when all bulk items succeed', () => {
+    mockViewFileService.bulkDeleteLocal.mockReturnValue(of([
+      { success: true, data: 'ok', errorMessage: null },
+      { success: true, data: 'ok2', errorMessage: null },
+    ]));
+
+    component.onBulkDeleteLocal();
+
+    expect(mockNotifService.show).not.toHaveBeenCalled();
   });
 
   it('should log info for successful bulk items', () => {

--- a/src/angular/src/app/pages/files/file-list.component.ts
+++ b/src/angular/src/app/pages/files/file-list.component.ts
@@ -20,8 +20,10 @@ import { ViewFile } from '../../models/view-file';
 import { ViewFileOptions } from '../../models/view-file-options';
 import { ViewFileOptionsService } from '../../services/files/view-file-options.service';
 import { LoggerService } from '../../services/utils/logger.service';
+import { NotificationService } from '../../services/utils/notification.service';
+import { NotificationLevel, createNotification } from '../../models/notification';
 import { fileKey } from '../../services/files/file-key';
-import { FileComponent } from './file.component';
+import { FileComponent, FileActionEvent } from './file.component';
 import { BulkActionBarComponent } from './bulk-action-bar.component';
 
 @Component({
@@ -38,6 +40,7 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
   private readonly logger = inject(LoggerService);
   private readonly viewFileService = inject(ViewFileService);
   private readonly viewFileOptionsService = inject(ViewFileOptionsService);
+  private readonly notifService = inject(NotificationService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly elRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly zone = inject(NgZone);
@@ -121,52 +124,80 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  onQueue(file: ViewFile): void {
-    this.viewFileService.queue(file).pipe(
+  onQueue(event: FileActionEvent): void {
+    this.viewFileService.queue(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
   }
 
-  onStop(file: ViewFile): void {
-    this.viewFileService.stop(file).pipe(
+  onStop(event: FileActionEvent): void {
+    this.viewFileService.stop(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
   }
 
-  onExtract(file: ViewFile): void {
-    this.viewFileService.extract(file).pipe(
+  onExtract(event: FileActionEvent): void {
+    this.viewFileService.extract(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
   }
 
-  onValidate(file: ViewFile): void {
-    this.viewFileService.validate(file).pipe(
+  onValidate(event: FileActionEvent): void {
+    this.viewFileService.validate(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
   }
 
-  onDeleteLocal(file: ViewFile): void {
-    this.viewFileService.deleteLocal(file).pipe(
+  onDeleteLocal(event: FileActionEvent): void {
+    this.viewFileService.deleteLocal(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
   }
 
-  onDeleteRemote(file: ViewFile): void {
-    this.viewFileService.deleteRemote(file).pipe(
+  onDeleteRemote(event: FileActionEvent): void {
+    this.viewFileService.deleteRemote(event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe(data => {
-      this.logger.info(data);
+    ).subscribe({
+      next: (data) => this.handleActionResponse(data, event),
+      error: (err) => this.handleActionError(err, event),
     });
+  }
+
+  private handleActionResponse(reaction: WebReaction, event: FileActionEvent): void {
+    if (reaction.success) {
+      this.logger.info(reaction.data);
+    } else {
+      this.failAction(reaction.errorMessage ?? 'Action failed', event);
+    }
+  }
+
+  private handleActionError(err: unknown, event: FileActionEvent): void {
+    this.failAction('Action failed', event);
+    this.logger.error('Action failed:', err);
+  }
+
+  // A backend rejection leaves the file model unchanged, so the child's
+  // ngOnChanges can't recover the row. Surface the error and clear the child's
+  // activeAction so the buttons re-enable and the spinner stops without a reload.
+  private failAction(text: string, event: FileActionEvent): void {
+    this.notifService.show(createNotification(NotificationLevel.DANGER, text, true));
+    event.clearActiveAction();
+    this.logger.error(text);
   }
 
   onCheck(event: {file: ViewFile, shiftKey: boolean}): void {
@@ -206,6 +237,11 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
         });
         if (failures > 0) {
           this.logger.warn(`Bulk action: ${failures} of ${reactions.length} items failed`);
+          this.notifService.show(createNotification(
+            NotificationLevel.DANGER,
+            `${failures} of ${reactions.length} items failed`,
+            true,
+          ));
         }
       },
       error: (err) => this.logger.error('Bulk action failed:', err),

--- a/src/angular/src/app/pages/files/file.component.spec.ts
+++ b/src/angular/src/app/pages/files/file.component.spec.ts
@@ -319,3 +319,47 @@ describe('FileComponent action events', () => {
     expect(component.activeAction).toBeNull();
   });
 });
+
+describe('FileComponent.clearActiveAction recycle guard (#540)', () => {
+  let fixture: ComponentFixture<FileComponent>;
+  let component: FileComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [FileComponent] }).compileComponents();
+    fixture = TestBed.createComponent(FileComponent);
+    fixture.componentRef.setInput('options', of({ nameFilter: '', statusFilter: '' }));
+    component = fixture.componentInstance;
+  });
+
+  it('clears when the instance still represents the same file and action', () => {
+    const fileA = makeViewFile({ name: 'a.txt' });
+    fixture.componentRef.setInput('file', fileA);
+    fixture.detectChanges();
+    component.activeAction = FileAction.QUEUE;
+
+    component.clearActiveAction(fileA, FileAction.QUEUE);
+    expect(component.activeAction).toBeNull();
+  });
+
+  it('does NOT clear when recycled to a different file (stale failure callback)', () => {
+    const fileA = makeViewFile({ name: 'a.txt' });
+    const fileB = makeViewFile({ name: 'b.txt' });
+    fixture.componentRef.setInput('file', fileB); // instance recycled to file B
+    fixture.detectChanges();
+    component.activeAction = FileAction.DELETE_LOCAL; // B started its own action
+
+    // A late failure callback captured for file A must not clear B's action.
+    component.clearActiveAction(fileA, FileAction.QUEUE);
+    expect(component.activeAction).toBe(FileAction.DELETE_LOCAL);
+  });
+
+  it('does NOT clear when the same file started a different action since', () => {
+    const fileA = makeViewFile({ name: 'a.txt' });
+    fixture.componentRef.setInput('file', fileA);
+    fixture.detectChanges();
+    component.activeAction = FileAction.VALIDATE;
+
+    component.clearActiveAction(fileA, FileAction.QUEUE); // stale callback for an older QUEUE
+    expect(component.activeAction).toBe(FileAction.VALIDATE);
+  });
+});

--- a/src/angular/src/app/pages/files/file.component.spec.ts
+++ b/src/angular/src/app/pages/files/file.component.spec.ts
@@ -175,7 +175,7 @@ describe('FileComponent inline delete confirmation', () => {
     component.onDeleteLocal(file);
     expect(component.confirmingDelete).toBeNull();
     expect(component.activeAction).toBe(FileAction.DELETE_LOCAL);
-    expect(spy).toHaveBeenCalledWith(file);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ file }));
   });
 
   it('first click on delete remote sets confirming state', () => {
@@ -193,7 +193,7 @@ describe('FileComponent inline delete confirmation', () => {
 
     expect(component.confirmingDelete).toBeNull();
     expect(component.activeAction).toBe(FileAction.DELETE_REMOTE);
-    expect(spy).toHaveBeenCalledWith(file);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ file }));
   });
 
   it('confirming state auto-resets after 3 seconds', () => {
@@ -254,5 +254,68 @@ describe('FileComponent inline delete confirmation', () => {
     vi.advanceTimersByTime(5000);
     // State stays as-is (timer was cleared, no reset happened)
     expect(component.confirmingDelete).toBe('local');
+  });
+});
+
+describe('FileComponent action events', () => {
+  let fixture: ComponentFixture<FileComponent>;
+  let component: FileComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FileComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FileComponent);
+    fixture.componentRef.setInput('file', makeViewFile());
+    fixture.componentRef.setInput('options', of({ nameFilter: '', statusFilter: '' }));
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+  });
+
+  it('clearActiveAction resets activeAction to null', () => {
+    component.activeAction = FileAction.QUEUE;
+    component.clearActiveAction();
+    expect(component.activeAction).toBeNull();
+  });
+
+  it.each([
+    ['onQueue', 'queueEvent'],
+    ['onStop', 'stopEvent'],
+    ['onExtract', 'extractEvent'],
+    ['onValidate', 'validateEvent'],
+  ] as const)(
+    '%s emits an event carrying the file and a clearActiveAction callback',
+    (method, eventName) => {
+      const file = makeViewFile();
+      const spy = vi.spyOn(component[eventName], 'emit');
+
+      component[method](file);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const payload = spy.mock.calls[0][0];
+      expect(payload.file).toBe(file);
+      expect(typeof payload.clearActiveAction).toBe('function');
+
+      // Action is active until the callback fires.
+      expect(component.activeAction).not.toBeNull();
+      payload.clearActiveAction();
+      expect(component.activeAction).toBeNull();
+    },
+  );
+
+  it('delete emits a clearActiveAction callback that resets activeAction', () => {
+    const file = makeViewFile();
+    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+
+    // Double-click to confirm and emit.
+    component.onDeleteLocal(file);
+    component.onDeleteLocal(file);
+
+    expect(component.activeAction).toBe(FileAction.DELETE_LOCAL);
+    const payload = spy.mock.calls[0][0];
+    expect(payload.file).toBe(file);
+    payload.clearActiveAction();
+    expect(component.activeAction).toBeNull();
   });
 });

--- a/src/angular/src/app/pages/files/file.component.ts
+++ b/src/angular/src/app/pages/files/file.component.ts
@@ -142,13 +142,27 @@ export class FileComponent implements OnChanges, OnDestroy {
   // Cleared by the parent when an action's backend request fails or errors.
   // Runs inside the parent's async subscribe callback, so OnPush needs an
   // explicit markForCheck to re-enable the buttons and stop the spinner.
-  clearActiveAction(): void {
+  // <app-file> is recycled by *cdkVirtualFor, so a late failure callback may
+  // target an instance now bound to a different file/action; only clear when
+  // this instance still represents the same file and the same in-flight action.
+  clearActiveAction(forFile?: ViewFile, forAction?: FileAction | null): void {
+    if (forFile !== undefined) {
+      const current = this.file();
+      if (
+        current.pairId !== forFile.pairId ||
+        current.name !== forFile.name ||
+        this.activeAction !== forAction
+      ) {
+        return;
+      }
+    }
     this.activeAction = null;
     this.cdr.markForCheck();
   }
 
   private actionEvent(file: ViewFile): FileActionEvent {
-    return { file, clearActiveAction: () => this.clearActiveAction() };
+    const action = this.activeAction;
+    return { file, clearActiveAction: () => this.clearActiveAction(file, action) };
   }
 
   onQueue(file: ViewFile): void {

--- a/src/angular/src/app/pages/files/file.component.ts
+++ b/src/angular/src/app/pages/files/file.component.ts
@@ -21,6 +21,17 @@ export enum FileAction {
   DELETE_REMOTE
 }
 
+// Payload emitted for each single-file action. Carries the target file plus a
+// callback the parent invokes to clear this child's activeAction when the
+// backend rejects the request — the file model never changes on failure, so
+// ngOnChanges cannot recover the row on its own. The callback is necessary
+// because <app-file> is rendered inside *cdkVirtualFor, which recycles
+// instances and prevents the parent from keying a @ViewChildren to a file.
+export interface FileActionEvent {
+  file: ViewFile;
+  clearActiveAction: () => void;
+}
+
 @Component({
   selector: 'app-file',
   standalone: true,
@@ -48,12 +59,12 @@ export class FileComponent implements OnChanges, OnDestroy {
   options = input.required<Observable<ViewFileOptions>>();
 
   checkEvent = output<{file: ViewFile, shiftKey: boolean}>();
-  queueEvent = output<ViewFile>();
-  stopEvent = output<ViewFile>();
-  extractEvent = output<ViewFile>();
-  deleteLocalEvent = output<ViewFile>();
-  validateEvent = output<ViewFile>();
-  deleteRemoteEvent = output<ViewFile>();
+  queueEvent = output<FileActionEvent>();
+  stopEvent = output<FileActionEvent>();
+  extractEvent = output<FileActionEvent>();
+  deleteLocalEvent = output<FileActionEvent>();
+  validateEvent = output<FileActionEvent>();
+  deleteRemoteEvent = output<FileActionEvent>();
 
   activeAction: FileAction | null = null;
 
@@ -128,24 +139,36 @@ export class FileComponent implements OnChanges, OnDestroy {
     return this.activeAction == null && this.file().isRemotelyDeletable;
   }
 
+  // Cleared by the parent when an action's backend request fails or errors.
+  // Runs inside the parent's async subscribe callback, so OnPush needs an
+  // explicit markForCheck to re-enable the buttons and stop the spinner.
+  clearActiveAction(): void {
+    this.activeAction = null;
+    this.cdr.markForCheck();
+  }
+
+  private actionEvent(file: ViewFile): FileActionEvent {
+    return { file, clearActiveAction: () => this.clearActiveAction() };
+  }
+
   onQueue(file: ViewFile): void {
     this.activeAction = FileAction.QUEUE;
-    this.queueEvent.emit(file);
+    this.queueEvent.emit(this.actionEvent(file));
   }
 
   onStop(file: ViewFile): void {
     this.activeAction = FileAction.STOP;
-    this.stopEvent.emit(file);
+    this.stopEvent.emit(this.actionEvent(file));
   }
 
   onExtract(file: ViewFile): void {
     this.activeAction = FileAction.EXTRACT;
-    this.extractEvent.emit(file);
+    this.extractEvent.emit(this.actionEvent(file));
   }
 
   onValidate(file: ViewFile): void {
     this.activeAction = FileAction.VALIDATE;
-    this.validateEvent.emit(file);
+    this.validateEvent.emit(this.actionEvent(file));
   }
 
   onDeleteLocal(file: ViewFile): void {
@@ -153,7 +176,7 @@ export class FileComponent implements OnChanges, OnDestroy {
       this.clearConfirmTimer();
       this.confirmingDelete = null;
       this.activeAction = FileAction.DELETE_LOCAL;
-      this.deleteLocalEvent.emit(file);
+      this.deleteLocalEvent.emit(this.actionEvent(file));
     } else {
       this.setConfirming('local');
     }
@@ -164,7 +187,7 @@ export class FileComponent implements OnChanges, OnDestroy {
       this.clearConfirmTimer();
       this.confirmingDelete = null;
       this.activeAction = FileAction.DELETE_REMOTE;
-      this.deleteRemoteEvent.emit(file);
+      this.deleteRemoteEvent.emit(this.actionEvent(file));
     } else {
       this.setConfirming('remote');
     }

--- a/src/angular/src/app/pages/logs/logs-page.component.html
+++ b/src/angular/src/app/pages/logs/logs-page.component.html
@@ -32,7 +32,7 @@
   } @else if (historyLoaded && historyRecords.length > 0) {
     <div class="history-section">
       <div class="history-header">Log History</div>
-      @for (entry of historyRecords; track $index) {
+      @for (entry of historyRecords; track trackHistory($index, entry)) {
         <p
           class="record"
           [class.debug]="entry.level === LogLevel.DEBUG"
@@ -61,7 +61,7 @@
 
   <div #logHead class="log-marker"></div>
 
-  @for (record of records; track $index) {
+  @for (record of records; track trackRecord($index, record)) {
     <p
       class="record"
       [class.debug]="record.level === LogLevel.DEBUG"

--- a/src/angular/src/app/pages/logs/logs-page.component.html
+++ b/src/angular/src/app/pages/logs/logs-page.component.html
@@ -26,7 +26,7 @@
   @if (historyLoaded && historyLoadFailed) {
     <div class="history-section">
       <div class="history-header">Log History</div>
-      <p class="history-load-error">Failed to load log history. Check the connection and try again.</p>
+      <p class="history-load-error" role="alert">Failed to load log history. Check the connection and try again.</p>
     </div>
     <hr class="log-divider" />
   } @else if (historyLoaded && historyRecords.length > 0) {

--- a/src/angular/src/app/pages/logs/logs-page.component.html
+++ b/src/angular/src/app/pages/logs/logs-page.component.html
@@ -23,7 +23,13 @@
     </select>
   </div>
 
-  @if (historyLoaded && historyRecords.length > 0) {
+  @if (historyLoaded && historyLoadFailed) {
+    <div class="history-section">
+      <div class="history-header">Log History</div>
+      <p class="record error">Failed to load log history. Check the connection and try again.</p>
+    </div>
+    <hr class="log-divider" />
+  } @else if (historyLoaded && historyRecords.length > 0) {
     <div class="history-section">
       <div class="history-header">Log History</div>
       @for (entry of historyRecords; track $index) {

--- a/src/angular/src/app/pages/logs/logs-page.component.html
+++ b/src/angular/src/app/pages/logs/logs-page.component.html
@@ -26,7 +26,7 @@
   @if (historyLoaded && historyLoadFailed) {
     <div class="history-section">
       <div class="history-header">Log History</div>
-      <p class="record error">Failed to load log history. Check the connection and try again.</p>
+      <p class="history-load-error">Failed to load log history. Check the connection and try again.</p>
     </div>
     <hr class="log-divider" />
   } @else if (historyLoaded && historyRecords.length > 0) {

--- a/src/angular/src/app/pages/logs/logs-page.component.scss
+++ b/src/angular/src/app/pages/logs/logs-page.component.scss
@@ -35,6 +35,13 @@
             color: var(--ss-text-muted);
             margin-bottom: 5px;
         }
+
+        // Distinct from p.record so log-record queries never match this banner.
+        .history-load-error {
+            color: var(--ss-log-error-text);
+            font-size: 90%;
+            margin: 0;
+        }
     }
 
     .log-divider {

--- a/src/angular/src/app/pages/logs/logs-page.component.spec.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.spec.ts
@@ -147,32 +147,41 @@ describe('LogsPageComponent live-log buffer cap (#522)', () => {
     expect(text).toContain('logger-1');
   });
 
-  it('trackRecord returns a stable non-index key for the same record', () => {
+  it('trackRecord is stable per record object and never collides for identical lines', () => {
     const record = makeRecord(7);
     const key = component.trackRecord(0, record);
-    // Stable across calls and across positions.
+    // Stable across calls and across positions (same object -> same key).
     expect(component.trackRecord(99, record)).toBe(key);
-    // Not the index, and derived from record identity.
-    expect(key).not.toBe('0');
-    expect(key).toContain('logger-7');
-    expect(key).toContain('message 7');
-    expect(key).toContain(String(record.time.getTime()));
+
+    // Two DISTINCT objects with IDENTICAL content must get DIFFERENT keys —
+    // the regression that content-derived keys (time+logger+message) caused.
+    const dupA = makeRecord(0);
+    const dupB = { ...dupA };
+    expect(dupA).toEqual(dupB);
+    expect(component.trackRecord(0, dupA)).not.toBe(component.trackRecord(1, dupB));
   });
 
-  it('trackHistory returns a stable non-index key for the same entry', () => {
-    const entry = {
-      timestamp: '2026-06-01 12:00:00',
-      level: 'INFO',
-      logger: 'hist-logger',
-      process: 'p',
-      thread: 't',
-      message: 'history message',
-    };
+  it('renders one row per record even for identical repeated log lines', () => {
+    const a = makeRecord(0);
+    const b = { ...a }; // identical content, distinct object
+    const c = { ...a };
+    logs$.next(a);
+    logs$.next(b);
+    logs$.next(c);
+    fixture.detectChanges();
+
+    // No duplicate-key collapse: a <p class="record"> per buffered record.
+    const rows = (fixture.nativeElement as HTMLElement).querySelectorAll('p.record');
+    expect(rows.length).toBe(component.records.length);
+    expect(component.records.length).toBe(3);
+  });
+
+  it('trackHistory is stable per entry object and never collides for identical entries', () => {
+    const entry = { timestamp: '2026-06-01 12:00:00', level: 'INFO', logger: 'h', process: 'p', thread: 't', message: 'm' };
     const key = component.trackHistory(0, entry);
     expect(component.trackHistory(42, entry)).toBe(key);
-    expect(key).not.toBe('0');
-    expect(key).toContain('hist-logger');
-    expect(key).toContain('history message');
-    expect(key).toContain('2026-06-01 12:00:00');
+
+    const dup = { ...entry };
+    expect(component.trackHistory(0, dup)).not.toBe(key);
   });
 });

--- a/src/angular/src/app/pages/logs/logs-page.component.spec.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.spec.ts
@@ -5,6 +5,7 @@ import { Subject, of } from 'rxjs';
 import { LogsPageComponent } from './logs-page.component';
 import { LogService } from '../../services/logs/log.service';
 import { DomService } from '../../services/utils/dom.service';
+import { LogRecord, LogLevel } from '../../models/log-record';
 
 /**
  * Covers #516: a log-history fetch failure must render a distinct "failed to
@@ -57,5 +58,121 @@ describe('LogsPageComponent history failure state (#516)', () => {
     fixture.detectChanges();
 
     expect(renderedText()).not.toContain('Failed to load log history');
+  });
+});
+
+/**
+ * Covers #522: the live-log buffer was unbounded and re-rendered the full list
+ * per incoming SSE record. The buffer is now capped (ring-buffer front-trim of
+ * the oldest) and the lists use a stable trackBy. These tests drive the live
+ * subscription via a Subject-backed LogService mock.
+ */
+describe('LogsPageComponent live-log buffer cap (#522)', () => {
+  let fixture: ComponentFixture<LogsPageComponent>;
+  let component: LogsPageComponent;
+  let logs$: Subject<LogRecord>;
+
+  function makeRecord(i: number): LogRecord {
+    return {
+      time: new Date(1_700_000_000_000 + i * 1000),
+      level: LogLevel.DEBUG,
+      loggerName: `logger-${i}`,
+      message: `message ${i}`,
+      exceptionTraceback: null,
+    };
+  }
+
+  beforeEach(() => {
+    logs$ = new Subject<LogRecord>();
+    TestBed.configureTestingModule({
+      imports: [LogsPageComponent],
+      providers: [
+        {
+          provide: LogService,
+          useValue: { logs$, fetchHistory: vi.fn().mockReturnValue(of([])) },
+        },
+        { provide: DomService, useValue: { headerHeight$: of(0) } },
+      ],
+    });
+    fixture = TestBed.createComponent(LogsPageComponent);
+    component = fixture.componentInstance;
+    // ngOnInit subscribes to logs$ here.
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    vi.restoreAllMocks();
+  });
+
+  function renderedText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('appends records in order while under the cap', () => {
+    const r0 = makeRecord(0);
+    const r1 = makeRecord(1);
+    const r2 = makeRecord(2);
+    logs$.next(r0);
+    logs$.next(r1);
+    logs$.next(r2);
+
+    expect(component.records.length).toBe(3);
+    expect(component.records).toEqual([r0, r1, r2]);
+  });
+
+  it('caps the buffer and drops the oldest, never the newest', () => {
+    const total = LogsPageComponent.MAX_LIVE_RECORDS + 50;
+    let last: LogRecord | undefined;
+    for (let i = 0; i < total; i++) {
+      last = makeRecord(i);
+      logs$.next(last);
+    }
+
+    expect(component.records.length).toBe(LogsPageComponent.MAX_LIVE_RECORDS);
+    // First 50 emitted records were front-trimmed away.
+    expect(component.records[0].message).toBe('message 50');
+    // Newest record is always retained.
+    expect(component.records[component.records.length - 1]).toBe(last);
+  });
+
+  it('renders the latest record text after appending', () => {
+    logs$.next(makeRecord(0));
+    logs$.next(makeRecord(1));
+    fixture.detectChanges();
+
+    const text = renderedText();
+    expect(text).toContain('message 1');
+    expect(text).toContain(LogLevel.DEBUG);
+    expect(text).toContain('logger-1');
+  });
+
+  it('trackRecord returns a stable non-index key for the same record', () => {
+    const record = makeRecord(7);
+    const key = component.trackRecord(0, record);
+    // Stable across calls and across positions.
+    expect(component.trackRecord(99, record)).toBe(key);
+    // Not the index, and derived from record identity.
+    expect(key).not.toBe('0');
+    expect(key).toContain('logger-7');
+    expect(key).toContain('message 7');
+    expect(key).toContain(String(record.time.getTime()));
+  });
+
+  it('trackHistory returns a stable non-index key for the same entry', () => {
+    const entry = {
+      timestamp: '2026-06-01 12:00:00',
+      level: 'INFO',
+      logger: 'hist-logger',
+      process: 'p',
+      thread: 't',
+      message: 'history message',
+    };
+    const key = component.trackHistory(0, entry);
+    expect(component.trackHistory(42, entry)).toBe(key);
+    expect(key).not.toBe('0');
+    expect(key).toContain('hist-logger');
+    expect(key).toContain('history message');
+    expect(key).toContain('2026-06-01 12:00:00');
   });
 });

--- a/src/angular/src/app/pages/logs/logs-page.component.spec.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Subject, of } from 'rxjs';
+
+import { LogsPageComponent } from './logs-page.component';
+import { LogService } from '../../services/logs/log.service';
+import { DomService } from '../../services/utils/dom.service';
+
+/**
+ * Covers #516: a log-history fetch failure must render a distinct "failed to
+ * load" state, not be indistinguishable from an empty (successful) result.
+ * The debounced search pipe is not exercised here (the failure flag is set by
+ * its catchError); these tests verify the template renders each state.
+ */
+describe('LogsPageComponent history failure state (#516)', () => {
+  let fixture: ComponentFixture<LogsPageComponent>;
+  let component: LogsPageComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [LogsPageComponent],
+      providers: [
+        {
+          provide: LogService,
+          useValue: { logs$: new Subject(), fetchHistory: vi.fn().mockReturnValue(of([])) },
+        },
+        { provide: DomService, useValue: { headerHeight$: of(0) } },
+      ],
+    });
+    fixture = TestBed.createComponent(LogsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    vi.restoreAllMocks();
+  });
+
+  function renderedText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('renders a distinct failure message when the history fetch failed', () => {
+    component.historyLoaded = true;
+    component.historyLoadFailed = true;
+    component.historyRecords = [];
+    fixture.detectChanges();
+
+    expect(renderedText()).toContain('Failed to load log history');
+  });
+
+  it('shows no failure message for an empty (successful) result', () => {
+    component.historyLoaded = true;
+    component.historyLoadFailed = false;
+    component.historyRecords = [];
+    fixture.detectChanges();
+
+    expect(renderedText()).not.toContain('Failed to load log history');
+  });
+});

--- a/src/angular/src/app/pages/logs/logs-page.component.spec.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.spec.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { Subject, of } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 
 import { LogsPageComponent } from './logs-page.component';
 import { LogService } from '../../services/logs/log.service';
 import { DomService } from '../../services/utils/dom.service';
+import { LoggerService } from '../../services/utils/logger.service';
+
+function loggerMock() {
+  return { error: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
+}
 
 /**
  * Covers #516: a log-history fetch failure must render a distinct "failed to
@@ -25,6 +30,7 @@ describe('LogsPageComponent history failure state (#516)', () => {
           useValue: { logs$: new Subject(), fetchHistory: vi.fn().mockReturnValue(of([])) },
         },
         { provide: DomService, useValue: { headerHeight$: of(0) } },
+        { provide: LoggerService, useValue: loggerMock() },
       ],
     });
     fixture = TestBed.createComponent(LogsPageComponent);
@@ -57,5 +63,47 @@ describe('LogsPageComponent history failure state (#516)', () => {
     fixture.detectChanges();
 
     expect(renderedText()).not.toContain('Failed to load log history');
+  });
+});
+
+/**
+ * Exercises the real debounced search pipe so the test fails if catchError stops
+ * setting the failure flag (not just the rendered template). Uses fake timers to
+ * flush the 300ms debounce deterministically.
+ */
+describe('LogsPageComponent history fetch failure (real pipe, #516)', () => {
+  let fixture: ComponentFixture<LogsPageComponent>;
+  let component: LogsPageComponent;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestBed.configureTestingModule({
+      imports: [LogsPageComponent],
+      providers: [
+        {
+          provide: LogService,
+          useValue: { logs$: new Subject(), fetchHistory: vi.fn().mockReturnValue(throwError(() => new Error('boom'))) },
+        },
+        { provide: DomService, useValue: { headerHeight$: of(0) } },
+        { provide: LoggerService, useValue: loggerMock() },
+      ],
+    });
+    fixture = TestBed.createComponent(LogsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges(); // ngOnInit -> initial searchChange$.next() schedules the debounce
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('flips into the failure state when fetchHistory errors', () => {
+    vi.advanceTimersByTime(300); // flush debounce -> fetchHistory errors -> catchError
+    fixture.detectChanges();
+
+    expect(component.historyLoadFailed).toBe(true);
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Failed to load log history');
   });
 });

--- a/src/angular/src/app/pages/logs/logs-page.component.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.ts
@@ -69,6 +69,13 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   private pendingScrollToBottom = false;
   private readonly searchChange$ = new Subject<void>();
 
+  // Per-object monotonic trackBy keys (#522) — unique even for identical log
+  // lines, since each record/entry is a distinct object.
+  private liveSeq = 0;
+  private historySeq = 0;
+  private readonly recordKey = new WeakMap<LogRecord, number>();
+  private readonly historyKey = new WeakMap<LogHistoryEntry, number>();
+
   ngOnInit(): void {
     this.logService.logs$.pipe(
       takeUntilDestroyed(this.destroyRef),
@@ -158,20 +165,31 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   /**
-   * Stable trackBy for the live-log list (#522). Keying by record identity
-   * (time+logger+message) instead of `$index` lets Angular reuse DOM nodes when
-   * the buffer is front-trimmed, instead of re-keying every row by position.
+   * Stable, collision-free trackBy for the live-log list (#522). A monotonic
+   * sequence id is assigned per record *object* (via a WeakMap), so identical
+   * repeated log lines (same logger+message in the same millisecond — common
+   * under high-throughput DEBUG sync) still get distinct keys. Content-derived
+   * keys would collide there and trip Angular's duplicate-key reconcile
+   * (NG0955), dropping/mis-associating rows. Keying by object identity lets
+   * Angular reuse DOM nodes when the buffer is front-trimmed.
    */
-  trackRecord(_index: number, record: LogRecord): string {
-    return `${record.time.getTime()}|${record.loggerName}|${record.message}`;
+  trackRecord(_index: number, record: LogRecord): number {
+    let key = this.recordKey.get(record);
+    if (key === undefined) {
+      key = this.liveSeq++;
+      this.recordKey.set(record, key);
+    }
+    return key;
   }
 
-  /**
-   * Stable trackBy for the history list (#522): avoids re-keying up to 500 rows
-   * by position on every committed search/level change.
-   */
-  trackHistory(_index: number, entry: LogHistoryEntry): string {
-    return `${entry.timestamp}|${entry.logger}|${entry.message}`;
+  /** Stable, collision-free trackBy for the history list (#522); see trackRecord. */
+  trackHistory(_index: number, entry: LogHistoryEntry): number {
+    let key = this.historyKey.get(entry);
+    if (key === undefined) {
+      key = this.historySeq++;
+      this.historyKey.set(entry, key);
+    }
+    return key;
   }
 
   private refreshScrollButtonVisibility(): void {

--- a/src/angular/src/app/pages/logs/logs-page.component.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.ts
@@ -21,6 +21,7 @@ import { of } from 'rxjs';
 import { LogService, LogHistoryEntry } from '../../services/logs/log.service';
 import { LogRecord, LogLevel } from '../../models/log-record';
 import { DomService } from '../../services/utils/dom.service';
+import { LoggerService } from '../../services/utils/logger.service';
 
 @Component({
   selector: 'app-logs-page',
@@ -38,6 +39,7 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   private readonly logService = inject(LogService);
   private readonly domService = inject(DomService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly logger = inject(LoggerService);
 
   readonly headerHeight$ = this.domService.headerHeight$;
 
@@ -46,6 +48,7 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   searchQuery = '';
   levelFilter = '';
   historyLoaded = false;
+  historyLoadFailed = false;
 
   showScrollToTopButton = false;
   showScrollToBottomButton = false;
@@ -78,13 +81,23 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
 
     this.searchChange$.pipe(
       debounceTime(300),
-      switchMap(() => this.logService.fetchHistory({
-        search: this.searchQuery || undefined,
-        level: this.levelFilter || undefined,
-        limit: 500,
-      }).pipe(
-        catchError(() => of([] as LogHistoryEntry[]))
-      )),
+      switchMap(() => {
+        // Reset the failure flag per search; catchError sets it on a real fetch
+        // failure so the template can distinguish "failed to load" from "no
+        // matching history" (both otherwise yield an empty list).
+        this.historyLoadFailed = false;
+        return this.logService.fetchHistory({
+          search: this.searchQuery || undefined,
+          level: this.levelFilter || undefined,
+          limit: 500,
+        }).pipe(
+          catchError((err) => {
+            this.logger.error('Failed to load log history: %O', err);
+            this.historyLoadFailed = true;
+            return of([] as LogHistoryEntry[]);
+          })
+        );
+      }),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((entries) => {
       this.historyRecords = entries;

--- a/src/angular/src/app/pages/logs/logs-page.component.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.ts
@@ -34,6 +34,16 @@ import { LoggerService } from '../../services/utils/logger.service';
 export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   readonly LogLevel = LogLevel;
 
+  /**
+   * Cap on the live-log buffer (#522). During DEBUG logging on an active sync
+   * the SSE stream is unbounded; without a cap `records` grows forever, causing
+   * unbounded memory, an O(n) array copy per event, and a DOM paragraph per
+   * record. We keep a ring-buffer tail of the newest records and drop the
+   * oldest on overflow. Full history remains server-queryable via fetchHistory,
+   * so no log data is truly lost — only the live tail is bounded.
+   */
+  static readonly MAX_LIVE_RECORDS = 2000;
+
   private readonly elementRef = inject(ElementRef);
   private readonly changeDetector = inject(ChangeDetectorRef);
   private readonly logService = inject(LogService);
@@ -69,7 +79,12 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
           this.logTail &&
           LogsPageComponent.isElementInViewport(this.logTail.nativeElement);
 
-        this.records = [...this.records, record];
+        const next = [...this.records, record];
+        // Front-trim the oldest on overflow so the newest record is never
+        // dropped (#522). Below the cap this slice is a no-op.
+        this.records = next.length > LogsPageComponent.MAX_LIVE_RECORDS
+          ? next.slice(next.length - LogsPageComponent.MAX_LIVE_RECORDS)
+          : next;
         this.changeDetector.detectChanges();
 
         if (shouldScroll) {
@@ -140,6 +155,23 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
 
   onLevelChange(): void {
     this.searchChange$.next();
+  }
+
+  /**
+   * Stable trackBy for the live-log list (#522). Keying by record identity
+   * (time+logger+message) instead of `$index` lets Angular reuse DOM nodes when
+   * the buffer is front-trimmed, instead of re-keying every row by position.
+   */
+  trackRecord(_index: number, record: LogRecord): string {
+    return `${record.time.getTime()}|${record.loggerName}|${record.message}`;
+  }
+
+  /**
+   * Stable trackBy for the history list (#522): avoids re-keying up to 500 rows
+   * by position on every committed search/level change.
+   */
+  trackHistory(_index: number, entry: LogHistoryEntry): string {
+    return `${entry.timestamp}|${entry.logger}|${entry.message}`;
   }
 
   private refreshScrollButtonVisibility(): void {

--- a/src/angular/src/app/pages/settings/path-pairs.component.spec.ts
+++ b/src/angular/src/app/pages/settings/path-pairs.component.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 
 import { PathPair } from '../../models/path-pair';
 import { ArrInstance } from '../../models/arr-instance';
@@ -8,6 +8,7 @@ interface PathPairsServiceLike {
   create(pair: Omit<PathPair, 'id'>): Observable<PathPair | null>;
   update(pair: PathPair): Observable<PathPair | null>;
   remove(pairId: string): Observable<boolean>;
+  refresh(): void;
 }
 
 function makePair(overrides: Partial<PathPair> = {}): PathPair {
@@ -47,6 +48,7 @@ class PathPairsLogic {
   addForm: Omit<PathPair, 'id'> = this.emptyForm();
   confirmingDeleteId: string | null = null;
   arrPickerPairId: string | null = null;
+  errorMessage: string | null = null;
   private confirmResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private service: PathPairsServiceLike) {}
@@ -110,11 +112,27 @@ class PathPairsLogic {
   }
 
   onToggleEnabled(pair: PathPair, enabled: boolean): void {
-    this.service.update({ ...pair, enabled }).subscribe();
+    this.applyToggle({ ...pair, enabled });
   }
 
   onToggleAutoQueue(pair: PathPair, autoQueue: boolean): void {
-    this.service.update({ ...pair, auto_queue: autoQueue }).subscribe();
+    this.applyToggle({ ...pair, auto_queue: autoQueue });
+  }
+
+  private applyToggle(updated: PathPair): void {
+    this.errorMessage = null;
+    this.service.update(updated).subscribe({
+      next: (result) => {
+        if (!result) {
+          this.errorMessage = 'Failed to update path pair. Please try again.';
+          this.service.refresh();
+        }
+      },
+      error: () => {
+        this.errorMessage = 'Failed to update path pair. Please try again.';
+        this.service.refresh();
+      },
+    });
   }
 
   // --- Arr targets ---
@@ -200,6 +218,7 @@ describe('PathPairsComponent logic', () => {
     create: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     remove: ReturnType<typeof vi.fn>;
+    refresh: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -207,6 +226,7 @@ describe('PathPairsComponent logic', () => {
       create: vi.fn().mockReturnValue(of(makePair({ id: '2', name: 'New' }))),
       update: vi.fn().mockReturnValue(of(makePair({ enabled: false }))),
       remove: vi.fn().mockReturnValue(of(true)),
+      refresh: vi.fn(),
     };
     component = new PathPairsLogic(mockService as unknown as PathPairsServiceLike);
   });
@@ -286,6 +306,36 @@ describe('PathPairsComponent logic', () => {
     component.onSaveEdit();
     expect(mockService.update).toHaveBeenCalled();
     expect(component.editingId).toBe('p1');
+  });
+
+  describe('toggle enable / auto-queue (#516)', () => {
+    it('clears the error and does not refresh on a successful toggle', () => {
+      mockService.update.mockReturnValue(of(makePair({ enabled: false })));
+
+      component.onToggleEnabled(makePair(), false);
+
+      expect(mockService.update).toHaveBeenCalled();
+      expect(component.errorMessage).toBeNull();
+      expect(mockService.refresh).not.toHaveBeenCalled();
+    });
+
+    it('sets an error and refreshes to reconcile when a toggle returns null', () => {
+      mockService.update.mockReturnValue(of(null));
+
+      component.onToggleAutoQueue(makePair(), true);
+
+      expect(component.errorMessage).toBe('Failed to update path pair. Please try again.');
+      expect(mockService.refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets an error and refreshes when a toggle errors (e.g. network failure)', () => {
+      mockService.update.mockReturnValue(throwError(() => new Error('network')));
+
+      component.onToggleEnabled(makePair(), true);
+
+      expect(component.errorMessage).toBe('Failed to update path pair. Please try again.');
+      expect(mockService.refresh).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('arr target attachment', () => {

--- a/src/angular/src/app/pages/settings/path-pairs.component.ts
+++ b/src/angular/src/app/pages/settings/path-pairs.component.ts
@@ -154,15 +154,34 @@ export class PathPairsComponent implements OnDestroy {
   // --- Toggle fields ---
 
   onToggleEnabled(pair: PathPair, enabled: boolean): void {
-    this.pathPairsService.update({ ...pair, enabled }).pipe(
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe();
+    this.applyToggle({ ...pair, enabled });
   }
 
   onToggleAutoQueue(pair: PathPair, autoQueue: boolean): void {
-    this.pathPairsService.update({ ...pair, auto_queue: autoQueue }).pipe(
+    this.applyToggle({ ...pair, auto_queue: autoQueue });
+  }
+
+  private applyToggle(updated: PathPair): void {
+    // The checkbox is bound one-way ([checked]="pair.enabled") with a (change)
+    // handler, so a failed update leaves it visually flipped vs the server.
+    // Surface an error and refresh() to reconcile the UI on any failure.
+    this.errorMessage = null;
+    this.pathPairsService.update(updated).pipe(
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe();
+    ).subscribe({
+      next: (result) => {
+        if (!result) {
+          this.errorMessage = 'Failed to update path pair. Please try again.';
+          this.pathPairsService.refresh();
+        }
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.errorMessage = 'Failed to update path pair. Please try again.';
+        this.pathPairsService.refresh();
+        this.cdr.markForCheck();
+      },
+    });
   }
 
   // --- Arr targets ---

--- a/src/angular/src/app/services/autoqueue/autoqueue.service.spec.ts
+++ b/src/angular/src/app/services/autoqueue/autoqueue.service.spec.ts
@@ -53,6 +53,18 @@ describe('AutoQueueService', () => {
     expect(snapshot()).toEqual([{ pattern: '*.mkv' }]);
   });
 
+  it('should fall back to an empty list (and not throw) on malformed pattern JSON', () => {
+    mockRestService.sendRequest.mockReturnValue(
+      of(makeReaction({ success: true, data: 'not-json{' })),
+    );
+    const logger = TestBed.inject(LoggerService);
+
+    expect(() => connectedSubject.next(true)).not.toThrow();
+
+    expect(snapshot()).toEqual([]);
+    expect(vi.mocked(logger.error)).toHaveBeenCalled();
+  });
+
   it('should clear patterns when disconnected', () => {
     mockRestService.sendRequest.mockReturnValue(
       of(makeReaction({ success: true, data: JSON.stringify([{ pattern: '*.mkv' }]) })),

--- a/src/angular/src/app/services/autoqueue/autoqueue.service.ts
+++ b/src/angular/src/app/services/autoqueue/autoqueue.service.ts
@@ -105,11 +105,18 @@ export class AutoQueueService {
     this.logger.debug('Getting autoqueue patterns...');
     this.restService.sendRequest(this.AUTOQUEUE_GET_URL).subscribe({
       next: (reaction) => {
-        if (reaction.success) {
+        if (!reaction.success) {
+          this.patternsSubject.next([]);
+          return;
+        }
+        try {
           const parsed: AutoQueuePatternJson[] = JSON.parse(reaction.data!);
           const newPatterns: AutoQueuePattern[] = parsed.map((p) => ({ pattern: p.pattern }));
           this.patternsSubject.next(newPatterns);
-        } else {
+        } catch (e) {
+          // Malformed response must not throw inside the subscribe callback;
+          // log and fall back to an empty list (mirrors the SSE-handler guards).
+          this.logger.error('Failed to parse autoqueue patterns: %O', e);
           this.patternsSubject.next([]);
         }
       },

--- a/src/angular/src/app/services/base/stream-dispatch.service.spec.ts
+++ b/src/angular/src/app/services/base/stream-dispatch.service.spec.ts
@@ -82,6 +82,7 @@ describe("StreamDispatchService", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     (globalThis as unknown as { EventSource: typeof EventSource }).EventSource = originalEventSource;
   });
 
@@ -186,27 +187,99 @@ describe("StreamDispatchService", () => {
 
   // --- Reconnection ---
 
-  it("should reconnect after error with retry delay", () => {
+  it("should reconnect after error with the base backoff delay", () => {
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0); // no jitter
     service.start();
     expect(MockEventSource.instances.length).toBe(1);
 
     latestEventSource().simulateError();
     expect(MockEventSource.instances.length).toBe(1);
 
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(1000);
     expect(MockEventSource.instances.length).toBe(2);
-
   });
 
-  it("should not reconnect before retry interval", () => {
+  it("should not reconnect before the base backoff interval", () => {
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0); // no jitter
     service.start();
     latestEventSource().simulateError();
 
-    vi.advanceTimersByTime(2999);
+    vi.advanceTimersByTime(999);
     expect(MockEventSource.instances.length).toBe(1);
+  });
 
+  it("should use exponential backoff across successive errors", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0); // no jitter
+    service.start();
+
+    // First error -> reconnect after ~base (1000ms)
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(1000);
+    expect(MockEventSource.instances.length).toBe(2);
+
+    // Second error -> backoff doubles to ~2*base (2000ms)
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(1000);
+    // base alone is not enough to reconnect now
+    expect(MockEventSource.instances.length).toBe(2);
+    vi.advanceTimersByTime(1000);
+    expect(MockEventSource.instances.length).toBe(3);
+  });
+
+  it("should cap the backoff at the maximum interval", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0); // no jitter
+    service.start();
+
+    // Fail many times so the exponential term would far exceed the cap.
+    for (let i = 0; i < 10; i++) {
+      latestEventSource().simulateError();
+      vi.advanceTimersByTime(30000); // advance by the max each time
+    }
+    const countAfterCapping = MockEventSource.instances.length;
+
+    // One more error: even advancing only by the max must reconnect (capped).
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(30000);
+    expect(MockEventSource.instances.length).toBe(countAfterCapping + 1);
+  });
+
+  it("should reset backoff to base after a successful open", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0); // no jitter
+    service.start();
+
+    // Fail a few times to grow the backoff.
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(1000); // attempt 1: base
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(2000); // attempt 2: 2*base
+    expect(MockEventSource.instances.length).toBe(3);
+
+    // A successful open resets the backoff counter.
+    latestEventSource().simulateOpen();
+
+    // A fresh error should now reconnect after ~base again.
+    latestEventSource().simulateError();
+    vi.advanceTimersByTime(1000);
+    expect(MockEventSource.instances.length).toBe(4);
+  });
+
+  it("should add jitter to the backoff delay", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(1); // max jitter (1000ms)
+    service.start();
+
+    latestEventSource().simulateError();
+
+    // base (1000) + jitter (1000) = 2000ms; base alone is not enough.
+    vi.advanceTimersByTime(1999);
+    expect(MockEventSource.instances.length).toBe(1);
+    vi.advanceTimersByTime(1);
+    expect(MockEventSource.instances.length).toBe(2);
   });
 
   // --- API key ---

--- a/src/angular/src/app/services/base/stream-dispatch.service.spec.ts
+++ b/src/angular/src/app/services/base/stream-dispatch.service.spec.ts
@@ -270,13 +270,14 @@ describe("StreamDispatchService", () => {
 
   it("should add jitter to the backoff delay", () => {
     vi.useFakeTimers();
-    vi.spyOn(Math, "random").mockReturnValue(1); // max jitter (1000ms)
+    // Math.random() returns [0, 1); use a value just below 1 (impossible: exactly 1).
+    vi.spyOn(Math, "random").mockReturnValue(0.999); // jitter ~999ms
     service.start();
 
     latestEventSource().simulateError();
 
-    // base (1000) + jitter (1000) = 2000ms; base alone is not enough.
-    vi.advanceTimersByTime(1999);
+    // base (1000) + jitter (~999) = ~1999ms; base alone is not enough.
+    vi.advanceTimersByTime(1998);
     expect(MockEventSource.instances.length).toBe(1);
     vi.advanceTimersByTime(1);
     expect(MockEventSource.instances.length).toBe(2);

--- a/src/angular/src/app/services/base/stream-dispatch.service.ts
+++ b/src/angular/src/app/services/base/stream-dispatch.service.ts
@@ -23,7 +23,12 @@ export interface StreamEventHandler {
 @Injectable({ providedIn: 'root' })
 export class StreamDispatchService {
   private readonly STREAM_URL = '/server/stream';
-  private readonly RETRY_INTERVAL_MS = 3000;
+  /** Base delay for the first reconnect attempt. */
+  private readonly RETRY_BASE_MS = 1000;
+  /** Upper bound on the exponential backoff delay. */
+  private readonly RETRY_MAX_MS = 30000;
+  /** Maximum random jitter added to each backoff delay. */
+  private readonly RETRY_JITTER_MS = 1000;
 
   private readonly logger = inject(LoggerService);
   private readonly zone = inject(NgZone);
@@ -45,6 +50,7 @@ export class StreamDispatchService {
   private apiKey: string | null = null;
   private eventSource: EventSource | null = null;
   private retryTimeout: ReturnType<typeof setTimeout> | null = null;
+  private retryAttempt = 0;
 
   setApiKey(key: string | null): void {
     if (key === this.apiKey) {
@@ -53,6 +59,8 @@ export class StreamDispatchService {
     this.apiKey = key;
     // Reconnect with the new key if we have an active connection or pending retry
     if (this.eventSource || this.retryTimeout) {
+      // A key change should retry promptly, not wait out the current backoff.
+      this.retryAttempt = 0;
       this.closeAndCancelRetry();
       this.connectStream();
     }
@@ -86,6 +94,8 @@ export class StreamDispatchService {
 
     eventSource.onopen = () => {
       this.logger.info('Connected to server stream');
+      // A successful connection resets the backoff so the next drop retries fast.
+      this.retryAttempt = 0;
       for (const handler of this.handlers) {
         this.zone.run(() => handler.onConnected());
       }
@@ -105,10 +115,23 @@ export class StreamDispatchService {
         this.zone.run(() => handler.onDisconnected());
       }
 
+      const delay = this.nextRetryDelayMs();
+      this.retryAttempt += 1;
       this.retryTimeout = setTimeout(() => {
         this.retryTimeout = null;
         this.connectStream();
-      }, this.RETRY_INTERVAL_MS);
+      }, delay);
     };
+  }
+
+  /**
+   * Capped exponential backoff with jitter. Prevents a tight reconnect loop
+   * (e.g. when the server keeps returning 401 for a bad/missing API key) from
+   * hammering the backend on a fixed cadence.
+   */
+  private nextRetryDelayMs(): number {
+    const exponential = Math.min(this.RETRY_MAX_MS, this.RETRY_BASE_MS * 2 ** this.retryAttempt);
+    const jitter = Math.random() * this.RETRY_JITTER_MS;
+    return exponential + jitter;
   }
 }

--- a/src/angular/src/app/services/files/model-file.service.spec.ts
+++ b/src/angular/src/app/services/files/model-file.service.spec.ts
@@ -300,5 +300,28 @@ describe("ModelFileService", () => {
       expect(result!.has("file1")).toBe(true);
       expect(result!.has("file2")).toBe(true);
     });
+
+    // Valid JSON, wrong shape: parses fine but the mapping below would throw.
+    // The dispatch (not just JSON.parse) must be guarded — log and skip.
+    it("should not throw on a valid-JSON-but-wrong-shape model-init (not an array)", () => {
+      expect(() => service.onEvent("model-init", "{}")).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(0);
+    });
+
+    it("should not throw on a wrong-shape model-added (missing new_file)", () => {
+      service.onEvent("model-init", JSON.stringify([makeFileJson("file1")]));
+
+      expect(() => service.onEvent("model-added", "{}")).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(1);
+      expect(result!.has("file1")).toBe(true);
+    });
   });
 });

--- a/src/angular/src/app/services/files/model-file.service.spec.ts
+++ b/src/angular/src/app/services/files/model-file.service.spec.ts
@@ -30,23 +30,27 @@ describe("ModelFileService", () => {
   let service: ModelFileService;
   let mockStreamDispatch: { registerHandler: ReturnType<typeof vi.fn> };
   let mockRestService: { sendRequest: ReturnType<typeof vi.fn> };
+  let mockLogger: {
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     mockStreamDispatch = { registerHandler: vi.fn() };
     mockRestService = { sendRequest: vi.fn() };
+    mockLogger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
     TestBed.configureTestingModule({
       providers: [
         ModelFileService,
         { provide: StreamDispatchService, useValue: mockStreamDispatch },
-        {
-          provide: LoggerService,
-          useValue: {
-            debug: vi.fn(),
-            error: vi.fn(),
-            info: vi.fn(),
-            warn: vi.fn(),
-          },
-        },
+        { provide: LoggerService, useValue: mockLogger },
         { provide: RestService, useValue: mockRestService },
       ],
     });
@@ -224,5 +228,77 @@ describe("ModelFileService", () => {
     expect(mockRestService.sendRequest).toHaveBeenCalledWith(
       "/server/command/delete_remote/" + encoded,
     );
+  });
+
+  describe("malformed SSE payloads (issue #516)", () => {
+    const malformed = "{not valid json";
+
+    it("should not throw and should log on a malformed model-init event", () => {
+      expect(() => service.onEvent("model-init", malformed)).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      // Existing (empty) state is preserved — no silent clear/poison.
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(0);
+    });
+
+    it("should not throw and should preserve the map on a malformed model-added event", () => {
+      service.onEvent("model-init", JSON.stringify([makeFileJson("file1")]));
+
+      expect(() => service.onEvent("model-added", malformed)).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(1);
+      expect(result!.has("file1")).toBe(true);
+    });
+
+    it("should not throw and should preserve the map on a malformed model-updated event", () => {
+      service.onEvent(
+        "model-init",
+        JSON.stringify([makeFileJson("file1", "DEFAULT")]),
+      );
+
+      expect(() => service.onEvent("model-updated", malformed)).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(1);
+      expect(result!.get("file1")!.state).toBe("default");
+    });
+
+    it("should not throw and should preserve the map on a malformed model-removed event", () => {
+      service.onEvent(
+        "model-init",
+        JSON.stringify([makeFileJson("file1"), makeFileJson("file2")]),
+      );
+
+      expect(() => service.onEvent("model-removed", malformed)).not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalled();
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(2);
+      expect(result!.has("file1")).toBe(true);
+      expect(result!.has("file2")).toBe(true);
+    });
+
+    it("should still parse a valid event after a malformed one (no poisoned state)", () => {
+      service.onEvent("model-init", malformed);
+      // A subsequent valid init must replace state normally.
+      service.onEvent(
+        "model-init",
+        JSON.stringify([makeFileJson("file1"), makeFileJson("file2")]),
+      );
+
+      let result: Map<string, ModelFile> | undefined;
+      service.files$.subscribe((f) => (result = f));
+      expect(result!.size).toBe(2);
+      expect(result!.has("file1")).toBe(true);
+      expect(result!.has("file2")).toBe(true);
+    });
   });
 });

--- a/src/angular/src/app/services/files/model-file.service.ts
+++ b/src/angular/src/app/services/files/model-file.service.ts
@@ -95,56 +95,64 @@ export class ModelFileService implements StreamEventHandler {
       return;
     }
 
-    if (name === this.EVENT_INIT) {
-      const init = parsed as ModelFileJson[];
-      const t0 = performance.now();
-      const newMap = new Map<string, ModelFile>();
-      for (const file of init) {
-        const modelFile = modelFileFromJson(file);
-        newMap.set(fileKey(modelFile.pair_id, modelFile.name), modelFile);
-      }
-      const t1 = performance.now();
-      this.logger.debug('ModelFile map creation took', (t1 - t0).toFixed(0), 'ms');
+    // The payload parsed, but a valid-JSON-but-wrong-shape event (e.g. model-init
+    // not an array, or model-added missing new_file) would throw in the mapping
+    // below; guard the dispatch too so one bad event is logged and skipped, not
+    // fatal to the listener.
+    try {
+      if (name === this.EVENT_INIT) {
+        const init = parsed as ModelFileJson[];
+        const t0 = performance.now();
+        const newMap = new Map<string, ModelFile>();
+        for (const file of init) {
+          const modelFile = modelFileFromJson(file);
+          newMap.set(fileKey(modelFile.pair_id, modelFile.name), modelFile);
+        }
+        const t1 = performance.now();
+        this.logger.debug('ModelFile map creation took', (t1 - t0).toFixed(0), 'ms');
 
-      this.filesSubject.next(newMap);
-    } else if (name === this.EVENT_ADDED) {
-      const added = parsed as { new_file: ModelFileJson };
-      const file = modelFileFromJson(added.new_file);
-      const key = fileKey(file.pair_id, file.name);
-      if (currentFiles.has(key)) {
-        this.logger.error('ModelFile named ' + key + ' already exists');
+        this.filesSubject.next(newMap);
+      } else if (name === this.EVENT_ADDED) {
+        const added = parsed as { new_file: ModelFileJson };
+        const file = modelFileFromJson(added.new_file);
+        const key = fileKey(file.pair_id, file.name);
+        if (currentFiles.has(key)) {
+          this.logger.error('ModelFile named ' + key + ' already exists');
+        } else {
+          const updated = new Map(currentFiles);
+          updated.set(key, file);
+          this.filesSubject.next(updated);
+          this.logger.debug('Added file: %O', file);
+        }
+      } else if (name === this.EVENT_REMOVED) {
+        const removed = parsed as { old_file: ModelFileJson };
+        const file = modelFileFromJson(removed.old_file);
+        const key = fileKey(file.pair_id, file.name);
+        if (currentFiles.has(key)) {
+          const updated = new Map(currentFiles);
+          updated.delete(key);
+          this.filesSubject.next(updated);
+          this.logger.debug('Removed file: %O', file);
+        } else {
+          this.logger.error('Failed to find ModelFile named ' + key);
+        }
+      } else if (name === this.EVENT_UPDATED) {
+        const updatedFile = parsed as { new_file: ModelFileJson };
+        const file = modelFileFromJson(updatedFile.new_file);
+        const key = fileKey(file.pair_id, file.name);
+        if (currentFiles.has(key)) {
+          const updated = new Map(currentFiles);
+          updated.set(key, file);
+          this.filesSubject.next(updated);
+          this.logger.debug('Updated file: %O', file);
+        } else {
+          this.logger.error('Failed to find ModelFile named ' + key);
+        }
       } else {
-        const updated = new Map(currentFiles);
-        updated.set(key, file);
-        this.filesSubject.next(updated);
-        this.logger.debug('Added file: %O', file);
+        this.logger.error('Unrecognized event:', name);
       }
-    } else if (name === this.EVENT_REMOVED) {
-      const removed = parsed as { old_file: ModelFileJson };
-      const file = modelFileFromJson(removed.old_file);
-      const key = fileKey(file.pair_id, file.name);
-      if (currentFiles.has(key)) {
-        const updated = new Map(currentFiles);
-        updated.delete(key);
-        this.filesSubject.next(updated);
-        this.logger.debug('Removed file: %O', file);
-      } else {
-        this.logger.error('Failed to find ModelFile named ' + key);
-      }
-    } else if (name === this.EVENT_UPDATED) {
-      const updatedFile = parsed as { new_file: ModelFileJson };
-      const file = modelFileFromJson(updatedFile.new_file);
-      const key = fileKey(file.pair_id, file.name);
-      if (currentFiles.has(key)) {
-        const updated = new Map(currentFiles);
-        updated.set(key, file);
-        this.filesSubject.next(updated);
-        this.logger.debug('Updated file: %O', file);
-      } else {
-        this.logger.error('Failed to find ModelFile named ' + key);
-      }
-    } else {
-      this.logger.error('Unrecognized event:', name);
+    } catch (e) {
+      this.logger.error('Failed to handle %s event (unexpected shape): %O', name, e);
     }
   }
 }

--- a/src/angular/src/app/services/files/model-file.service.ts
+++ b/src/angular/src/app/services/files/model-file.service.ts
@@ -84,28 +84,32 @@ export class ModelFileService implements StreamEventHandler {
   private parseEvent(name: string, data: string): void {
     const currentFiles = this.filesSubject.getValue();
 
+    // Guard the parse of server-controlled SSE payloads: a malformed/truncated
+    // event must not throw inside the listener callback. Log and skip the bad
+    // event, leaving existing state untouched (mirrors ConfigService.getConfig).
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data);
+    } catch (e) {
+      this.logger.error('Failed to parse %s event: %O', name, e);
+      return;
+    }
+
     if (name === this.EVENT_INIT) {
-      let t0: number;
-      let t1: number;
-
-      t0 = performance.now();
-      const parsed: ModelFileJson[] = JSON.parse(data);
-      t1 = performance.now();
-      this.logger.debug('Parsing took', (t1 - t0).toFixed(0), 'ms');
-
-      t0 = performance.now();
+      const init = parsed as ModelFileJson[];
+      const t0 = performance.now();
       const newMap = new Map<string, ModelFile>();
-      for (const file of parsed) {
+      for (const file of init) {
         const modelFile = modelFileFromJson(file);
         newMap.set(fileKey(modelFile.pair_id, modelFile.name), modelFile);
       }
-      t1 = performance.now();
+      const t1 = performance.now();
       this.logger.debug('ModelFile map creation took', (t1 - t0).toFixed(0), 'ms');
 
       this.filesSubject.next(newMap);
     } else if (name === this.EVENT_ADDED) {
-      const parsed: { new_file: ModelFileJson } = JSON.parse(data);
-      const file = modelFileFromJson(parsed.new_file);
+      const added = parsed as { new_file: ModelFileJson };
+      const file = modelFileFromJson(added.new_file);
       const key = fileKey(file.pair_id, file.name);
       if (currentFiles.has(key)) {
         this.logger.error('ModelFile named ' + key + ' already exists');
@@ -116,8 +120,8 @@ export class ModelFileService implements StreamEventHandler {
         this.logger.debug('Added file: %O', file);
       }
     } else if (name === this.EVENT_REMOVED) {
-      const parsed: { old_file: ModelFileJson } = JSON.parse(data);
-      const file = modelFileFromJson(parsed.old_file);
+      const removed = parsed as { old_file: ModelFileJson };
+      const file = modelFileFromJson(removed.old_file);
       const key = fileKey(file.pair_id, file.name);
       if (currentFiles.has(key)) {
         const updated = new Map(currentFiles);
@@ -128,8 +132,8 @@ export class ModelFileService implements StreamEventHandler {
         this.logger.error('Failed to find ModelFile named ' + key);
       }
     } else if (name === this.EVENT_UPDATED) {
-      const parsed: { new_file: ModelFileJson } = JSON.parse(data);
-      const file = modelFileFromJson(parsed.new_file);
+      const updatedFile = parsed as { new_file: ModelFileJson };
+      const file = modelFileFromJson(updatedFile.new_file);
       const key = fileKey(file.pair_id, file.name);
       if (currentFiles.has(key)) {
         const updated = new Map(currentFiles);

--- a/src/angular/src/app/services/files/view-file.service.spec.ts
+++ b/src/angular/src/app/services/files/view-file.service.spec.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import { BehaviorSubject, of } from "rxjs";
-import { ViewFileService, ViewFileFilterCriteria } from "./view-file.service";
+import { ViewFileService, ViewFileFilterCriteria, VIEW_FILE_COALESCE_MS } from "./view-file.service";
 import { ModelFileService } from "./model-file.service";
 import { PathPairsService } from "../settings/path-pairs.service";
 import { LoggerService } from "../utils/logger.service";
@@ -714,5 +714,270 @@ describe("ViewFileService", () => {
     const files = latestFiles();
     expect(files.find((f) => f.pairId === "pair-a")!.status).toBe(ViewFileStatus.DOWNLOADING);
     expect(files.find((f) => f.pairId === "pair-b")!.status).toBe(ViewFileStatus.DEFAULT);
+  });
+
+  // --- Reference identity: unchanged rows keep === identity (issue #521 #4) ---
+
+  it("should preserve object identity of unchanged rows when toggling one checkbox", () => {
+    emitModelFiles([
+      makeModelFile({ name: "a", remote_size: 100, local_size: 100, state: ModelFileState.DOWNLOADED }),
+      makeModelFile({ name: "b", remote_size: 100, local_size: 100, state: ModelFileState.DOWNLOADED }),
+      makeModelFile({ name: "c", remote_size: 100, local_size: 100, state: ModelFileState.DOWNLOADED }),
+    ]);
+    const before = latestFiles();
+
+    service.toggleCheck(before.find((f) => f.name === "b")!);
+    const after = latestFiles();
+
+    // Only the toggled row's object reference changed; isChecked stays derived.
+    expect(after.find((f) => f.name === "b")!.isChecked).toBe(true);
+    expect(after.find((f) => f.name === "b")!).not.toBe(before.find((f) => f.name === "b")!);
+    expect(after.find((f) => f.name === "a")!).toBe(before.find((f) => f.name === "a")!);
+    expect(after.find((f) => f.name === "c")!).toBe(before.find((f) => f.name === "c")!);
+  });
+
+  it("should preserve object identity of unchanged rows on a single-file SSE update", () => {
+    emitModelFiles([
+      makeModelFile({ name: "a", remote_size: 200, local_size: 50, state: ModelFileState.DOWNLOADING }),
+      makeModelFile({ name: "b", remote_size: 200, local_size: 50, state: ModelFileState.DOWNLOADING }),
+      makeModelFile({ name: "c", remote_size: 200, local_size: 50, state: ModelFileState.DOWNLOADING }),
+    ]);
+    const before = latestFiles();
+
+    // Only "b" advances (eta/local_size change → an "updated" key).
+    emitModelFiles([
+      makeModelFile({ name: "a", remote_size: 200, local_size: 50, state: ModelFileState.DOWNLOADING }),
+      makeModelFile({ name: "b", remote_size: 200, local_size: 120, state: ModelFileState.DOWNLOADING }),
+      makeModelFile({ name: "c", remote_size: 200, local_size: 50, state: ModelFileState.DOWNLOADING }),
+    ]);
+    const after = latestFiles();
+
+    expect(after.find((f) => f.name === "b")!.percentDownloaded).toBe(60);
+    expect(after.find((f) => f.name === "b")!).not.toBe(before.find((f) => f.name === "b")!);
+    expect(after.find((f) => f.name === "a")!).toBe(before.find((f) => f.name === "a")!);
+    expect(after.find((f) => f.name === "c")!).toBe(before.find((f) => f.name === "c")!);
+  });
+
+  it("should preserve object identity of rows whose pairName is unchanged", () => {
+    pairsSubject.next([
+      { id: "pair-a", name: "Seedbox", remote_path: "/r", local_path: "/l", enabled: true, auto_queue: false, arr_target_ids: [] },
+    ]);
+    emitModelFiles([
+      makeModelFile({ name: "x", pair_id: "pair-a", remote_size: 100 }),
+      makeModelFile({ name: "y", pair_id: null, remote_size: 100 }),
+    ]);
+    const before = latestFiles();
+
+    // Add a second pair; only pair-a-resolved rows are affected, pair-b not present.
+    pairsSubject.next([
+      { id: "pair-a", name: "Seedbox", remote_path: "/r", local_path: "/l", enabled: true, auto_queue: false, arr_target_ids: [] },
+      { id: "pair-b", name: "Media", remote_path: "/r2", local_path: "/l2", enabled: true, auto_queue: false, arr_target_ids: [] },
+    ]);
+    const after = latestFiles();
+
+    // Neither row's resolved pairName changed → both keep identity.
+    expect(after.find((f) => f.name === "x")!.pairName).toBe("Seedbox");
+    expect(after.find((f) => f.name === "x")!).toBe(before.find((f) => f.name === "x")!);
+    expect(after.find((f) => f.name === "y")!).toBe(before.find((f) => f.name === "y")!);
+  });
+
+  it("should re-spread only the row whose pairName actually changed", () => {
+    pairsSubject.next([]);
+    emitModelFiles([
+      makeModelFile({ name: "x", pair_id: "pair-a", remote_size: 100 }),
+      makeModelFile({ name: "y", pair_id: null, remote_size: 100 }),
+    ]);
+    const before = latestFiles();
+    expect(before.find((f) => f.name === "x")!.pairName).toBeNull();
+
+    // pair-a name now resolvable → only "x" changes; "y" (null pair) keeps identity.
+    pairsSubject.next([
+      { id: "pair-a", name: "Seedbox", remote_path: "/r", local_path: "/l", enabled: true, auto_queue: false, arr_target_ids: [] },
+    ]);
+    const after = latestFiles();
+
+    expect(after.find((f) => f.name === "x")!.pairName).toBe("Seedbox");
+    expect(after.find((f) => f.name === "x")!).not.toBe(before.find((f) => f.name === "x")!);
+    expect(after.find((f) => f.name === "y")!).toBe(before.find((f) => f.name === "y")!);
+  });
+
+  // --- Bulk remove single-pass (issue #521 #3) ---
+
+  it("should correctly remove an interleaved set of files in a single pass", () => {
+    emitModelFiles([
+      makeModelFile({ name: "f0", remote_size: 100 }),
+      makeModelFile({ name: "f1", remote_size: 100 }),
+      makeModelFile({ name: "f2", remote_size: 100 }),
+      makeModelFile({ name: "f3", remote_size: 100 }),
+      makeModelFile({ name: "f4", remote_size: 100 }),
+    ]);
+
+    // Remove an interleaved pattern (f1, f3) — survivors keep relative order.
+    emitModelFiles([
+      makeModelFile({ name: "f0", remote_size: 100 }),
+      makeModelFile({ name: "f2", remote_size: 100 }),
+      makeModelFile({ name: "f4", remote_size: 100 }),
+    ]);
+
+    const files = latestFiles();
+    expect(files.map((f) => f.name)).toEqual(["f0", "f2", "f4"]);
+  });
+
+  it("should drop checkedSet entries for removed files and re-emit checked$", () => {
+    emitModelFiles([
+      makeModelFile({ name: "keep", remote_size: 100, local_size: 100, state: ModelFileState.DOWNLOADED }),
+      makeModelFile({ name: "gone", remote_size: 100, local_size: 100, state: ModelFileState.DOWNLOADED }),
+    ]);
+    service.toggleCheck(latestFiles().find((f) => f.name === "gone")!);
+
+    let checked = new Set<string>();
+    service.checked$.subscribe((s) => (checked = s));
+    expect(checked.has(fileKey(null, "gone"))).toBe(true);
+
+    emitModelFiles([
+      makeModelFile({ name: "keep", remote_size: 100, local_size: 100, state: ModelFileState.DOWNLOADED }),
+    ]);
+
+    expect(latestFiles().map((f) => f.name)).toEqual(["keep"]);
+    expect(checked.has(fileKey(null, "gone"))).toBe(false);
+  });
+
+  // --- Filter memoization (issue #521 #2) ---
+
+  it("should reuse the filtered array reference when membership is unchanged", () => {
+    emitModelFiles([
+      makeModelFile({ name: "a", remote_size: 200, local_size: 50, state: ModelFileState.DOWNLOADING }),
+      makeModelFile({ name: "b", remote_size: 200, local_size: 0, state: ModelFileState.DEFAULT }),
+    ]);
+    const criteria: ViewFileFilterCriteria = {
+      meetsCriteria: (vf) => vf.status === ViewFileStatus.DEFAULT,
+    };
+    service.setFilterCriteria(criteria);
+
+    let emissions = 0;
+    let lastFiltered: ViewFile[] = [];
+    service.filteredFiles$.subscribe((f) => {
+      emissions += 1;
+      lastFiltered = f;
+    });
+    const baselineEmissions = emissions;
+    const filteredBefore = lastFiltered;
+    expect(filteredBefore.map((f) => f.name)).toEqual(["b"]);
+
+    // Update "a" (not in the filtered set) — "b" (the only filtered row) is left
+    // identical, so filtered membership is unchanged and filteredFiles$ must NOT
+    // re-emit; the array reference is reused.
+    emitModelFiles([
+      makeModelFile({ name: "a", remote_size: 200, local_size: 120, state: ModelFileState.DOWNLOADING }),
+      makeModelFile({ name: "b", remote_size: 200, local_size: 0, state: ModelFileState.DEFAULT }),
+    ]);
+
+    expect(emissions).toBe(baselineEmissions);
+    expect(lastFiltered).toBe(filteredBefore);
+    expect(lastFiltered.map((f) => f.name)).toEqual(["b"]);
+  });
+
+  it("should re-emit the filtered list when membership changes", () => {
+    const criteria: ViewFileFilterCriteria = {
+      meetsCriteria: (vf) => vf.status === ViewFileStatus.DOWNLOADING,
+    };
+    service.setFilterCriteria(criteria);
+    emitModelFiles([
+      makeModelFile({ name: "a", remote_size: 200, local_size: 50, state: ModelFileState.DEFAULT }),
+    ]);
+    expect(latestFilteredFiles().length).toBe(0);
+
+    // "a" enters the filtered set.
+    emitModelFiles([
+      makeModelFile({ name: "a", remote_size: 200, local_size: 50, state: ModelFileState.DOWNLOADING }),
+    ]);
+    expect(latestFilteredFiles().map((f) => f.name)).toEqual(["a"]);
+  });
+});
+
+// --- SSE fan-out coalescing (issue #521 #1) ---
+// Uses a non-zero coalesce window so multiple model emissions within one window
+// collapse into a single view rebuild + emission, instead of the synchronous
+// pass-through used by the rest of the suite (coalesceMs = 0). auditTime uses the
+// default asyncScheduler (setTimeout), which vitest fake timers drive — the same
+// pattern as option.component.spec.ts.
+describe("ViewFileService coalescing", () => {
+  const COALESCE_MS = 100;
+  let service: ViewFileService;
+  let modelFilesSubject: BehaviorSubject<Map<string, ModelFile>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    modelFilesSubject = new BehaviorSubject<Map<string, ModelFile>>(new Map());
+    const pairsSubject = new BehaviorSubject<PathPair[]>([]);
+    TestBed.configureTestingModule({
+      providers: [
+        ViewFileService,
+        { provide: VIEW_FILE_COALESCE_MS, useValue: COALESCE_MS },
+        { provide: ModelFileService, useValue: { files$: modelFilesSubject.asObservable() } },
+        { provide: PathPairsService, useValue: { pairs$: pairsSubject.asObservable() } },
+        {
+          provide: LoggerService,
+          useValue: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+        },
+      ],
+    });
+    service = TestBed.inject(ViewFileService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function emit(files: ModelFile[]): void {
+    const map = new Map<string, ModelFile>();
+    for (const f of files) {
+      map.set(fileKey(f.pair_id, f.name), f);
+    }
+    modelFilesSubject.next(map);
+  }
+
+  it("should collapse a burst of model emissions into one view emission per window", () => {
+    let emissions = 0;
+    let lastFiles: ViewFile[] = [];
+    service.files$.subscribe((f) => {
+      emissions += 1;
+      lastFiles = f;
+    });
+    const baseline = emissions; // initial BehaviorSubject([]) emission
+
+    // Three rapid per-file ticks within one coalescing window (the realistic
+    // SSE fan-out: one event per changed file every controller cycle).
+    emit([makeModelFile({ name: "a", remote_size: 200, local_size: 10, state: ModelFileState.DOWNLOADING })]);
+    emit([makeModelFile({ name: "a", remote_size: 200, local_size: 20, state: ModelFileState.DOWNLOADING })]);
+    emit([makeModelFile({ name: "a", remote_size: 200, local_size: 30, state: ModelFileState.DOWNLOADING })]);
+
+    // Nothing rebuilt yet — the window has not elapsed.
+    expect(emissions).toBe(baseline);
+
+    vi.advanceTimersByTime(COALESCE_MS);
+
+    // Exactly one rebuild for the whole burst, reflecting the LAST state.
+    expect(emissions).toBe(baseline + 1);
+    expect(lastFiles.length).toBe(1);
+    expect(lastFiles[0].percentDownloaded).toBe(15);
+  });
+
+  it("should reflect the final coalesced state across add/update/remove in a window", () => {
+    let lastFiles: ViewFile[] = [];
+    service.files$.subscribe((f) => (lastFiles = f));
+
+    emit([
+      makeModelFile({ name: "a", remote_size: 100 }),
+      makeModelFile({ name: "b", remote_size: 100 }),
+    ]);
+    emit([
+      makeModelFile({ name: "a", remote_size: 100 }),
+      makeModelFile({ name: "c", remote_size: 100 }),
+    ]); // b removed, c added vs prev — but only final state matters
+
+    vi.advanceTimersByTime(COALESCE_MS);
+
+    expect(lastFiles.map((f) => f.name).sort()).toEqual(["a", "c"]);
   });
 });

--- a/src/angular/src/app/services/files/view-file.service.spec.ts
+++ b/src/angular/src/app/services/files/view-file.service.spec.ts
@@ -801,6 +801,29 @@ describe("ViewFileService", () => {
     expect(after.find((f) => f.name === "y")!).toBe(before.find((f) => f.name === "y")!);
   });
 
+  it("re-sorts when a pairName change affects the active pairName sort (#540)", () => {
+    pairsSubject.next([
+      { id: "pair-a", name: "Zeta", remote_path: "/r", local_path: "/l", enabled: true, auto_queue: false, arr_target_ids: [] },
+      { id: "pair-b", name: "Alpha", remote_path: "/r", local_path: "/l", enabled: true, auto_queue: false, arr_target_ids: [] },
+    ]);
+    emitModelFiles([
+      makeModelFile({ name: "x", pair_id: "pair-a", remote_size: 100 }),
+      makeModelFile({ name: "y", pair_id: "pair-b", remote_size: 100 }),
+    ]);
+    // Sort ascending by pairName: Alpha(y) before Zeta(x).
+    service.setComparator((a, b) => (a.pairName ?? "").localeCompare(b.pairName ?? ""));
+    expect(latestFiles().map((f) => f.name)).toEqual(["y", "x"]);
+
+    // Rename pair-a "Zeta" -> "Aaa": file x should now sort first.
+    pairsSubject.next([
+      { id: "pair-a", name: "Aaa", remote_path: "/r", local_path: "/l", enabled: true, auto_queue: false, arr_target_ids: [] },
+      { id: "pair-b", name: "Alpha", remote_path: "/r", local_path: "/l", enabled: true, auto_queue: false, arr_target_ids: [] },
+    ]);
+
+    // The pairName update must reapply the comparator, not leave the order stale.
+    expect(latestFiles().map((f) => f.name)).toEqual(["x", "y"]);
+  });
+
   // --- Bulk remove single-pass (issue #521 #3) ---
 
   it("should correctly remove an interleaved set of files in a single pass", () => {

--- a/src/angular/src/app/services/files/view-file.service.ts
+++ b/src/angular/src/app/services/files/view-file.service.ts
@@ -80,6 +80,12 @@ export class ViewFileService {
           return { ...f, pairName };
         });
         if (changed) {
+          // pairName changed for some rows; if the active sort keys on pairName
+          // the order is now stale (pushViewFiles does not re-sort), so reapply
+          // the comparator before pushing.
+          if (this.sortComparator != null) {
+            nextFiles.sort(this.sortComparator);
+          }
           this.files = nextFiles;
           this.pushViewFiles();
         }

--- a/src/angular/src/app/services/files/view-file.service.ts
+++ b/src/angular/src/app/services/files/view-file.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, InjectionToken, inject } from '@angular/core';
 import { BehaviorSubject, Observable, of, from } from 'rxjs';
-import { mergeMap, toArray } from 'rxjs/operators';
+import { auditTime, mergeMap, toArray } from 'rxjs/operators';
 
 import { LoggerService } from '../utils/logger.service';
 import { ModelFileService } from './model-file.service';
@@ -9,6 +9,21 @@ import { WebReaction } from '../utils/rest.service';
 import { ModelFile, ModelFileState } from '../../models/model-file';
 import { ViewFile, ViewFileStatus } from '../../models/view-file';
 import { fileKey } from './file-key';
+
+/**
+ * Coalescing window (ms) for batching incremental SSE model-file emissions before
+ * rebuilding the view. The backend controller loop emits one SSE event per changed
+ * file every ~0.5s; without coalescing, N concurrently-downloading files trigger N
+ * full view rebuilds + 2N subject emissions per cycle (issue #521).
+ *
+ * Defaults to 0 (synchronous pass-through) so unit tests — which read the view
+ * synchronously right after emitting — stay deterministic without extra setup.
+ * Production overrides this in app.config.ts.
+ */
+export const VIEW_FILE_COALESCE_MS = new InjectionToken<number>('VIEW_FILE_COALESCE_MS', {
+  providedIn: 'root',
+  factory: () => 0,
+});
 
 function viewFileKey(vf: ViewFile): string {
   return fileKey(vf.pairId, vf.name);
@@ -25,6 +40,7 @@ export class ViewFileService {
   private readonly logger = inject(LoggerService);
   private readonly modelFileService = inject(ModelFileService);
   private readonly pathPairsService = inject(PathPairsService);
+  private readonly coalesceMs = inject(VIEW_FILE_COALESCE_MS);
 
   private pairNameMap = new Map<string, string>();
   private files: ViewFile[] = [];
@@ -51,17 +67,37 @@ export class ViewFileService {
       for (const pair of pairs) {
         this.pairNameMap.set(pair.id, pair.name);
       }
-      // Rebuild pairName on existing view files immediately
+      // Rebuild pairName on existing view files immediately. Only re-spread rows
+      // whose resolved pairName actually changed so unchanged rows keep identity.
       if (this.files.length > 0) {
-        this.files = this.files.map(f => ({
-          ...f,
-          pairName: f.pairId ? (this.pairNameMap.get(f.pairId) ?? null) : null,
-        }));
-        this.pushViewFiles();
+        let changed = false;
+        const nextFiles = this.files.map(f => {
+          const pairName = f.pairId ? (this.pairNameMap.get(f.pairId) ?? null) : null;
+          if (pairName === f.pairName) {
+            return f;
+          }
+          changed = true;
+          return { ...f, pairName };
+        });
+        if (changed) {
+          this.files = nextFiles;
+          this.pushViewFiles();
+        }
       }
     });
 
-    this.modelFileService.files$.subscribe({
+    // Coalesce the per-file SSE fan-out: the backend emits one model event per
+    // changed file every ~0.5s, so N active files would otherwise drive N full
+    // view rebuilds per tick. auditTime collapses a burst into a single rebuild
+    // on the trailing edge (the last Map already reflects the cumulative state,
+    // since each event is an idempotent set/delete on the shared key space).
+    // coalesceMs === 0 (the unit-test default) keeps the pass-through synchronous.
+    const modelFiles$ =
+      this.coalesceMs > 0
+        ? this.modelFileService.files$.pipe(auditTime(this.coalesceMs))
+        : this.modelFileService.files$;
+
+    modelFiles$.subscribe({
       next: (modelFiles) => {
         const t0 = performance.now();
         this.buildViewFromModelFiles(modelFiles);
@@ -182,10 +218,21 @@ export class ViewFileService {
   }
 
   private updateCheckedState(): void {
-    this.files = this.files.map(f => ({
-      ...f,
-      isChecked: this.checkedSet.has(viewFileKey(f))
-    }));
+    // Only replace rows whose derived isChecked actually flips, preserving object
+    // identity for unchanged rows so OnPush/ngOnChanges can skip them. isChecked
+    // stays strictly derived from checkedSet.
+    let changed = false;
+    const nextFiles = this.files.map(f => {
+      const isChecked = this.checkedSet.has(viewFileKey(f));
+      if (isChecked === f.isChecked) {
+        return f;
+      }
+      changed = true;
+      return { ...f, isChecked };
+    });
+    if (changed) {
+      this.files = nextFiles;
+    }
     this.checkedSubject.next(new Set(this.checkedSet));
     this.pushViewFiles();
   }
@@ -244,7 +291,7 @@ export class ViewFileService {
   private buildViewFromModelFiles(modelFiles: Map<string, ModelFile>): void {
     this.logger.debug('Received next model files');
 
-    const newViewFiles = [...this.files];
+    let newViewFiles = [...this.files];
 
     const addedKeys: string[] = [];
     const removedKeys: string[] = [];
@@ -292,16 +339,19 @@ export class ViewFileService {
       this.indices.set(viewFileKey(viewFile), newViewFiles.length - 1);
     }
 
-    // Do the removes (no re-sort required)
+    // Do the removes (no re-sort required). Filter out every removed key in a
+    // single O(n) pass instead of findIndex+splice per key (O(n*m)). filter is
+    // stable, so the surviving order is identical to the splice-loop result.
     let checkedChanged = false;
-    for (const key of removedKeys) {
+    if (removedKeys.length > 0) {
       updateIndices = true;
-      if (this.checkedSet.delete(key)) {
-        checkedChanged = true;
+      const removed = new Set(removedKeys);
+      for (const key of removedKeys) {
+        if (this.checkedSet.delete(key)) {
+          checkedChanged = true;
+        }
       }
-      const index = newViewFiles.findIndex((v) => viewFileKey(v) === key);
-      newViewFiles.splice(index, 1);
-      this.indices.delete(key);
+      newViewFiles = newViewFiles.filter((v) => !removed.has(viewFileKey(v)));
     }
     if (checkedChanged) {
       this.checkedSubject.next(new Set(this.checkedSet));
@@ -358,8 +408,28 @@ export class ViewFileService {
     if (this.filterCriteria != null) {
       filteredFiles = this.files.filter((f) => this.filterCriteria!.meetsCriteria(f));
     }
+
+    // Skip re-emitting the filtered list when its membership/order is unchanged
+    // (element-wise reference-identical to the last emission). The rendered DOM is
+    // identical either way; this lets OnPush consumers skip a needless CD pass.
+    const prevFiltered = this.filteredFilesSubject.getValue();
+    if (filteredFiles !== prevFiltered && arraysReferenceEqual(filteredFiles, prevFiltered)) {
+      return;
+    }
     this.filteredFilesSubject.next(filteredFiles);
   }
+}
+
+function arraysReferenceEqual(a: readonly ViewFile[], b: readonly ViewFile[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function modelFilesEqual(a: ModelFile, b: ModelFile): boolean {

--- a/src/angular/src/app/services/logs/log.service.spec.ts
+++ b/src/angular/src/app/services/logs/log.service.spec.ts
@@ -2,18 +2,32 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import { LogService } from "./log.service";
 import { StreamDispatchService } from "../base/stream-dispatch.service";
+import { LoggerService } from "../utils/logger.service";
 import { LogRecord, LogRecordJson } from "../../models/log-record";
 
 describe("LogService", () => {
   let service: LogService;
   let mockStreamDispatch: { registerHandler: ReturnType<typeof vi.fn> };
+  let mockLogger: {
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     mockStreamDispatch = { registerHandler: vi.fn() };
+    mockLogger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
     TestBed.configureTestingModule({
       providers: [
         LogService,
         { provide: StreamDispatchService, useValue: mockStreamDispatch },
+        { provide: LoggerService, useValue: mockLogger },
       ],
     });
     service = TestBed.inject(LogService);
@@ -69,5 +83,32 @@ describe("LogService", () => {
     expect(results.length).toBe(2);
     expect(results[0].message).toBe("First");
     expect(results[1].message).toBe("Second");
+  });
+
+  it("should not throw and should emit nothing on a malformed log-record event (issue #516)", () => {
+    const results: LogRecord[] = [];
+    service.logs$.subscribe((r) => results.push(r));
+
+    expect(() => service.onEvent("log-record", "not json")).not.toThrow();
+    expect(mockLogger.error).toHaveBeenCalled();
+    expect(results.length).toBe(0);
+  });
+
+  it("should still emit a valid log-record after a malformed one (issue #516)", () => {
+    const results: LogRecord[] = [];
+    service.logs$.subscribe((r) => results.push(r));
+
+    service.onEvent("log-record", "not json");
+    const logJson: LogRecordJson = {
+      time: 1700000000,
+      level_name: "INFO",
+      logger_name: "test.logger",
+      message: "After malformed",
+      exc_tb: "",
+    };
+    service.onEvent("log-record", JSON.stringify(logJson));
+
+    expect(results.length).toBe(1);
+    expect(results[0].message).toBe("After malformed");
   });
 });

--- a/src/angular/src/app/services/logs/log.service.ts
+++ b/src/angular/src/app/services/logs/log.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 
 import { StreamEventHandler, StreamDispatchService } from '../base/stream-dispatch.service';
+import { LoggerService } from '../utils/logger.service';
 import { LogRecord, logRecordFromJson } from '../../models/log-record';
 
 export interface LogHistoryParams {
@@ -25,6 +26,7 @@ export interface LogHistoryEntry {
 export class LogService implements StreamEventHandler {
     private readonly streamDispatch = inject(StreamDispatchService);
     private readonly http = inject(HttpClient);
+    private readonly logger = inject(LoggerService);
 
     private readonly logsSubject = new Subject<LogRecord>();
 
@@ -39,7 +41,14 @@ export class LogService implements StreamEventHandler {
     }
 
     onEvent(_eventName: string, data: string): void {
-        this.logsSubject.next(logRecordFromJson(JSON.parse(data)));
+        // Guard the parse of server-controlled SSE payloads: a malformed/truncated
+        // event must not throw inside the listener callback. Log and skip the bad
+        // record, emitting nothing (mirrors ConfigService.getConfig).
+        try {
+            this.logsSubject.next(logRecordFromJson(JSON.parse(data)));
+        } catch (e) {
+            this.logger.error('Failed to parse log-record event: %O', e);
+        }
     }
 
     onConnected(): void {

--- a/src/angular/src/app/services/server/server-status.service.spec.ts
+++ b/src/angular/src/app/services/server/server-status.service.spec.ts
@@ -2,19 +2,33 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import { ServerStatusService } from "./server-status.service";
 import { StreamDispatchService } from "../base/stream-dispatch.service";
+import { LoggerService } from "../utils/logger.service";
 import { ServerStatus, ServerStatusJson } from "../../models/server-status";
 import { Localization } from "../../models/localization";
 
 describe("ServerStatusService", () => {
   let service: ServerStatusService;
   let mockStreamDispatch: { registerHandler: ReturnType<typeof vi.fn> };
+  let mockLogger: {
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     mockStreamDispatch = { registerHandler: vi.fn() };
+    mockLogger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
     TestBed.configureTestingModule({
       providers: [
         ServerStatusService,
         { provide: StreamDispatchService, useValue: mockStreamDispatch },
+        { provide: LoggerService, useValue: mockLogger },
       ],
     });
     service = TestBed.inject(ServerStatusService);
@@ -88,5 +102,48 @@ describe("ServerStatusService", () => {
     expect(result!.controller.latestRemoteScanTime).toBeNull();
     expect(result!.controller.latestRemoteScanFailed).toBe(false);
     expect(result!.controller.latestRemoteScanError).toBeNull();
+  });
+
+  it("should not throw and should keep last-good status on a malformed status event (issue #516)", () => {
+    // Seed a valid connected status.
+    const statusJson: ServerStatusJson = {
+      server: { up: true, error_msg: "" },
+      controller: {
+        latest_local_scan_time: "1700000000",
+        latest_remote_scan_time: null,
+        latest_remote_scan_failed: false,
+        latest_remote_scan_error: null,
+        no_enabled_pairs: false,
+      },
+    };
+    service.onEvent("status", JSON.stringify(statusJson));
+
+    // A malformed payload must not throw and must not degrade the status.
+    expect(() => service.onEvent("status", "garbage")).not.toThrow();
+    expect(mockLogger.error).toHaveBeenCalled();
+
+    let result: ServerStatus | undefined;
+    service.status$.subscribe((s) => (result = s));
+    expect(result!.server.up).toBe(true);
+  });
+
+  it("should still parse a valid status event after a malformed one (issue #516)", () => {
+    service.onEvent("status", "garbage");
+
+    const statusJson: ServerStatusJson = {
+      server: { up: true, error_msg: "" },
+      controller: {
+        latest_local_scan_time: null,
+        latest_remote_scan_time: null,
+        latest_remote_scan_failed: false,
+        latest_remote_scan_error: null,
+        no_enabled_pairs: false,
+      },
+    };
+    service.onEvent("status", JSON.stringify(statusJson));
+
+    let result: ServerStatus | undefined;
+    service.status$.subscribe((s) => (result = s));
+    expect(result!.server.up).toBe(true);
   });
 });

--- a/src/angular/src/app/services/server/server-status.service.ts
+++ b/src/angular/src/app/services/server/server-status.service.ts
@@ -2,12 +2,14 @@ import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 import { StreamEventHandler, StreamDispatchService } from '../base/stream-dispatch.service';
+import { LoggerService } from '../utils/logger.service';
 import { Localization } from '../../models/localization';
 import { ServerStatus, ServerStatusJson, serverStatusFromJson } from '../../models/server-status';
 
 @Injectable({ providedIn: 'root' })
 export class ServerStatusService implements StreamEventHandler {
   private readonly streamDispatch = inject(StreamDispatchService);
+  private readonly logger = inject(LoggerService);
 
   private readonly statusSubject = new BehaviorSubject<ServerStatus>({
     server: {
@@ -34,8 +36,15 @@ export class ServerStatusService implements StreamEventHandler {
   }
 
   onEvent(_eventName: string, data: string): void {
-    const statusJson: ServerStatusJson = JSON.parse(data);
-    this.statusSubject.next(serverStatusFromJson(statusJson));
+    // Guard the parse of server-controlled SSE payloads: a malformed/truncated
+    // event must not throw inside the listener callback. Log and skip the bad
+    // event, leaving the last-good status in place (mirrors ConfigService).
+    try {
+      const statusJson: ServerStatusJson = JSON.parse(data);
+      this.statusSubject.next(serverStatusFromJson(statusJson));
+    } catch (e) {
+      this.logger.error('Failed to parse status event: %O', e);
+    }
   }
 
   onConnected(): void {

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -235,6 +235,27 @@ describe("ConfigService", () => {
     expect(service.configSnapshot?.web?.api_key).toBe("new-key");
   });
 
+  it("preserves a cleared (empty) api_key across a redacted refresh (#540)", () => {
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(makeConfig({ web: { port: 8080, api_key: "old-key" } })), errorMessage: null }),
+    );
+    createService();
+
+    // The user clears the key.
+    mockRestService.sendRequest.mockReturnValueOnce(of({ success: true, data: null, errorMessage: null }));
+    service.set("web", "api_key", "");
+    expect(service.configSnapshot?.web?.api_key).toBe("");
+
+    // The backend redacts even an empty key to the sentinel on refresh; the
+    // cleared state must survive, not be turned back into a phantom secret.
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(makeConfig({ web: { port: 8080, api_key: REDACTED_SENTINEL } })), errorMessage: null }),
+    );
+    connectedSubject.next(true);
+
+    expect(service.configSnapshot?.web?.api_key).toBe("");
+  });
+
   // --- Disconnect ---
 
   it("should retain config on disconnect so the UI keeps working", () => {

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -8,7 +8,7 @@ import { ConnectedService } from "../utils/connected.service";
 import { LoggerService } from "../utils/logger.service";
 import { RestService, WebReaction } from "../utils/rest.service";
 import { StreamDispatchService } from "../base/stream-dispatch.service";
-import { Config } from "../../models/config";
+import { Config, REDACTED_SENTINEL } from "../../models/config";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
@@ -201,16 +201,38 @@ describe("ConfigService", () => {
   });
 
   it("should NOT push the redacted sentinel from /server/config/get to the stream", () => {
-    const config = makeConfig({ web: { port: 8080, api_key: "********" } });
+    const config = makeConfig({ web: { port: 8080, api_key: REDACTED_SENTINEL } });
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
 
     createService();
 
-    // The redacted '********' returned by the auth-exempt config endpoint must
+    // The redacted sentinel returned by the auth-exempt config endpoint must
     // never be pushed to the stream as a credential.
-    expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalledWith("********");
+    expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalledWith(REDACTED_SENTINEL);
+  });
+
+  it("preserves the real api_key in the snapshot when a refresh returns the redacted sentinel", () => {
+    // Init with a web section so set() has an existing option to update.
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(makeConfig({ web: { port: 8080, api_key: "" } })), errorMessage: null }),
+    );
+    createService();
+
+    // The user enters the real key in Settings.
+    mockRestService.sendRequest.mockReturnValueOnce(of({ success: true, data: null, errorMessage: null }));
+    service.set("web", "api_key", "new-key");
+    expect(service.configSnapshot?.web?.api_key).toBe("new-key");
+
+    // A later config refresh returns the redacted sentinel. It must NOT clobber
+    // the real key the apiKeyInterceptor relies on for REST auth this session.
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(makeConfig({ web: { port: 8080, api_key: REDACTED_SENTINEL } })), errorMessage: null }),
+    );
+    connectedSubject.next(true);
+
+    expect(service.configSnapshot?.web?.api_key).toBe("new-key");
   });
 
   // --- Disconnect ---

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 // Injector not needed — TestBed handles DI
 import { BehaviorSubject, of } from "rxjs";
@@ -8,6 +8,7 @@ import { ConnectedService } from "../utils/connected.service";
 import { LoggerService } from "../utils/logger.service";
 import { RestService, WebReaction } from "../utils/rest.service";
 import { StreamDispatchService } from "../base/stream-dispatch.service";
+import { StorageKeys } from "../../common/storage-keys";
 import { Config } from "../../models/config";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
@@ -80,11 +81,50 @@ describe("ConfigService", () => {
   let connectedSubject: BehaviorSubject<boolean>;
   let mockRestService: { sendRequest: ReturnType<typeof vi.fn> };
   let mockStreamDispatch: { setApiKey: ReturnType<typeof vi.fn> };
+  let store: Record<string, string>;
+  let mockSessionStorage: {
+    getItem: ReturnType<typeof vi.fn>;
+    setItem: ReturnType<typeof vi.fn>;
+    removeItem: ReturnType<typeof vi.fn>;
+  };
+  let originalSessionStorage: Storage;
+
+  /**
+   * Lazily construct the service. The constructor fetches config and
+   * rehydrates the persisted API key, so each test configures its mocks
+   * (sendRequest return values, seeded sessionStorage) BEFORE calling this.
+   */
+  function createService(): ConfigService {
+    service = TestBed.inject(ConfigService);
+    return service;
+  }
 
   beforeEach(() => {
     connectedSubject = new BehaviorSubject<boolean>(false);
-    mockRestService = { sendRequest: vi.fn() };
+    // Safe default so the constructor's init fetch never crashes on undefined.
+    mockRestService = {
+      sendRequest: vi.fn().mockReturnValue(
+        of({ success: false, data: null, errorMessage: "not configured" }),
+      ),
+    };
     mockStreamDispatch = { setApiKey: vi.fn() };
+
+    store = {};
+    mockSessionStorage = {
+      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+    };
+    originalSessionStorage = globalThis.sessionStorage;
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: mockSessionStorage,
+      configurable: true,
+      writable: true,
+    });
 
     TestBed.configureTestingModule({
       providers: [
@@ -109,18 +149,28 @@ describe("ConfigService", () => {
         },
       ],
     });
-    service = TestBed.inject(ConfigService);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: originalSessionStorage,
+      configurable: true,
+      writable: true,
+    });
   });
 
   // --- Initial state ---
 
   it("should emit null as the initial config", () => {
+    // Default mock returns a failure reaction, so the init fetch leaves config null.
+    createService();
     let result: Config | null | undefined;
     service.config$.subscribe((c) => (result = c));
     expect(result).toBeNull();
   });
 
   it("should return null from configSnapshot initially", () => {
+    createService();
     expect(service.configSnapshot).toBeNull();
   });
 
@@ -132,6 +182,7 @@ describe("ConfigService", () => {
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
 
+    createService();
     connectedSubject.next(true);
 
     let result: Config | null | undefined;
@@ -148,6 +199,7 @@ describe("ConfigService", () => {
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
 
+    createService();
     connectedSubject.next(true);
     expect(service.configSnapshot).toEqual(config);
   });
@@ -158,36 +210,99 @@ describe("ConfigService", () => {
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
 
+    createService();
     connectedSubject.next(true);
     expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("my-key");
   });
 
-  // --- Disconnect ---
+  // --- Init-ordering deadlock fix (#514) ---
 
-  it("should emit null config when disconnected", () => {
+  it("should fetch config at init independent of connected$", () => {
     const config = makeConfig();
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
+
+    // connected$ is still false (never emits true)
+    createService();
+
+    let result: Config | null | undefined;
+    service.config$.subscribe((c) => (result = c));
+    expect(result).toEqual(config);
+    expect(mockRestService.sendRequest).toHaveBeenCalledWith(
+      "/server/config/get",
+    );
+  });
+
+  it("should rehydrate persisted api_key from sessionStorage at init and push it to the stream before any connect", () => {
+    store[StorageKeys.API_KEY] = "real-key";
+
+    // connected$ stays false; the key must reach the stream during construction
+    createService();
+
+    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("real-key");
+  });
+
+  it("should NOT push the redacted sentinel to the stream and should keep the persisted key", () => {
+    store[StorageKeys.API_KEY] = "real-key";
+    const config = makeConfig({ web: { port: 8080, api_key: "********" } });
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+    );
+
+    createService();
+
+    // The persisted real key is pushed at init, but the redacted '********'
+    // returned by /server/config/get must never reach the stream.
+    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("real-key");
+    expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalledWith("********");
+    expect(store[StorageKeys.API_KEY]).toBe("real-key");
+  });
+
+  it("should tolerate sessionStorage throwing during init (private browsing)", () => {
+    mockSessionStorage.getItem.mockImplementation(() => {
+      throw new Error("denied");
+    });
+    const config = makeConfig();
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+    );
+
+    expect(() => createService()).not.toThrow();
+  });
+
+  // --- Disconnect ---
+
+  it("should retain config on disconnect so the UI keeps working", () => {
+    const config = makeConfig();
+    mockRestService.sendRequest.mockReturnValue(
+      of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+    );
+    createService();
     connectedSubject.next(true);
 
     connectedSubject.next(false);
 
+    // Config is fetched at init independent of the stream, so a transient
+    // disconnect must not wipe it out (and trigger a deadlock-prone refetch loop).
     let result: Config | null | undefined;
     service.config$.subscribe((c) => (result = c));
-    expect(result).toBeNull();
+    expect(result).toEqual(config);
   });
 
-  it("should sync null API key when disconnected", () => {
-    const config = makeConfig();
+  it("should NOT clear the api key on disconnect so the next reconnect can authenticate", () => {
+    const config = makeConfig({ web: { port: 8080, api_key: "my-key" } });
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
+    createService();
     connectedSubject.next(true);
     mockStreamDispatch.setApiKey.mockClear();
 
     connectedSubject.next(false);
-    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith(null);
+
+    // The key must stay on the stream so the backoff-driven reconnect carries it.
+    expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalledWith(null);
   });
 
   // --- Error handling ---
@@ -201,6 +316,7 @@ describe("ConfigService", () => {
       }),
     );
 
+    createService();
     connectedSubject.next(true);
 
     let result: Config | null | undefined;
@@ -213,6 +329,7 @@ describe("ConfigService", () => {
       of({ success: true, data: "not valid json {{{", errorMessage: null }),
     );
 
+    createService();
     connectedSubject.next(true);
 
     let result: Config | null | undefined;
@@ -227,6 +344,7 @@ describe("ConfigService", () => {
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
+    createService();
     connectedSubject.next(true);
 
     let result: WebReaction | undefined;
@@ -241,6 +359,7 @@ describe("ConfigService", () => {
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
     );
+    createService();
     connectedSubject.next(true);
 
     let result: WebReaction | undefined;
@@ -251,7 +370,8 @@ describe("ConfigService", () => {
   });
 
   it("should return error when config is null", () => {
-    // Config is null by default (not connected)
+    // Default mock returns failure, so config stays null after init.
+    createService();
     let result: WebReaction | undefined;
     service.set("web", "port", "9090").subscribe((r: WebReaction) => (result = r));
 
@@ -260,13 +380,18 @@ describe("ConfigService", () => {
 
   it("should call REST with double-encoded value", () => {
     const config = makeConfig();
+    // init fetch -> connect fetch -> set response
     mockRestService.sendRequest
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
       .mockReturnValueOnce(
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("web", "api_key", "my/key");
@@ -284,8 +409,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("web", "api_key", "");
@@ -297,6 +426,76 @@ describe("ConfigService", () => {
     expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith(null);
   });
 
+  it("should remove persisted api_key from sessionStorage when set empty", () => {
+    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
+    store[StorageKeys.API_KEY] = "old";
+    mockRestService.sendRequest
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: null, errorMessage: null }),
+      );
+    createService();
+    connectedSubject.next(true);
+
+    service.set("web", "api_key", "");
+
+    expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(StorageKeys.API_KEY);
+    expect(store[StorageKeys.API_KEY]).toBeUndefined();
+    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith(null);
+  });
+
+  it("should persist the real api_key to sessionStorage on successful set", () => {
+    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
+    mockRestService.sendRequest
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: null, errorMessage: null }),
+      );
+    createService();
+    connectedSubject.next(true);
+
+    service.set("web", "api_key", "new-key");
+
+    expect(mockSessionStorage.setItem).toHaveBeenCalledWith(
+      StorageKeys.API_KEY,
+      "new-key",
+    );
+    expect(store[StorageKeys.API_KEY]).toBe("new-key");
+  });
+
+  it("should not throw when sessionStorage throws during set", () => {
+    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
+    mockRestService.sendRequest
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: null, errorMessage: null }),
+      );
+    createService();
+    connectedSubject.next(true);
+    mockSessionStorage.setItem.mockImplementation(() => {
+      throw new Error("denied");
+    });
+
+    expect(() => service.set("web", "api_key", "new-key")).not.toThrow();
+    // Stream still receives the key even if persistence failed.
+    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("new-key");
+  });
+
   it("should update BehaviorSubject on successful set", () => {
     const config = makeConfig({ web: { port: 8080, api_key: "old" } });
     mockRestService.sendRequest
@@ -304,8 +503,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("web", "api_key", "new-key");
@@ -320,8 +523,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: false, data: null, errorMessage: "fail" }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("web", "api_key", "new-key");
@@ -336,8 +543,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
     mockStreamDispatch.setApiKey.mockClear();
 
@@ -353,8 +564,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("autoqueue", "enabled", true);
@@ -373,8 +588,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("autoqueue", "enabled", false);
@@ -393,8 +612,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
 
     service.set("lftp", "net_limit_rate", null);
@@ -411,8 +634,12 @@ describe("ConfigService", () => {
         of({ success: true, data: JSON.stringify(config), errorMessage: null }),
       )
       .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
         of({ success: true, data: null, errorMessage: null }),
       );
+    createService();
     connectedSubject.next(true);
     mockStreamDispatch.setApiKey.mockClear();
 

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 // Injector not needed — TestBed handles DI
 import { BehaviorSubject, of } from "rxjs";
@@ -8,7 +8,6 @@ import { ConnectedService } from "../utils/connected.service";
 import { LoggerService } from "../utils/logger.service";
 import { RestService, WebReaction } from "../utils/rest.service";
 import { StreamDispatchService } from "../base/stream-dispatch.service";
-import { StorageKeys } from "../../common/storage-keys";
 import { Config } from "../../models/config";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
@@ -81,18 +80,10 @@ describe("ConfigService", () => {
   let connectedSubject: BehaviorSubject<boolean>;
   let mockRestService: { sendRequest: ReturnType<typeof vi.fn> };
   let mockStreamDispatch: { setApiKey: ReturnType<typeof vi.fn> };
-  let store: Record<string, string>;
-  let mockSessionStorage: {
-    getItem: ReturnType<typeof vi.fn>;
-    setItem: ReturnType<typeof vi.fn>;
-    removeItem: ReturnType<typeof vi.fn>;
-  };
-  let originalSessionStorage: Storage;
 
   /**
-   * Lazily construct the service. The constructor fetches config and
-   * rehydrates the persisted API key, so each test configures its mocks
-   * (sendRequest return values, seeded sessionStorage) BEFORE calling this.
+   * Lazily construct the service. The constructor fetches config, so each test
+   * configures its mocks (sendRequest return values) BEFORE calling this.
    */
   function createService(): ConfigService {
     service = TestBed.inject(ConfigService);
@@ -108,23 +99,6 @@ describe("ConfigService", () => {
       ),
     };
     mockStreamDispatch = { setApiKey: vi.fn() };
-
-    store = {};
-    mockSessionStorage = {
-      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
-      setItem: vi.fn((key: string, value: string) => {
-        store[key] = value;
-      }),
-      removeItem: vi.fn((key: string) => {
-        delete store[key];
-      }),
-    };
-    originalSessionStorage = globalThis.sessionStorage;
-    Object.defineProperty(globalThis, "sessionStorage", {
-      value: mockSessionStorage,
-      configurable: true,
-      writable: true,
-    });
 
     TestBed.configureTestingModule({
       providers: [
@@ -148,14 +122,6 @@ describe("ConfigService", () => {
           useValue: mockStreamDispatch,
         },
       ],
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(globalThis, "sessionStorage", {
-      value: originalSessionStorage,
-      configurable: true,
-      writable: true,
     });
   });
 
@@ -234,17 +200,7 @@ describe("ConfigService", () => {
     );
   });
 
-  it("should rehydrate persisted api_key from sessionStorage at init and push it to the stream before any connect", () => {
-    store[StorageKeys.API_KEY] = "real-key";
-
-    // connected$ stays false; the key must reach the stream during construction
-    createService();
-
-    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("real-key");
-  });
-
-  it("should NOT push the redacted sentinel to the stream and should keep the persisted key", () => {
-    store[StorageKeys.API_KEY] = "real-key";
+  it("should NOT push the redacted sentinel from /server/config/get to the stream", () => {
     const config = makeConfig({ web: { port: 8080, api_key: "********" } });
     mockRestService.sendRequest.mockReturnValue(
       of({ success: true, data: JSON.stringify(config), errorMessage: null }),
@@ -252,23 +208,9 @@ describe("ConfigService", () => {
 
     createService();
 
-    // The persisted real key is pushed at init, but the redacted '********'
-    // returned by /server/config/get must never reach the stream.
-    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("real-key");
+    // The redacted '********' returned by the auth-exempt config endpoint must
+    // never be pushed to the stream as a credential.
     expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalledWith("********");
-    expect(store[StorageKeys.API_KEY]).toBe("real-key");
-  });
-
-  it("should tolerate sessionStorage throwing during init (private browsing)", () => {
-    mockSessionStorage.getItem.mockImplementation(() => {
-      throw new Error("denied");
-    });
-    const config = makeConfig();
-    mockRestService.sendRequest.mockReturnValue(
-      of({ success: true, data: JSON.stringify(config), errorMessage: null }),
-    );
-
-    expect(() => createService()).not.toThrow();
   });
 
   // --- Disconnect ---
@@ -426,30 +368,7 @@ describe("ConfigService", () => {
     expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith(null);
   });
 
-  it("should remove persisted api_key from sessionStorage when set empty", () => {
-    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
-    store[StorageKeys.API_KEY] = "old";
-    mockRestService.sendRequest
-      .mockReturnValueOnce(
-        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
-      )
-      .mockReturnValueOnce(
-        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
-      )
-      .mockReturnValueOnce(
-        of({ success: true, data: null, errorMessage: null }),
-      );
-    createService();
-    connectedSubject.next(true);
-
-    service.set("web", "api_key", "");
-
-    expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(StorageKeys.API_KEY);
-    expect(store[StorageKeys.API_KEY]).toBeUndefined();
-    expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith(null);
-  });
-
-  it("should persist the real api_key to sessionStorage on successful set", () => {
+  it("should push the real api_key to the stream on successful set", () => {
     const config = makeConfig({ web: { port: 8080, api_key: "old" } });
     mockRestService.sendRequest
       .mockReturnValueOnce(
@@ -466,33 +385,8 @@ describe("ConfigService", () => {
 
     service.set("web", "api_key", "new-key");
 
-    expect(mockSessionStorage.setItem).toHaveBeenCalledWith(
-      StorageKeys.API_KEY,
-      "new-key",
-    );
-    expect(store[StorageKeys.API_KEY]).toBe("new-key");
-  });
-
-  it("should not throw when sessionStorage throws during set", () => {
-    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
-    mockRestService.sendRequest
-      .mockReturnValueOnce(
-        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
-      )
-      .mockReturnValueOnce(
-        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
-      )
-      .mockReturnValueOnce(
-        of({ success: true, data: null, errorMessage: null }),
-      );
-    createService();
-    connectedSubject.next(true);
-    mockSessionStorage.setItem.mockImplementation(() => {
-      throw new Error("denied");
-    });
-
-    expect(() => service.set("web", "api_key", "new-key")).not.toThrow();
-    // Stream still receives the key even if persistence failed.
+    // set() is the only place the real key is available client-side; it is
+    // pushed to the stream (but not persisted anywhere).
     expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("new-key");
   });
 

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -6,7 +6,6 @@ import { LoggerService } from '../utils/logger.service';
 import { RestService, WebReaction } from '../utils/rest.service';
 import { StreamDispatchService } from '../base/stream-dispatch.service';
 import { Config, REDACTED_SENTINEL } from '../../models/config';
-import { StorageKeys } from '../../common/storage-keys';
 
 /** Value a config field may take (matches OptionComponent's value shape). */
 export type ConfigValue = string | number | boolean | null;
@@ -42,26 +41,16 @@ export class ConfigService {
   }
 
   constructor() {
-    // Rehydrate any persisted API key BEFORE the stream connects, so the
-    // first connection on an auth-enabled instance carries the key. This is
-    // the only client-side data that can re-authenticate after a reload —
-    // /server/config/get redacts web.api_key, so it cannot supply the key.
-    const persistedKey = this.readPersistedApiKey();
-    if (persistedKey) {
-      this.setStreamApiKey(persistedKey);
-    }
-
     // Fetch config at init independent of the stream connection.
     // /server/config/get is auth-exempt, so config$ can populate for the UI
     // even before (and without) an authenticated stream connection. This
     // breaks the init-ordering deadlock where the config fetch was gated
-    // behind a stream that could never connect without the key.
+    // behind a stream that could never connect without the key. The key itself
+    // is NOT persisted client-side; after a reload on an auth-enabled instance
+    // the user re-enters it in Settings (which re-pushes it to the stream).
     this.getConfig();
 
     this.connectedService.connected$.subscribe((connected) => {
-      // The connected$ subscription now only refreshes config on (re)connect;
-      // bootstrap is handled above. On disconnect, leave any persisted key in
-      // place so the next connect attempt can still authenticate.
       if (connected) {
         this.getConfig();
       }
@@ -93,12 +82,10 @@ export class ConfigService {
             const configRecord = config as unknown as ConfigRecord;
             const newConfig = { ...config, [section]: { ...configRecord[section], [option]: value } };
             this.configSubject.next(newConfig);
-            // Propagate API key changes to the SSE stream immediately. This is
-            // the only place the real (un-redacted) key is available, so it is
-            // also where we persist it for recovery after a reload.
+            // Propagate API key changes to the SSE stream immediately. set() is
+            // the only place the real (un-redacted) key is available client-side.
             if (section === 'web' && option === 'api_key') {
               const realKey = String(value ?? '') || null;
-              this.writePersistedApiKey(realKey);
               this.setStreamApiKey(realKey);
             }
           }
@@ -148,26 +135,5 @@ export class ConfigService {
     // StreamDispatchService -> ConnectedService -> ConfigService
     const streamDispatch = this.injector.get(StreamDispatchService);
     streamDispatch.setApiKey(apiKey);
-  }
-
-  private readPersistedApiKey(): string | null {
-    try {
-      return sessionStorage.getItem(StorageKeys.API_KEY);
-    } catch {
-      // sessionStorage may be unavailable (private browsing, test environments)
-      return null;
-    }
-  }
-
-  private writePersistedApiKey(apiKey: string | null): void {
-    try {
-      if (apiKey) {
-        sessionStorage.setItem(StorageKeys.API_KEY, apiKey);
-      } else {
-        sessionStorage.removeItem(StorageKeys.API_KEY);
-      }
-    } catch {
-      // sessionStorage may be unavailable (private browsing, test environments)
-    }
   }
 }

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -123,20 +123,22 @@ export class ConfigService {
    * value is treated as "no change" and never overwrites the stream's key.
    */
   /**
-   * /server/config/get redacts web.api_key to the sentinel. A refresh must not
-   * clobber a real key the user entered this session — the apiKeyInterceptor
-   * reads configSnapshot.web.api_key for REST auth, so overwriting it with the
-   * sentinel would break authenticated REST calls until the next set(). Keep the
-   * existing real key when the incoming value is redacted.
+   * /server/config/get redacts web.api_key to the sentinel *unconditionally*
+   * (even when the stored value is empty). A refresh must not clobber whatever
+   * the user-set snapshot holds — the apiKeyInterceptor reads it for REST auth,
+   * so overwriting it with the sentinel would break authenticated REST calls
+   * until the next set(). Preserve the existing value (including a cleared empty
+   * key, which must not look like a phantom secret) whenever the snapshot's
+   * value is not itself the sentinel.
    */
   private preserveRealApiKey(incoming: Config): Config {
-    const currentKey = this.configSubject.getValue()?.web?.api_key;
+    const currentWeb = this.configSubject.getValue()?.web;
     if (
       incoming.web?.api_key === REDACTED_SENTINEL &&
-      currentKey &&
-      currentKey !== REDACTED_SENTINEL
+      currentWeb !== undefined &&
+      currentWeb.api_key !== REDACTED_SENTINEL
     ) {
-      return { ...incoming, web: { ...incoming.web, api_key: currentKey } };
+      return { ...incoming, web: { ...incoming.web, api_key: currentWeb.api_key } };
     }
     return incoming;
   }

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -101,7 +101,7 @@ export class ConfigService {
       next: (reaction) => {
         if (reaction.success) {
           try {
-            const configJson: Config = JSON.parse(reaction.data!);
+            const configJson: Config = this.preserveRealApiKey(JSON.parse(reaction.data!));
             this.configSubject.next(configJson);
             this.syncStreamApiKey(configJson);
           } catch (e) {
@@ -122,6 +122,25 @@ export class ConfigService {
    * which would fail auth and clobber a good persisted key, so a redacted
    * value is treated as "no change" and never overwrites the stream's key.
    */
+  /**
+   * /server/config/get redacts web.api_key to the sentinel. A refresh must not
+   * clobber a real key the user entered this session — the apiKeyInterceptor
+   * reads configSnapshot.web.api_key for REST auth, so overwriting it with the
+   * sentinel would break authenticated REST calls until the next set(). Keep the
+   * existing real key when the incoming value is redacted.
+   */
+  private preserveRealApiKey(incoming: Config): Config {
+    const currentKey = this.configSubject.getValue()?.web?.api_key;
+    if (
+      incoming.web?.api_key === REDACTED_SENTINEL &&
+      currentKey &&
+      currentKey !== REDACTED_SENTINEL
+    ) {
+      return { ...incoming, web: { ...incoming.web, api_key: currentKey } };
+    }
+    return incoming;
+  }
+
   private syncStreamApiKey(config: Config | null): void {
     const apiKey = config?.web?.api_key || null;
     if (apiKey === REDACTED_SENTINEL) {

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -5,7 +5,7 @@ import { ConnectedService } from '../utils/connected.service';
 import { LoggerService } from '../utils/logger.service';
 import { RestService, WebReaction } from '../utils/rest.service';
 import { StreamDispatchService } from '../base/stream-dispatch.service';
-import { Config } from '../../models/config';
+import { Config, REDACTED_SENTINEL } from '../../models/config';
 import { StorageKeys } from '../../common/storage-keys';
 
 /** Value a config field may take (matches OptionComponent's value shape). */
@@ -17,13 +17,10 @@ type ConfigRecord = Record<string, Record<string, ConfigValue>>;
 /** Sentinel value sent to the backend when the user clears a text field. */
 export const EMPTY_VALUE_SENTINEL = '__empty__';
 
-/**
- * Value the backend substitutes for web.api_key in /server/config/get
- * responses (see common/config.py). It must never be treated as a real
- * key — pushing it to the stream would fail auth and could clobber a
- * good persisted key.
- */
-const REDACTED_SENTINEL = '********';
+// REDACTED_SENTINEL (imported from models/config) is the value the backend
+// substitutes for web.api_key in /server/config/get responses. It must never be
+// treated as a real key — pushing it to the stream would fail auth and could
+// clobber a good persisted key.
 
 @Injectable({ providedIn: 'root' })
 export class ConfigService {

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -6,6 +6,7 @@ import { LoggerService } from '../utils/logger.service';
 import { RestService, WebReaction } from '../utils/rest.service';
 import { StreamDispatchService } from '../base/stream-dispatch.service';
 import { Config } from '../../models/config';
+import { StorageKeys } from '../../common/storage-keys';
 
 /** Value a config field may take (matches OptionComponent's value shape). */
 export type ConfigValue = string | number | boolean | null;
@@ -15,6 +16,14 @@ type ConfigRecord = Record<string, Record<string, ConfigValue>>;
 
 /** Sentinel value sent to the backend when the user clears a text field. */
 export const EMPTY_VALUE_SENTINEL = '__empty__';
+
+/**
+ * Value the backend substitutes for web.api_key in /server/config/get
+ * responses (see common/config.py). It must never be treated as a real
+ * key — pushing it to the stream would fail auth and could clobber a
+ * good persisted key.
+ */
+const REDACTED_SENTINEL = '********';
 
 @Injectable({ providedIn: 'root' })
 export class ConfigService {
@@ -36,12 +45,28 @@ export class ConfigService {
   }
 
   constructor() {
+    // Rehydrate any persisted API key BEFORE the stream connects, so the
+    // first connection on an auth-enabled instance carries the key. This is
+    // the only client-side data that can re-authenticate after a reload —
+    // /server/config/get redacts web.api_key, so it cannot supply the key.
+    const persistedKey = this.readPersistedApiKey();
+    if (persistedKey) {
+      this.setStreamApiKey(persistedKey);
+    }
+
+    // Fetch config at init independent of the stream connection.
+    // /server/config/get is auth-exempt, so config$ can populate for the UI
+    // even before (and without) an authenticated stream connection. This
+    // breaks the init-ordering deadlock where the config fetch was gated
+    // behind a stream that could never connect without the key.
+    this.getConfig();
+
     this.connectedService.connected$.subscribe((connected) => {
+      // The connected$ subscription now only refreshes config on (re)connect;
+      // bootstrap is handled above. On disconnect, leave any persisted key in
+      // place so the next connect attempt can still authenticate.
       if (connected) {
         this.getConfig();
-      } else {
-        this.configSubject.next(null);
-        this.syncStreamApiKey(null);
       }
     });
   }
@@ -71,9 +96,13 @@ export class ConfigService {
             const configRecord = config as unknown as ConfigRecord;
             const newConfig = { ...config, [section]: { ...configRecord[section], [option]: value } };
             this.configSubject.next(newConfig);
-            // Propagate API key changes to the SSE stream immediately
+            // Propagate API key changes to the SSE stream immediately. This is
+            // the only place the real (un-redacted) key is available, so it is
+            // also where we persist it for recovery after a reload.
             if (section === 'web' && option === 'api_key') {
-              this.syncStreamApiKey(newConfig);
+              const realKey = String(value ?? '') || null;
+              this.writePersistedApiKey(realKey);
+              this.setStreamApiKey(realKey);
             }
           }
         }
@@ -94,22 +123,54 @@ export class ConfigService {
           } catch (e) {
             this.logger.error('Failed to parse config: %O', e);
             this.configSubject.next(null);
-            this.syncStreamApiKey(null);
           }
         } else {
           this.logger.error('Failed to get config: %s', reaction.errorMessage);
           this.configSubject.next(null);
-          this.syncStreamApiKey(null);
         }
       },
     });
   }
 
+  /**
+   * Push an API key from a fetched config to the stream, guarding against the
+   * redacted sentinel. /server/config/get redacts web.api_key to '********',
+   * which would fail auth and clobber a good persisted key, so a redacted
+   * value is treated as "no change" and never overwrites the stream's key.
+   */
   private syncStreamApiKey(config: Config | null): void {
     const apiKey = config?.web?.api_key || null;
+    if (apiKey === REDACTED_SENTINEL) {
+      return;
+    }
+    this.setStreamApiKey(apiKey);
+  }
+
+  private setStreamApiKey(apiKey: string | null): void {
     // Use injector.get() to break circular dependency:
     // StreamDispatchService -> ConnectedService -> ConfigService
     const streamDispatch = this.injector.get(StreamDispatchService);
     streamDispatch.setApiKey(apiKey);
+  }
+
+  private readPersistedApiKey(): string | null {
+    try {
+      return sessionStorage.getItem(StorageKeys.API_KEY);
+    } catch {
+      // sessionStorage may be unavailable (private browsing, test environments)
+      return null;
+    }
+  }
+
+  private writePersistedApiKey(apiKey: string | null): void {
+    try {
+      if (apiKey) {
+        sessionStorage.setItem(StorageKeys.API_KEY, apiKey);
+      } else {
+        sessionStorage.removeItem(StorageKeys.API_KEY);
+      }
+    } catch {
+      // sessionStorage may be unavailable (private browsing, test environments)
+    }
   }
 }

--- a/src/angular/src/app/services/utils/api-key.interceptor.spec.ts
+++ b/src/angular/src/app/services/utils/api-key.interceptor.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import {
   provideHttpClient,
@@ -12,6 +12,7 @@ import {
 
 import { apiKeyInterceptor } from "./api-key.interceptor";
 import { ConfigService } from "../settings/config.service";
+import { StorageKeys } from "../../common/storage-keys";
 import { Web } from "../../models/config";
 
 // Shape used by the interceptor's partial-config tests. The interceptor only
@@ -23,9 +24,33 @@ describe("apiKeyInterceptor", () => {
   let http: HttpClient;
   let httpTesting: HttpTestingController;
   let mockConfigService: { configSnapshot: MockConfigSnapshot };
+  let store: Record<string, string>;
+  let mockSessionStorage: {
+    getItem: ReturnType<typeof vi.fn>;
+    setItem: ReturnType<typeof vi.fn>;
+    removeItem: ReturnType<typeof vi.fn>;
+  };
+  let originalSessionStorage: Storage;
 
   beforeEach(() => {
     mockConfigService = { configSnapshot: null };
+
+    store = {};
+    mockSessionStorage = {
+      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+    };
+    originalSessionStorage = globalThis.sessionStorage;
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: mockSessionStorage,
+      configurable: true,
+      writable: true,
+    });
 
     TestBed.configureTestingModule({
       providers: [
@@ -41,6 +66,11 @@ describe("apiKeyInterceptor", () => {
 
   afterEach(() => {
     httpTesting.verify();
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: originalSessionStorage,
+      configurable: true,
+      writable: true,
+    });
   });
 
   // --- API key added to /server/* requests ---
@@ -146,6 +176,66 @@ describe("apiKeyInterceptor", () => {
 
     const req = httpTesting.expectOne("/serverExtra");
     expect(req.request.headers.has("X-Api-Key")).toBe(false);
+    req.flush("");
+  });
+
+  // --- Persisted real key recovery (#514) ---
+
+  it("should use the persisted sessionStorage key when the snapshot is redacted", () => {
+    // /server/config/get redacts the key to '********'; the persisted real key
+    // must be used so REST requests authenticate after a reload.
+    store[StorageKeys.API_KEY] = "real-key";
+    mockConfigService.configSnapshot = { web: { api_key: "********" } };
+
+    http.get("/server/config/get", { responseType: "text" }).subscribe();
+
+    const req = httpTesting.expectOne("/server/config/get");
+    expect(req.request.headers.get("X-Api-Key")).toBe("real-key");
+    req.flush("");
+  });
+
+  it("should prefer the persisted key over the snapshot key", () => {
+    store[StorageKeys.API_KEY] = "persisted-key";
+    mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
+
+    http.get("/server/config/get", { responseType: "text" }).subscribe();
+
+    const req = httpTesting.expectOne("/server/config/get");
+    expect(req.request.headers.get("X-Api-Key")).toBe("persisted-key");
+    req.flush("");
+  });
+
+  it("should never send the redacted sentinel as a credential", () => {
+    // No persisted key, and the snapshot only holds the redacted sentinel.
+    mockConfigService.configSnapshot = { web: { api_key: "********" } };
+
+    http.get("/server/config/get", { responseType: "text" }).subscribe();
+
+    const req = httpTesting.expectOne("/server/config/get");
+    expect(req.request.headers.has("X-Api-Key")).toBe(false);
+    req.flush("");
+  });
+
+  it("should fall back to the snapshot key when nothing is persisted", () => {
+    mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
+
+    http.get("/server/config/get", { responseType: "text" }).subscribe();
+
+    const req = httpTesting.expectOne("/server/config/get");
+    expect(req.request.headers.get("X-Api-Key")).toBe("snapshot-key");
+    req.flush("");
+  });
+
+  it("should tolerate sessionStorage throwing and fall back to the snapshot", () => {
+    mockSessionStorage.getItem.mockImplementation(() => {
+      throw new Error("denied");
+    });
+    mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
+
+    http.get("/server/config/get", { responseType: "text" }).subscribe();
+
+    const req = httpTesting.expectOne("/server/config/get");
+    expect(req.request.headers.get("X-Api-Key")).toBe("snapshot-key");
     req.flush("");
   });
 });

--- a/src/angular/src/app/services/utils/api-key.interceptor.spec.ts
+++ b/src/angular/src/app/services/utils/api-key.interceptor.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import {
   provideHttpClient,
@@ -12,7 +12,6 @@ import {
 
 import { apiKeyInterceptor } from "./api-key.interceptor";
 import { ConfigService } from "../settings/config.service";
-import { StorageKeys } from "../../common/storage-keys";
 import { Web } from "../../models/config";
 
 // Shape used by the interceptor's partial-config tests. The interceptor only
@@ -24,33 +23,9 @@ describe("apiKeyInterceptor", () => {
   let http: HttpClient;
   let httpTesting: HttpTestingController;
   let mockConfigService: { configSnapshot: MockConfigSnapshot };
-  let store: Record<string, string>;
-  let mockSessionStorage: {
-    getItem: ReturnType<typeof vi.fn>;
-    setItem: ReturnType<typeof vi.fn>;
-    removeItem: ReturnType<typeof vi.fn>;
-  };
-  let originalSessionStorage: Storage;
 
   beforeEach(() => {
     mockConfigService = { configSnapshot: null };
-
-    store = {};
-    mockSessionStorage = {
-      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
-      setItem: vi.fn((key: string, value: string) => {
-        store[key] = value;
-      }),
-      removeItem: vi.fn((key: string) => {
-        delete store[key];
-      }),
-    };
-    originalSessionStorage = globalThis.sessionStorage;
-    Object.defineProperty(globalThis, "sessionStorage", {
-      value: mockSessionStorage,
-      configurable: true,
-      writable: true,
-    });
 
     TestBed.configureTestingModule({
       providers: [
@@ -66,11 +41,6 @@ describe("apiKeyInterceptor", () => {
 
   afterEach(() => {
     httpTesting.verify();
-    Object.defineProperty(globalThis, "sessionStorage", {
-      value: originalSessionStorage,
-      configurable: true,
-      writable: true,
-    });
   });
 
   // --- API key added to /server/* requests ---
@@ -179,34 +149,11 @@ describe("apiKeyInterceptor", () => {
     req.flush("");
   });
 
-  // --- Persisted real key recovery (#514) ---
-
-  it("should use the persisted sessionStorage key when the snapshot is redacted", () => {
-    // /server/config/get redacts the key to '********'; the persisted real key
-    // must be used so REST requests authenticate after a reload.
-    store[StorageKeys.API_KEY] = "real-key";
-    mockConfigService.configSnapshot = { web: { api_key: "********" } };
-
-    http.get("/server/config/get", { responseType: "text" }).subscribe();
-
-    const req = httpTesting.expectOne("/server/config/get");
-    expect(req.request.headers.get("X-Api-Key")).toBe("real-key");
-    req.flush("");
-  });
-
-  it("should prefer the persisted key over the snapshot key", () => {
-    store[StorageKeys.API_KEY] = "persisted-key";
-    mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
-
-    http.get("/server/config/get", { responseType: "text" }).subscribe();
-
-    const req = httpTesting.expectOne("/server/config/get");
-    expect(req.request.headers.get("X-Api-Key")).toBe("persisted-key");
-    req.flush("");
-  });
+  // --- Redacted sentinel guard (#514) ---
 
   it("should never send the redacted sentinel as a credential", () => {
-    // No persisted key, and the snapshot only holds the redacted sentinel.
+    // /server/config/get redacts the key to '********'; that must never be
+    // sent as a credential.
     mockConfigService.configSnapshot = { web: { api_key: "********" } };
 
     http.get("/server/config/get", { responseType: "text" }).subscribe();
@@ -216,20 +163,7 @@ describe("apiKeyInterceptor", () => {
     req.flush("");
   });
 
-  it("should fall back to the snapshot key when nothing is persisted", () => {
-    mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
-
-    http.get("/server/config/get", { responseType: "text" }).subscribe();
-
-    const req = httpTesting.expectOne("/server/config/get");
-    expect(req.request.headers.get("X-Api-Key")).toBe("snapshot-key");
-    req.flush("");
-  });
-
-  it("should tolerate sessionStorage throwing and fall back to the snapshot", () => {
-    mockSessionStorage.getItem.mockImplementation(() => {
-      throw new Error("denied");
-    });
+  it("should send the real snapshot key (present during the session it was set)", () => {
     mockConfigService.configSnapshot = { web: { api_key: "snapshot-key" } };
 
     http.get("/server/config/get", { responseType: "text" }).subscribe();

--- a/src/angular/src/app/services/utils/api-key.interceptor.ts
+++ b/src/angular/src/app/services/utils/api-key.interceptor.ts
@@ -3,14 +3,11 @@ import { inject } from '@angular/core';
 
 import { ConfigService } from '../settings/config.service';
 import { StorageKeys } from '../../common/storage-keys';
+import { REDACTED_SENTINEL } from '../../models/config';
 
-/**
- * Value the backend substitutes for web.api_key in /server/config/get
- * responses (see common/config.py). /server/config/get is auth-exempt, so the
- * config snapshot can hold this sentinel before the real key is known — it
- * must never be sent as a credential.
- */
-const REDACTED_SENTINEL = '********';
+// REDACTED_SENTINEL is the value the backend substitutes for web.api_key in the
+// auth-exempt /server/config/get response, so the config snapshot can hold it
+// before the real key is known — it must never be sent as a credential.
 
 function readPersistedApiKey(): string | null {
   try {

--- a/src/angular/src/app/services/utils/api-key.interceptor.ts
+++ b/src/angular/src/app/services/utils/api-key.interceptor.ts
@@ -2,21 +2,7 @@ import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 
 import { ConfigService } from '../settings/config.service';
-import { StorageKeys } from '../../common/storage-keys';
 import { REDACTED_SENTINEL } from '../../models/config';
-
-// REDACTED_SENTINEL is the value the backend substitutes for web.api_key in the
-// auth-exempt /server/config/get response, so the config snapshot can hold it
-// before the real key is known — it must never be sent as a credential.
-
-function readPersistedApiKey(): string | null {
-  try {
-    return sessionStorage.getItem(StorageKeys.API_KEY);
-  } catch {
-    // sessionStorage may be unavailable (private browsing, test environments)
-    return null;
-  }
-}
 
 export const apiKeyInterceptor: HttpInterceptorFn = (req, next) => {
   // Only attach the API key to internal backend /server/* requests
@@ -25,17 +11,13 @@ export const apiKeyInterceptor: HttpInterceptorFn = (req, next) => {
     return next(req);
   }
 
-  // Prefer the persisted real key: /server/config/get redacts web.api_key to
-  // '********', so on an auth-enabled instance the config snapshot cannot
-  // supply a usable credential after a reload. The persisted key (written by
-  // ConfigService when the user saves it) is the only client-side source of
-  // the real key, so REST requests can re-authenticate after a reload.
-  const persistedKey = readPersistedApiKey();
   const configService = inject(ConfigService);
   const snapshotKey = configService.configSnapshot?.web?.api_key;
 
-  // Never send the redacted sentinel as a credential.
-  const apiKey = persistedKey || (snapshotKey === REDACTED_SENTINEL ? null : snapshotKey);
+  // /server/config/get redacts web.api_key to '********'; never send the
+  // redacted sentinel as a credential. The real key is only present in the
+  // snapshot during the session in which the user entered it in Settings.
+  const apiKey = snapshotKey === REDACTED_SENTINEL ? null : snapshotKey;
 
   if (apiKey) {
     const authReq = req.clone({

--- a/src/angular/src/app/services/utils/api-key.interceptor.ts
+++ b/src/angular/src/app/services/utils/api-key.interceptor.ts
@@ -2,6 +2,24 @@ import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 
 import { ConfigService } from '../settings/config.service';
+import { StorageKeys } from '../../common/storage-keys';
+
+/**
+ * Value the backend substitutes for web.api_key in /server/config/get
+ * responses (see common/config.py). /server/config/get is auth-exempt, so the
+ * config snapshot can hold this sentinel before the real key is known — it
+ * must never be sent as a credential.
+ */
+const REDACTED_SENTINEL = '********';
+
+function readPersistedApiKey(): string | null {
+  try {
+    return sessionStorage.getItem(StorageKeys.API_KEY);
+  } catch {
+    // sessionStorage may be unavailable (private browsing, test environments)
+    return null;
+  }
+}
 
 export const apiKeyInterceptor: HttpInterceptorFn = (req, next) => {
   // Only attach the API key to internal backend /server/* requests
@@ -10,9 +28,17 @@ export const apiKeyInterceptor: HttpInterceptorFn = (req, next) => {
     return next(req);
   }
 
+  // Prefer the persisted real key: /server/config/get redacts web.api_key to
+  // '********', so on an auth-enabled instance the config snapshot cannot
+  // supply a usable credential after a reload. The persisted key (written by
+  // ConfigService when the user saves it) is the only client-side source of
+  // the real key, so REST requests can re-authenticate after a reload.
+  const persistedKey = readPersistedApiKey();
   const configService = inject(ConfigService);
-  const config = configService.configSnapshot;
-  const apiKey = config?.web?.api_key;
+  const snapshotKey = configService.configSnapshot?.web?.api_key;
+
+  // Never send the redacted sentinel as a credential.
+  const apiKey = persistedKey || (snapshotKey === REDACTED_SENTINEL ? null : snapshotKey);
 
   if (apiKey) {
     const authReq = req.clone({

--- a/src/python/controller/model_builder.py
+++ b/src/python/controller/model_builder.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import os
+from collections import deque
 
 from lftp import LftpJobStatus
 from model import Model, ModelError, ModelFile
@@ -236,11 +237,11 @@ class ModelBuilder:
         # for the pair
         # Note: in this case the frontier contains nodes that have already been process, it is
         #       merely used for traversing children
-        frontier: list[tuple[SystemFile | None, SystemFile | None, LftpJobStatus | None, ModelFile]] = []
+        frontier: deque[tuple[SystemFile | None, SystemFile | None, LftpJobStatus | None, ModelFile]] = deque()
         if remote or local:
             frontier.append((remote, local, status, root_model_file))
         while frontier:
-            _remote, _local, _status, _model_file = frontier.pop(0)
+            _remote, _local, _status, _model_file = frontier.popleft()
             _remote_children: dict[str, SystemFile] = {sf.name: sf for sf in _remote.children} if _remote else {}
             _local_children: dict[str, SystemFile] = {sf.name: sf for sf in _local.children} if _local else {}
             _all_children_names: set[str] = set[str]().union(_remote_children.keys(), _local_children.keys())
@@ -426,10 +427,10 @@ class ModelBuilder:
                 # root is a directory that also exists remotely
                 # check all the children
                 all_downloaded = True
-                frontier_check: list[ModelFile] = []
-                frontier_check += model_file.get_children()
+                frontier_check: deque[ModelFile] = deque()
+                frontier_check.extend(model_file.iter_children())
                 while frontier_check:
-                    _child_file = frontier_check.pop(0)
+                    _child_file = frontier_check.popleft()
                     if (
                         not _child_file.is_dir
                         and _child_file.remote_size is not None
@@ -437,7 +438,7 @@ class ModelBuilder:
                     ):
                         all_downloaded = False
                         break
-                    frontier_check += _child_file.get_children()
+                    frontier_check.extend(_child_file.iter_children())
                 if all_downloaded:
                     model_file.state = ModelFile.State.DOWNLOADED
                 else:

--- a/src/python/model/file.py
+++ b/src/python/model/file.py
@@ -2,6 +2,7 @@
 
 import copy
 import os
+from collections.abc import Iterator
 from datetime import datetime
 from enum import Enum
 from typing import Optional
@@ -260,6 +261,12 @@ class ModelFile:
 
     def get_children(self) -> list["ModelFile"]:
         return copy.copy(self.__children)
+
+    def iter_children(self) -> Iterator["ModelFile"]:
+        # Read-only iterator over the live child list, avoiding the defensive
+        # copy that get_children() makes. Callers MUST NOT mutate the child
+        # list while iterating. Use get_children() if a snapshot is needed.
+        return iter(self.__children)
 
     @property
     def parent(self) -> Optional["ModelFile"]:

--- a/src/python/tests/unittests/test_controller/test_model_builder.py
+++ b/src/python/tests/unittests/test_controller/test_model_builder.py
@@ -980,6 +980,61 @@ class TestModelBuilder(unittest.TestCase):
         m_ab = m_a_ch["ab"]
         self.assertEqual(ModelFile.State.DOWNLOADED, m_ab.state)
 
+    @staticmethod
+    def __build_deep_wide_tree(name: str, depth: int, breadth: int, leaf_size: int) -> SystemFile:
+        """Build a balanced tree `depth` levels deep with `breadth` children per dir.
+
+        Leaves (depth == 0) are files of `leaf_size`; interior nodes are directories
+        whose size is the sum of their descendants. `leaf_size` may be a callable
+        taking the dotted leaf path to vary individual leaf sizes (used to simulate
+        an incomplete branch). Exercises the BFS in _check_root_downloaded over a
+        large tree (depth=4, breadth=4 -> 256 leaves).
+        """
+        if depth == 0:
+            size = leaf_size(name) if callable(leaf_size) else leaf_size
+            return SystemFile(name, size, False)
+        children = [
+            TestModelBuilder.__build_deep_wide_tree(f"{name}.{i}", depth - 1, breadth, leaf_size)
+            for i in range(breadth)
+        ]
+        sized = SystemFile(name, sum(c.size for c in children), True)
+        for child in children:
+            sized.add_child(child)
+        return sized
+
+    def test_build_state_deep_wide_tree_downloaded(self):
+        """_check_root_downloaded over a multi-level, multi-sibling tree resolves DOWNLOADED."""
+        # 4 levels deep, 4 children per directory -> 4^4 = 256 leaves
+        remote = TestModelBuilder.__build_deep_wide_tree("a", depth=4, breadth=4, leaf_size=10)
+        local = TestModelBuilder.__build_deep_wide_tree("a", depth=4, breadth=4, leaf_size=10)
+
+        self.model_builder.set_remote_files([remote])
+        self.model_builder.set_local_files([local])
+
+        model = self.model_builder.build_model()
+        m_a = model.get_file("a")
+        # every remote leaf is fully present locally -> root is DOWNLOADED
+        self.assertEqual(ModelFile.State.DOWNLOADED, m_a.state)
+
+    def test_build_state_deep_wide_tree_incomplete_leaf(self):
+        """A single under-sized deep leaf keeps the root DEFAULT (incomplete_children)."""
+        remote = TestModelBuilder.__build_deep_wide_tree("a", depth=4, breadth=4, leaf_size=10)
+        # One specific deep leaf is only partially present locally (1 < remote 10)
+        incomplete_leaf = "a.3.3.3.3"
+
+        def local_leaf_size(leaf_name: str) -> int:
+            return 1 if leaf_name == incomplete_leaf else 10
+
+        local = TestModelBuilder.__build_deep_wide_tree("a", depth=4, breadth=4, leaf_size=local_leaf_size)
+
+        self.model_builder.set_remote_files([remote])
+        self.model_builder.set_local_files([local])
+
+        model = self.model_builder.build_model()
+        m_a = model.get_file("a")
+        # one deep leaf is not downloaded -> root cannot be DOWNLOADED
+        self.assertEqual(ModelFile.State.DEFAULT, m_a.state)
+
     def test_build_children_state_downloaded_full_extra(self):
         """Fully downloaded but with an extra local-only file"""
         r_a = SystemFile("a", 300, True)

--- a/src/python/tests/unittests/test_model/test_file.py
+++ b/src/python/tests/unittests/test_model/test_file.py
@@ -177,6 +177,17 @@ class TestModelFile(unittest.TestCase):
         file_parent.add_child(file_child2)
         self.assertEqual([file_child1, file_child2], file_parent.get_children())
 
+    def test_iter_children(self):
+        file_parent = ModelFile("parent", True)
+        file_child1 = ModelFile("child1", True)
+        file_child2 = ModelFile("child2", False)
+        self.assertEqual([], list(file_parent.iter_children()))
+        file_parent.add_child(file_child1)
+        file_parent.add_child(file_child2)
+        # iter_children yields the same elements in the same order as get_children
+        self.assertEqual(file_parent.get_children(), list(file_parent.iter_children()))
+        self.assertEqual([file_child1, file_child2], list(file_parent.iter_children()))
+
     def test_child_equality(self):
         l_a = ModelFile("a", True)
         l_a.remote_size = 3 + 1 + 2


### PR DESCRIPTION
Fixes the **⚡ Performance** bucket of tracking issue #531 (3 issues) — behavior-preserving optimizations with tests.

> [!NOTE]
> **Stacked on #538** (frontend bucket): #521/#522 touch the logs/file-list code #538 also changed, so this branch builds on it. GitHub will auto-retarget this PR to `develop` once #538 merges, at which point the diff shows only these performance commits. Intentional multi-issue grouping (per the maintainer's request), one commit per issue.

## How this was built
A multi-agent workflow: parallel investigation → sequential implementation (one tested commit per issue) → parallel adversarial review, with the review explicitly checking each optimization is **strictly behavior-preserving** (identical output, only faster), not just that tests pass.

## Issues fixed

| # | Stack | Fix |
|---|-------|-----|
| **#520** | Python | `build_model()` (every 0.5s on the controller thread) used `list.pop(0)` in two per-file BFS traversals → **O(n²)** on large trees, plus a `copy.copy` of each node's child list. Now `collections.deque` + `popleft()` (O(1)) and a non-copying `iter_children()` on the hot read-only path. Byte-identical model output; big asymptotic win on deep/wide seedbox trees. |
| **#521** | Angular | `ViewFileService` rebuilt the whole file list on every SSE update. Now coalesces SSE-driven rebuilds, memoizes the filter, and preserves `ViewFile` object identity for unchanged rows so OnPush/`trackBy` can skip them; single-pass bulk remove. Same rendered view (files, order, checked/selected state). |
| **#522** | Angular | Logs page kept an **unbounded** live buffer and re-rendered per record. Now a ring-buffer cap (newest kept, oldest front-trimmed) + a stable, collision-free `trackBy`. |

## Review findings → resolution
- **#520, #521:** passed clean — `behaviorPreserved=true`, all acceptance criteria met.
- **#522 (was blocking):** the agent's first `trackBy` keyed by `time+logger+message`, which **collides for identical repeated log lines in the same millisecond** (common under DEBUG sync) → Angular NG0955 duplicate-key reconcile drops/mis-associates rows. **Fixed** with a per-object monotonic seq key (WeakMap) — unique even for identical content, stable per object. Added a duplicate-identical-lines render guard.
- **#522 remaining ACs deferred → #539:** CDK virtual scroll and batched change detection. Virtual scroll doesn't cleanly fit the logs page's **variable-height** rows (wrapped messages + inline tracebacks) and the current window-scroll model; batching needs fake-timer tests. The ring-buffer cap (the primary unbounded-memory hazard) + collision-free trackBy ship here; the virtualization/batching enhancements are tracked in **#539**.

## Test plan
- ✅ Full Angular suite (Vitest): **473 passed** (37 files); `ng lint --max-warnings 0` clean.
- ✅ Full Python unit suite: **849 passed** (the lone failure, `test_scan_file_with_latin_chars`, is a pre-existing macOS-only `Errno 92` that passes on CI's Linux runner); `ruff check` + `C901` (complexity ≤ 12) clean.
- New tests: deeper/larger-tree BFS correctness (#520), view-rebuild coalescing + identity preservation (#521), buffer cap + duplicate-line trackBy guard (#522).

Closes #520. Closes #521. Closes #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-click confirmation for delete actions to prevent accidental deletions.

* **Bug Fixes**
  * File action errors now display notifications.
  * Log history load failures now show error messages.
  * Improved connection retry logic with exponential backoff for better stability.
  * Enhanced error recovery for malformed server data.

* **Style**
  * Added visual confirmation state styling for delete buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->