### PR TITLE
Frontend audit follow-ups: #542 #541 #539

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ Services that mutate a `BehaviorSubject` from a REST/HTTP call should follow **o
 
 `IntegrationsService` (`src/angular/src/app/services/settings/integrations.service.ts`) is the reference implementation: `create`/`update`/`remove`/`test` use `tap`/`map` to update `instancesSubject` and `catchError` to map failures to a typed result, with no second subscribe.
 
-**Known deviation (tracked):** `ConfigService.set` and `AutoQueueService.add/remove` still use the legacy `const obs = sendRequest(url); obs.subscribe({next: ...mutate...}); return obs;` pattern (a second internal subscribe). Migrating them to `tap` is **deferred**: their unit specs call `set()`/`add()`/`remove()` *without* subscribing and assert the `BehaviorSubject` mutated, which the current caller-independent subscribe makes pass. Because `RestService.sendRequest` uses `shareReplay(1)`, switching to `tap` defers the mutation to caller subscription and is **not** behavior-preserving against those unchanged tests. The migration must ship in its own PR that also updates those specs to subscribe.
+`ConfigService.set` and `AutoQueueService.add/remove` were migrated to this contract (#542): they now fold their `BehaviorSubject` mutation into the returned pipeline via `tap` (no second internal subscribe) and return the typed `WebReaction` (`RestService.sendRequest` already recovers HTTP errors into a failure `WebReaction`, so no extra `catchError` is needed). Their specs subscribe to the returned observable before asserting the subject mutated, since the mutation now defers to caller subscription. No remaining services use the legacy second-subscribe pattern.
 
 ## GitHub Repository
 

--- a/src/angular/src/app/models/model-file.spec.ts
+++ b/src/angular/src/app/models/model-file.spec.ts
@@ -57,6 +57,7 @@ describe('modelFileFromJson', () => {
       ['deleted', ModelFileState.DELETED],
       ['extracting', ModelFileState.EXTRACTING],
       ['extracted', ModelFileState.EXTRACTED],
+      ['move_failed', ModelFileState.MOVE_FAILED],
       ['DOWNLOADING', ModelFileState.DOWNLOADING],
       ['Queued', ModelFileState.QUEUED],
     ];

--- a/src/angular/src/app/models/model-file.ts
+++ b/src/angular/src/app/models/model-file.ts
@@ -32,6 +32,7 @@ export enum ModelFileState {
   VALIDATING      = 'validating',
   VALIDATED       = 'validated',
   CORRUPT         = 'corrupt',
+  MOVE_FAILED     = 'move_failed',
 }
 
 const STATE_LOOKUP: Record<string, ModelFileState> = {
@@ -46,6 +47,7 @@ const STATE_LOOKUP: Record<string, ModelFileState> = {
   VALIDATING:     ModelFileState.VALIDATING,
   VALIDATED:      ModelFileState.VALIDATED,
   CORRUPT:        ModelFileState.CORRUPT,
+  MOVE_FAILED:    ModelFileState.MOVE_FAILED,
 };
 
 /**

--- a/src/angular/src/app/models/view-file.ts
+++ b/src/angular/src/app/models/view-file.ts
@@ -43,4 +43,5 @@ export enum ViewFileStatus {
   VALIDATING      = 'validating',
   VALIDATED       = 'validated',
   CORRUPT         = 'corrupt',
+  MOVE_FAILED     = 'move_failed',
 }

--- a/src/angular/src/app/pages/files/file.component.html
+++ b/src/angular/src/app/pages/files/file.component.html
@@ -47,6 +47,9 @@
             @if (file().status === ViewFileStatus.CORRUPT) {
                 <img src="assets/icons/corrupt.svg" class="corrupt" alt="" aria-hidden="true" />
             }
+            @if (file().status === ViewFileStatus.MOVE_FAILED) {
+                <img src="assets/icons/downloaded.svg" class="move-failed" alt="" aria-hidden="true" />
+            }
             <!-- don't show text for default status -->
             @if (file().status !== ViewFileStatus.DEFAULT) {
                 <span class="text">{{file().status | capitalize}}</span>

--- a/src/angular/src/app/pages/files/file.component.scss
+++ b/src/angular/src/app/pages/files/file.component.scss
@@ -354,6 +354,7 @@
         img.validating   { filter: $tint-blue; }
         img.validated    { filter: $tint-green; }
         img.corrupt      { filter: $tint-red; }
+        img.move-failed  { filter: $tint-red; }
     }
 
     // ── Dim 0% progress rows ──

--- a/src/angular/src/app/pages/logs/logs-page.component.html
+++ b/src/angular/src/app/pages/logs/logs-page.component.html
@@ -59,27 +59,36 @@
     Scroll To Top
   </button>
 
-  <div #logHead class="log-marker"></div>
-
-  @for (record of records; track trackRecord($index, record)) {
+  <cdk-virtual-scroll-viewport [itemSize]="rowHeight" class="log-viewport">
     <p
+      *cdkVirtualFor="let record of records; trackBy: trackRecord"
       class="record"
       [class.debug]="record.level === LogLevel.DEBUG"
       [class.info]="record.level === LogLevel.INFO"
       [class.warning]="record.level === LogLevel.WARNING"
       [class.error]="record.level === LogLevel.ERROR"
-      [class.critical]="record.level === LogLevel.CRITICAL">
-      {{ record.time | date: 'yyyy/MM/dd HH:mm:ss' }} -
-      {{ record.level }} -
-      {{ record.loggerName }} -
-      {{ record.message }}
+      [class.critical]="record.level === LogLevel.CRITICAL"
+      [title]="record.message">
+      <span class="line">
+        {{ record.time | date: 'yyyy/MM/dd HH:mm:ss' }} -
+        {{ record.level }} -
+        {{ record.loggerName }} -
+        {{ record.message }}
+      </span>
       @if (record.exceptionTraceback) {
-        <span class="traceback">{{ record.exceptionTraceback }}</span>
+        <button
+          type="button"
+          class="traceback-toggle"
+          [attr.aria-expanded]="expandedTraceback === record"
+          (click)="toggleTraceback(record)">
+          {{ expandedTraceback === record ? 'Hide trace' : 'Show trace' }}
+        </button>
+        @if (expandedTraceback === record) {
+          <span class="traceback">{{ record.exceptionTraceback }}</span>
+        }
       }
     </p>
-  }
-
-  <div #logTail class="log-marker"></div>
+  </cdk-virtual-scroll-viewport>
 
   <button
     id="btn-scroll-bottom"

--- a/src/angular/src/app/pages/logs/logs-page.component.scss
+++ b/src/angular/src/app/pages/logs/logs-page.component.scss
@@ -7,7 +7,7 @@
 
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
 
     .log-filters {
         display: flex;
@@ -49,9 +49,15 @@
         margin: 10px 0;
     }
 
-    .log-marker {
+    /* CDK virtual-scroll viewport for the live log tail (#539). It scrolls
+       internally (not the window), so its height must be bounded. The 220px
+       fallback leaves room for the filters + a short history section; dvh
+       adapts to the visible viewport, vh is the older-browser fallback. */
+    .log-viewport {
         width: 100%;
-        height: 2px;
+        height: calc(100vh - 220px);
+        height: calc(100dvh - 220px);
+        min-height: 200px;
     }
 
     .btn-scroll {
@@ -98,15 +104,63 @@
             background-color: var(--ss-log-error-bg);
             border-color: var(--ss-log-error-border);
         }
+    }
 
+    /* Live-log rows are virtualized with a FIXED itemSize (#539), so each row
+       must be exactly --log-row-height tall regardless of message length or a
+       traceback. The message line is kept single-line (ellipsis + title tooltip)
+       and the traceback opens in an absolutely-positioned popover that does NOT
+       grow the row, preserving the fixed-size scroll math. Keep this height in
+       sync with LogsPageComponent.ROW_HEIGHT. */
+    .log-viewport p.record {
+        --log-row-height: 22px;
+        position: relative;
+        height: var(--log-row-height);
+        line-height: var(--log-row-height);
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 0 4px;
+
+        .line {
+            flex: 1 1 auto;
+            min-width: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+        }
+
+        .traceback-toggle {
+            flex: 0 0 auto;
+            background: none;
+            border: none;
+            padding: 0;
+            font: inherit;
+            text-decoration: underline;
+            cursor: pointer;
+            color: inherit;
+        }
+
+        /* Popover: full traceback overlaid below the row without changing the
+           row's fixed height, so the virtual-scroll itemSize stays accurate. */
         span.traceback {
+            position: absolute;
+            top: 100%;
+            left: 0;
+            right: 0;
+            z-index: 5;
             display: block;
-            white-space: pre-line;
-            margin-inline-start: 30px;
+            max-height: 240px;
+            overflow: auto;
+            white-space: pre-wrap;
+            line-height: 1.3;
+            padding: 6px 10px;
+            background-color: var(--ss-log-divider-bg, #161A21);
+            border: 1px solid var(--ss-border);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
 
             /* break up long text */
-            overflow-wrap: normal;
-            hyphens: auto;
+            overflow-wrap: anywhere;
             word-break: break-all;
         }
     }

--- a/src/angular/src/app/pages/logs/logs-page.component.spec.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ChangeDetectorRef } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { Subject, of, throwError } from 'rxjs';
+import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 
 import { LogsPageComponent } from './logs-page.component';
 import { LogService } from '../../services/logs/log.service';
@@ -24,7 +26,7 @@ describe('LogsPageComponent history failure state (#516)', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [LogsPageComponent],
+      imports: [LogsPageComponent, ScrollingModule],
       providers: [
         {
           provide: LogService,
@@ -68,12 +70,13 @@ describe('LogsPageComponent history failure state (#516)', () => {
 });
 
 /**
- * Covers #522: the live-log buffer was unbounded and re-rendered the full list
- * per incoming SSE record. The buffer is now capped (ring-buffer front-trim of
- * the oldest) and the lists use a stable, collision-free trackBy. These tests
- * drive the live subscription via a Subject-backed LogService mock.
+ * Covers #522 + #539: the live-log buffer is capped (ring-buffer front-trim of
+ * the oldest), uses a stable collision-free trackBy, AND batches incoming SSE
+ * records into one change-detection pass per window before applying them. With
+ * batching the records land in the buffer only after the auditTime window
+ * elapses, so these tests use fake timers and advance past BATCH_WINDOW_MS.
  */
-describe('LogsPageComponent live-log buffer cap (#522)', () => {
+describe('LogsPageComponent live-log buffer + batching (#522, #539)', () => {
   let fixture: ComponentFixture<LogsPageComponent>;
   let component: LogsPageComponent;
   let logs$: Subject<LogRecord>;
@@ -88,10 +91,17 @@ describe('LogsPageComponent live-log buffer cap (#522)', () => {
     };
   }
 
+  // Flush the auditTime batch window so pendingRecords drain into `records`.
+  function flushBatch(): void {
+    vi.advanceTimersByTime(LogsPageComponent.BATCH_WINDOW_MS);
+    fixture.detectChanges();
+  }
+
   beforeEach(() => {
+    vi.useFakeTimers();
     logs$ = new Subject<LogRecord>();
     TestBed.configureTestingModule({
-      imports: [LogsPageComponent],
+      imports: [LogsPageComponent, ScrollingModule],
       providers: [
         {
           provide: LogService,
@@ -105,10 +115,17 @@ describe('LogsPageComponent live-log buffer cap (#522)', () => {
     component = fixture.componentInstance;
     // ngOnInit subscribes to logs$ here.
     fixture.detectChanges();
+    // Give the virtual-scroll viewport a stable height so it renders rows.
+    const viewportEl = (fixture.nativeElement as HTMLElement)
+      .querySelector('cdk-virtual-scroll-viewport') as HTMLElement | null;
+    if (viewportEl) viewportEl.style.height = '400px';
+    component.viewport?.checkViewportSize();
+    fixture.detectChanges();
   });
 
   afterEach(() => {
     fixture.destroy();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -123,6 +140,7 @@ describe('LogsPageComponent live-log buffer cap (#522)', () => {
     logs$.next(r0);
     logs$.next(r1);
     logs$.next(r2);
+    flushBatch();
 
     expect(component.records.length).toBe(3);
     expect(component.records).toEqual([r0, r1, r2]);
@@ -135,6 +153,7 @@ describe('LogsPageComponent live-log buffer cap (#522)', () => {
       last = makeRecord(i);
       logs$.next(last);
     }
+    flushBatch();
 
     expect(component.records.length).toBe(LogsPageComponent.MAX_LIVE_RECORDS);
     // First 50 emitted records were front-trimmed away.
@@ -143,10 +162,37 @@ describe('LogsPageComponent live-log buffer cap (#522)', () => {
     expect(component.records[component.records.length - 1]).toBe(last);
   });
 
-  it('renders the latest record text after appending', () => {
+  it('batches a burst into ONE change-detection pass per window (#539)', () => {
+    // Spy on the component's own ChangeDetectorRef without touching the private
+    // field directly (strict TS forbids `component['changeDetector']`).
+    const cdr = (component as unknown as { changeDetector: ChangeDetectorRef })
+      .changeDetector;
+    const detectSpy = vi.spyOn(cdr, 'detectChanges');
+    detectSpy.mockClear();
+
+    // A flood of records within a single window.
+    for (let i = 0; i < 10; i++) {
+      logs$.next(makeRecord(i));
+    }
+    // Nothing applied yet — the records are buffered, not yet rendered.
+    expect(component.records.length).toBe(0);
+    expect(detectSpy).not.toHaveBeenCalled();
+
+    // Advance only the batch window so the audit fires; flushPendingRecords runs
+    // its OWN detectChanges synchronously here. We deliberately do NOT call
+    // fixture.detectChanges() so the spy count reflects exactly the per-window
+    // change detection.
+    vi.advanceTimersByTime(LogsPageComponent.BATCH_WINDOW_MS);
+
+    // All ten landed, but detectChanges ran once for the whole window.
+    expect(component.records.length).toBe(10);
+    expect(detectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the latest record text after the window flushes', () => {
     logs$.next(makeRecord(0));
     logs$.next(makeRecord(1));
-    fixture.detectChanges();
+    flushBatch();
 
     const text = renderedText();
     expect(text).toContain('message 1');
@@ -168,21 +214,6 @@ describe('LogsPageComponent live-log buffer cap (#522)', () => {
     expect(component.trackRecord(0, dupA)).not.toBe(component.trackRecord(1, dupB));
   });
 
-  it('renders one row per record even for identical repeated log lines', () => {
-    const a = makeRecord(0);
-    const b = { ...a }; // identical content, distinct object
-    const c = { ...a };
-    logs$.next(a);
-    logs$.next(b);
-    logs$.next(c);
-    fixture.detectChanges();
-
-    // No duplicate-key collapse: a <p class="record"> per buffered record.
-    const rows = (fixture.nativeElement as HTMLElement).querySelectorAll('p.record');
-    expect(rows.length).toBe(component.records.length);
-    expect(component.records.length).toBe(3);
-  });
-
   it('trackHistory is stable per entry object and never collides for identical entries', () => {
     const entry = { timestamp: '2026-06-01 12:00:00', level: 'INFO', logger: 'h', process: 'p', thread: 't', message: 'm' };
     const key = component.trackHistory(0, entry);
@@ -190,6 +221,271 @@ describe('LogsPageComponent live-log buffer cap (#522)', () => {
 
     const dup = { ...entry };
     expect(component.trackHistory(0, dup)).not.toBe(key);
+  });
+});
+
+/**
+ * Covers #539: the live log list is virtualized with the CDK fixed-size
+ * viewport so the rendered DOM is bounded by the viewport height rather than
+ * the 2000-record cap. These tests assert the virtual-scroll wiring and a
+ * bounded rendered range without relying on positional selectors.
+ */
+describe('LogsPageComponent virtual scroll rendering (#539)', () => {
+  let fixture: ComponentFixture<LogsPageComponent>;
+  let component: LogsPageComponent;
+  let logs$: Subject<LogRecord>;
+
+  function makeRecord(i: number): LogRecord {
+    return {
+      time: new Date(1_700_000_000_000 + i * 1000),
+      level: LogLevel.INFO,
+      loggerName: `logger-${i}`,
+      message: `message ${i}`,
+      exceptionTraceback: null,
+    };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logs$ = new Subject<LogRecord>();
+    TestBed.configureTestingModule({
+      imports: [LogsPageComponent, ScrollingModule],
+      providers: [
+        {
+          provide: LogService,
+          useValue: { logs$, fetchHistory: vi.fn().mockReturnValue(of([])) },
+        },
+        { provide: DomService, useValue: { headerHeight$: of(0) } },
+        { provide: LoggerService, useValue: loggerMock() },
+      ],
+    });
+    fixture = TestBed.createComponent(LogsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges(); // renders the viewport into the DOM
+    // Bound the viewport height so the fixed-size scroll strategy renders only a
+    // window of rows, not the full buffer.
+    const host = fixture.nativeElement as HTMLElement;
+    const viewportEl = host.querySelector('cdk-virtual-scroll-viewport') as HTMLElement | null;
+    if (viewportEl) viewportEl.style.height = '200px';
+    component.viewport?.checkViewportSize();
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the live list inside a cdk-virtual-scroll-viewport with cdkVirtualFor', () => {
+    const host = fixture.nativeElement as HTMLElement;
+    const viewport = host.querySelector('cdk-virtual-scroll-viewport');
+    expect(viewport).toBeTruthy();
+    // The viewport reports its bound data length once records are present.
+    logs$.next(makeRecord(0));
+    vi.advanceTimersByTime(LogsPageComponent.BATCH_WINDOW_MS);
+    fixture.detectChanges();
+    expect(component.viewport?.getDataLength()).toBe(component.records.length);
+  });
+
+  it('renders far fewer DOM rows than the buffered record count (bounded by viewport)', () => {
+    // Fill well past what a 200px / 22px-row viewport can show.
+    for (let i = 0; i < 500; i++) {
+      logs$.next(makeRecord(i));
+    }
+    vi.advanceTimersByTime(LogsPageComponent.BATCH_WINDOW_MS);
+    fixture.detectChanges();
+    component.viewport?.checkViewportSize();
+    fixture.detectChanges();
+
+    expect(component.records.length).toBe(500);
+    const renderedRows = (fixture.nativeElement as HTMLElement).querySelectorAll('p.record');
+    // DOM is bounded by the viewport (a small window + CDK buffer), not the cap.
+    expect(renderedRows.length).toBeLessThan(component.records.length);
+    expect(renderedRows.length).toBeLessThan(100);
+
+    // The viewport's rendered range is likewise bounded.
+    const range = component.viewport?.getRenderedRange();
+    expect(range).toBeTruthy();
+    if (range) {
+      expect(range.end - range.start).toBeLessThan(component.records.length);
+    }
+  });
+});
+
+/**
+ * Covers #539: incoming records auto-scroll the viewport to the bottom IFF the
+ * user was already pinned to the bottom; if they have scrolled up, a new batch
+ * must NOT yank them back down. The viewport is replaced with a stub so the
+ * scroll/measure calls are deterministic in jsdom.
+ */
+describe('LogsPageComponent auto-scroll-to-bottom (#539)', () => {
+  let fixture: ComponentFixture<LogsPageComponent>;
+  let component: LogsPageComponent;
+  let logs$: Subject<LogRecord>;
+
+  interface ViewportStub {
+    scrollToIndex: ReturnType<typeof vi.fn>;
+    measureScrollOffset: ReturnType<typeof vi.fn>;
+    getDataLength: ReturnType<typeof vi.fn>;
+    getRenderedRange: ReturnType<typeof vi.fn>;
+  }
+
+  function makeRecord(i: number): LogRecord {
+    return {
+      time: new Date(1_700_000_000_000 + i * 1000),
+      level: LogLevel.DEBUG,
+      loggerName: `logger-${i}`,
+      message: `message ${i}`,
+      exceptionTraceback: null,
+    };
+  }
+
+  function stubViewport(bottomOffset: number): ViewportStub {
+    const stub: ViewportStub = {
+      scrollToIndex: vi.fn(),
+      measureScrollOffset: vi.fn((from?: string) => (from === 'bottom' ? bottomOffset : 0)),
+      getDataLength: vi.fn(() => component.records.length),
+      getRenderedRange: vi.fn(() => ({ start: 0, end: 0 })),
+    };
+    // Pin the stub as the ViewChild. flushPendingRecords() runs detectChanges()
+    // before scrolling, which re-runs Angular's @ViewChild query and would
+    // overwrite a plain assignment with the real viewport. A getter (with a
+    // no-op setter that swallows Angular's write) keeps the stub in place
+    // across change detection.
+    Object.defineProperty(component, 'viewport', {
+      configurable: true,
+      get: () => stub as unknown as CdkVirtualScrollViewport,
+      set: () => undefined,
+    });
+    return stub;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logs$ = new Subject<LogRecord>();
+    TestBed.configureTestingModule({
+      imports: [LogsPageComponent, ScrollingModule],
+      providers: [
+        {
+          provide: LogService,
+          useValue: { logs$, fetchHistory: vi.fn().mockReturnValue(of([])) },
+        },
+        { provide: DomService, useValue: { headerHeight$: of(0) } },
+        { provide: LoggerService, useValue: loggerMock() },
+      ],
+    });
+    fixture = TestBed.createComponent(LogsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('scrolls to the new last index when the viewport was at the bottom', () => {
+    const stub = stubViewport(0); // bottomOffset 0 -> at bottom
+
+    logs$.next(makeRecord(0));
+    logs$.next(makeRecord(1));
+    vi.advanceTimersByTime(LogsPageComponent.BATCH_WINDOW_MS);
+
+    expect(stub.scrollToIndex).toHaveBeenCalledTimes(1);
+    expect(stub.scrollToIndex).toHaveBeenCalledWith(component.records.length - 1);
+  });
+
+  it('does NOT scroll when the user has scrolled up', () => {
+    const stub = stubViewport(500); // far from the bottom -> user scrolled up
+
+    logs$.next(makeRecord(0));
+    logs$.next(makeRecord(1));
+    vi.advanceTimersByTime(LogsPageComponent.BATCH_WINDOW_MS);
+
+    expect(stub.scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it('scrollToBottom() jumps to the last record index', () => {
+    const stub = stubViewport(500);
+    component.records = [makeRecord(0), makeRecord(1), makeRecord(2)];
+
+    component.scrollToBottom();
+
+    expect(stub.scrollToIndex).toHaveBeenCalledWith(2, 'smooth');
+  });
+
+  it('scrollToTop() jumps to the first index', () => {
+    const stub = stubViewport(500);
+
+    component.scrollToTop();
+
+    expect(stub.scrollToIndex).toHaveBeenCalledWith(0, 'smooth');
+  });
+});
+
+/**
+ * Covers #539: a record's exception traceback opens in a popover toggle so the
+ * row stays a fixed height (required by the fixed-size virtual scroll), rather
+ * than expanding inline.
+ */
+describe('LogsPageComponent traceback popover (#539)', () => {
+  let component: LogsPageComponent;
+  let fixture: ComponentFixture<LogsPageComponent>;
+
+  function makeRecord(tb: string | null): LogRecord {
+    return {
+      time: new Date(1_700_000_000_000),
+      level: LogLevel.ERROR,
+      loggerName: 'logger',
+      message: 'boom',
+      exceptionTraceback: tb,
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [LogsPageComponent, ScrollingModule],
+      providers: [
+        {
+          provide: LogService,
+          useValue: { logs$: new Subject(), fetchHistory: vi.fn().mockReturnValue(of([])) },
+        },
+        { provide: DomService, useValue: { headerHeight$: of(0) } },
+        { provide: LoggerService, useValue: loggerMock() },
+      ],
+    });
+    fixture = TestBed.createComponent(LogsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    vi.restoreAllMocks();
+  });
+
+  it('toggles the expanded traceback for a record and back off', () => {
+    const rec = makeRecord('Traceback (most recent call last): ...');
+    expect(component.expandedTraceback).toBeNull();
+
+    component.toggleTraceback(rec);
+    expect(component.expandedTraceback).toBe(rec);
+
+    component.toggleTraceback(rec);
+    expect(component.expandedTraceback).toBeNull();
+  });
+
+  it('switches the expansion to a different record', () => {
+    const a = makeRecord('trace a');
+    const b = makeRecord('trace b');
+
+    component.toggleTraceback(a);
+    expect(component.expandedTraceback).toBe(a);
+
+    component.toggleTraceback(b);
+    expect(component.expandedTraceback).toBe(b);
   });
 });
 
@@ -205,7 +501,7 @@ describe('LogsPageComponent history fetch failure (real pipe, #516)', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     TestBed.configureTestingModule({
-      imports: [LogsPageComponent],
+      imports: [LogsPageComponent, ScrollingModule],
       providers: [
         {
           provide: LogService,

--- a/src/angular/src/app/pages/logs/logs-page.component.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.ts
@@ -1,11 +1,9 @@
 import {
-  AfterViewChecked,
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
-  ElementRef,
-  HostListener,
   OnInit,
   OnDestroy,
   ViewChild,
@@ -14,8 +12,13 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import {
+  CdkFixedSizeVirtualScroll,
+  CdkVirtualForOf,
+  CdkVirtualScrollViewport,
+} from '@angular/cdk/scrolling';
 import { Subject } from 'rxjs';
-import { debounceTime, switchMap, catchError } from 'rxjs/operators';
+import { auditTime, debounceTime, switchMap, catchError } from 'rxjs/operators';
 import { of } from 'rxjs';
 
 import { LogService, LogHistoryEntry } from '../../services/logs/log.service';
@@ -26,12 +29,18 @@ import { LoggerService } from '../../services/utils/logger.service';
 @Component({
   selector: 'app-logs-page',
   standalone: true,
-  imports: [DatePipe, FormsModule],
+  imports: [
+    DatePipe,
+    FormsModule,
+    CdkVirtualScrollViewport,
+    CdkFixedSizeVirtualScroll,
+    CdkVirtualForOf,
+  ],
   templateUrl: './logs-page.component.html',
   styleUrls: ['./logs-page.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
+export class LogsPageComponent implements OnInit, OnDestroy, AfterViewInit {
   readonly LogLevel = LogLevel;
 
   /**
@@ -44,7 +53,26 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
    */
   static readonly MAX_LIVE_RECORDS = 2000;
 
-  private readonly elementRef = inject(ElementRef);
+  /**
+   * Fixed row height (px) for the CDK virtual-scroll viewport (#539). The live
+   * list is virtualized with `CdkFixedSizeVirtualScroll`, so every row MUST be
+   * exactly this tall or the viewport's scroll math drifts (rows clip/overlap).
+   * To keep rows uniform: the message is rendered single-line (truncated with
+   * ellipsis, full text in `title`) and an exception traceback is shown in an
+   * absolutely-positioned popover (see toggleTraceback) rather than expanding
+   * the row inline. Keep this in sync with `p.record` height in the SCSS.
+   */
+  static readonly ROW_HEIGHT = 22;
+
+  /**
+   * Window (ms) over which incoming SSE records are batched before a single
+   * change-detection pass (#539). Under high-throughput DEBUG sync the stream
+   * emits many records per frame; running `detectChanges()` per record pegs the
+   * main thread. `auditTime` coalesces a burst into one render. ~16ms ≈ one
+   * frame at 60fps.
+   */
+  static readonly BATCH_WINDOW_MS = 16;
+
   private readonly changeDetector = inject(ChangeDetectorRef);
   private readonly logService = inject(LogService);
   private readonly domService = inject(DomService);
@@ -52,6 +80,10 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   private readonly logger = inject(LoggerService);
 
   readonly headerHeight$ = this.domService.headerHeight$;
+
+  // Template-accessible alias of the static fixed row height (Angular templates
+  // cannot read static class members).
+  readonly rowHeight = LogsPageComponent.ROW_HEIGHT;
 
   records: LogRecord[] = [];
   historyRecords: LogHistoryEntry[] = [];
@@ -63,10 +95,15 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
   showScrollToTopButton = false;
   showScrollToBottomButton = false;
 
-  @ViewChild('logHead') logHead!: ElementRef<HTMLElement>;
-  @ViewChild('logTail') logTail!: ElementRef<HTMLElement>;
+  /** Record whose traceback popover is currently open (object identity), or null. */
+  expandedTraceback: LogRecord | null = null;
 
-  private pendingScrollToBottom = false;
+  @ViewChild(CdkVirtualScrollViewport) viewport?: CdkVirtualScrollViewport;
+
+  // Records arriving since the last flushed change-detection window (#539). The
+  // batch pipe drains this into `records` once per BATCH_WINDOW_MS.
+  private pendingRecords: LogRecord[] = [];
+  private readonly recordBatch$ = new Subject<void>();
   private readonly searchChange$ = new Subject<void>();
 
   // Per-object monotonic trackBy keys (#522) — unique even for identical log
@@ -81,25 +118,21 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
       takeUntilDestroyed(this.destroyRef),
     ).subscribe({
       next: (record) => {
-        const shouldScroll =
-          this.elementRef.nativeElement.offsetParent != null &&
-          this.logTail &&
-          LogsPageComponent.isElementInViewport(this.logTail.nativeElement);
-
-        const next = [...this.records, record];
-        // Front-trim the oldest on overflow so the newest record is never
-        // dropped (#522). Below the cap this slice is a no-op.
-        this.records = next.length > LogsPageComponent.MAX_LIVE_RECORDS
-          ? next.slice(next.length - LogsPageComponent.MAX_LIVE_RECORDS)
-          : next;
-        this.changeDetector.detectChanges();
-
-        if (shouldScroll) {
-          this.pendingScrollToBottom = true;
-        }
-        this.refreshScrollButtonVisibility();
+        // Buffer the record and signal the batch pipe; the actual list mutation
+        // and change detection happen once per window (#539), not per record.
+        this.pendingRecords.push(record);
+        this.recordBatch$.next();
       },
     });
+
+    // Batch incoming records: at most one change-detection pass per window even
+    // under a flood of SSE events (#539). auditTime emits on the trailing edge,
+    // so the first record schedules a flush and any records arriving within the
+    // window ride along on that same flush.
+    this.recordBatch$.pipe(
+      auditTime(LogsPageComponent.BATCH_WINDOW_MS),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(() => this.flushPendingRecords());
 
     this.searchChange$.pipe(
       debounceTime(300),
@@ -131,29 +164,34 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
     this.searchChange$.next();
   }
 
+  ngAfterViewInit(): void {
+    // The viewport scroll position (not the window) now drives scroll-button
+    // visibility (#539). Subscribe outside the SSE batch so manual user scrolls
+    // also keep the buttons in sync.
+    const viewport = this.viewport;
+    if (!viewport) return;
+    viewport.elementScrolled().pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(() => {
+      this.refreshScrollButtonVisibility();
+      this.changeDetector.markForCheck();
+    });
+    this.refreshScrollButtonVisibility();
+    this.changeDetector.markForCheck();
+  }
+
   ngOnDestroy(): void {
+    this.recordBatch$.complete();
     this.searchChange$.complete();
   }
 
-  ngAfterViewChecked(): void {
-    if (this.pendingScrollToBottom) {
-      this.pendingScrollToBottom = false;
-      this.scrollToBottom();
-    }
-    this.refreshScrollButtonVisibility();
-  }
-
   scrollToTop(): void {
-    window.scrollTo(0, 0);
+    this.viewport?.scrollToIndex(0, 'smooth');
   }
 
   scrollToBottom(): void {
-    window.scrollTo(0, document.body.scrollHeight);
-  }
-
-  @HostListener('window:scroll')
-  checkScroll(): void {
-    this.refreshScrollButtonVisibility();
+    const lastIndex = Math.max(0, this.records.length - 1);
+    this.viewport?.scrollToIndex(lastIndex, 'smooth');
   }
 
   onSearchChange(): void {
@@ -164,6 +202,12 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
     this.searchChange$.next();
   }
 
+  /** Toggle the absolutely-positioned traceback popover for a record (#539). */
+  toggleTraceback(record: LogRecord): void {
+    this.expandedTraceback = this.expandedTraceback === record ? null : record;
+    this.changeDetector.markForCheck();
+  }
+
   /**
    * Stable, collision-free trackBy for the live-log list (#522). A monotonic
    * sequence id is assigned per record *object* (via a WeakMap), so identical
@@ -172,15 +216,19 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
    * keys would collide there and trip Angular's duplicate-key reconcile
    * (NG0955), dropping/mis-associating rows. Keying by object identity lets
    * Angular reuse DOM nodes when the buffer is front-trimmed.
+   *
+   * Defined as an arrow field so `this` stays bound when passed by reference to
+   * `*cdkVirtualFor`'s `trackBy` (#539) — CDK invokes the TrackByFunction
+   * without the component as receiver.
    */
-  trackRecord(_index: number, record: LogRecord): number {
+  readonly trackRecord = (_index: number, record: LogRecord): number => {
     let key = this.recordKey.get(record);
     if (key === undefined) {
       key = this.liveSeq++;
       this.recordKey.set(record, key);
     }
     return key;
-  }
+  };
 
   /** Stable, collision-free trackBy for the history list (#522); see trackRecord. */
   trackHistory(_index: number, entry: LogHistoryEntry): number {
@@ -192,23 +240,61 @@ export class LogsPageComponent implements OnInit, OnDestroy, AfterViewChecked {
     return key;
   }
 
-  private refreshScrollButtonVisibility(): void {
-    if (!this.logHead || !this.logTail) return;
-    this.showScrollToTopButton = !LogsPageComponent.isElementInViewport(
-      this.logHead.nativeElement,
-    );
-    this.showScrollToBottomButton = !LogsPageComponent.isElementInViewport(
-      this.logTail.nativeElement,
-    );
+  /**
+   * Drain the pending SSE records into the live buffer in a single pass (#539).
+   * Auto-scroll-to-bottom is preserved by sampling "was the viewport pinned to
+   * the bottom?" BEFORE applying the batch, then re-pinning afterward only if it
+   * was. OnPush: this runs inside an async (auditTime) callback, so we must
+   * explicitly run change detection.
+   */
+  private flushPendingRecords(): void {
+    if (this.pendingRecords.length === 0) return;
+
+    const wasAtBottom = this.isViewportAtBottom();
+
+    const next = [...this.records, ...this.pendingRecords];
+    this.pendingRecords = [];
+    // Front-trim the oldest on overflow so the newest record is never dropped
+    // (#522). Below the cap this slice is a no-op.
+    this.records = next.length > LogsPageComponent.MAX_LIVE_RECORDS
+      ? next.slice(next.length - LogsPageComponent.MAX_LIVE_RECORDS)
+      : next;
+
+    // Synchronous CD so the viewport's data length is up to date before we ask
+    // it to scroll to the new last index.
+    this.changeDetector.detectChanges();
+
+    if (wasAtBottom) {
+      this.viewport?.scrollToIndex(Math.max(0, this.records.length - 1));
+    }
+    this.refreshScrollButtonVisibility();
   }
 
-  private static isElementInViewport(el: HTMLElement): boolean {
-    const rect = el.getBoundingClientRect();
-    return (
-      rect.top >= 0 &&
-      rect.left >= 0 &&
-      rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-      rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-    );
+  /**
+   * True when the viewport is scrolled to (or near) the bottom. Uses the CDK
+   * viewport's own scroll metrics rather than window/getBoundingClientRect
+   * (#539). A small slack absorbs sub-pixel rounding so auto-scroll stays
+   * sticky once the user is at the tail.
+   */
+  private isViewportAtBottom(): boolean {
+    const viewport = this.viewport;
+    if (!viewport) return true; // no viewport yet -> default to pinned
+    // measureScrollOffset('bottom') is the distance from the scrolled content's
+    // bottom to the viewport's bottom edge; 0 means fully scrolled down.
+    return viewport.measureScrollOffset('bottom') <= LogsPageComponent.ROW_HEIGHT;
+  }
+
+  private refreshScrollButtonVisibility(): void {
+    const viewport = this.viewport;
+    if (!viewport) {
+      this.showScrollToTopButton = false;
+      this.showScrollToBottomButton = false;
+      return;
+    }
+    const hasOverflow = viewport.measureScrollOffset('top') +
+      viewport.measureScrollOffset('bottom') > 0;
+    this.showScrollToTopButton = hasOverflow && viewport.measureScrollOffset('top') > 0;
+    this.showScrollToBottomButton =
+      hasOverflow && viewport.measureScrollOffset('bottom') > 0;
   }
 }

--- a/src/angular/src/app/services/autoqueue/autoqueue.service.spec.ts
+++ b/src/angular/src/app/services/autoqueue/autoqueue.service.spec.ts
@@ -121,8 +121,35 @@ describe('AutoQueueService', () => {
       of(makeReaction({ success: true })),
     );
 
-    service.add('*.mkv');
+    // The tap-based contract defers the mutation to caller subscription.
+    let result: WebReaction | undefined;
+    service.add('*.mkv').subscribe(r => result = r);
+
+    expect(result!.success).toBe(true);
     expect(snapshot()).toEqual([{ pattern: '*.mkv' }]);
+  });
+
+  it('should append to the pattern list exactly once per caller subscription', () => {
+    mockRestService.sendRequest.mockReturnValueOnce(
+      of(makeReaction({ success: true, data: JSON.stringify([]) })),
+    );
+    connectedSubject.next(true);
+
+    mockRestService.sendRequest.mockReturnValue(
+      of(makeReaction({ success: true })),
+    );
+
+    // Count patterns$ emissions caused by add(). Subscribing first records the
+    // baseline (the current empty list).
+    const emitted: AutoQueuePattern[][] = [];
+    service.patterns$.subscribe(p => emitted.push(p));
+    const baseline = emitted.length;
+
+    service.add('*.mkv').subscribe();
+
+    // No second internal subscribe means the subject mutates exactly once.
+    expect(emitted.length - baseline).toBe(1);
+    expect(emitted[emitted.length - 1]).toEqual([{ pattern: '*.mkv' }]);
   });
 
   it('should send double-encoded URL for add', () => {
@@ -135,7 +162,7 @@ describe('AutoQueueService', () => {
       of(makeReaction({ success: true })),
     );
 
-    service.add('my pattern');
+    service.add('my pattern').subscribe();
 
     const encoded = encodeURIComponent(encodeURIComponent('my pattern'));
     expect(mockRestService.sendRequest).toHaveBeenCalledWith(`/server/autoqueue/add/${encoded}`);
@@ -151,7 +178,10 @@ describe('AutoQueueService', () => {
       of(makeReaction({ success: false, errorMessage: 'Server error' })),
     );
 
-    service.add('*.mkv');
+    let result: WebReaction | undefined;
+    service.add('*.mkv').subscribe(r => result = r);
+
+    expect(result!.success).toBe(false);
     expect(snapshot()).toEqual([]);
   });
 
@@ -165,7 +195,7 @@ describe('AutoQueueService', () => {
       of(makeReaction({ success: true })),
     );
 
-    service.add('test/path&name');
+    service.add('test/path&name').subscribe();
 
     const encoded = encodeURIComponent(encodeURIComponent('test/path&name'));
     expect(mockRestService.sendRequest).toHaveBeenCalledWith(`/server/autoqueue/add/${encoded}`);
@@ -184,7 +214,10 @@ describe('AutoQueueService', () => {
       of(makeReaction({ success: true })),
     );
 
-    service.remove('*.mkv');
+    let result: WebReaction | undefined;
+    service.remove('*.mkv').subscribe(r => result = r);
+
+    expect(result!.success).toBe(true);
     expect(snapshot()).toEqual([{ pattern: '*.avi' }]);
   });
 
@@ -198,7 +231,10 @@ describe('AutoQueueService', () => {
       of(makeReaction({ success: false, errorMessage: 'Server error' })),
     );
 
-    service.remove('*.mkv');
+    let result: WebReaction | undefined;
+    service.remove('*.mkv').subscribe(r => result = r);
+
+    expect(result!.success).toBe(false);
     expect(snapshot()).toEqual([{ pattern: '*.mkv' }]);
   });
 

--- a/src/angular/src/app/services/autoqueue/autoqueue.service.ts
+++ b/src/angular/src/app/services/autoqueue/autoqueue.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 import { ConnectedService } from '../utils/connected.service';
 import { LoggerService } from '../utils/logger.service';
@@ -55,16 +56,18 @@ export class AutoQueueService {
     // Double-encode the value
     const patternEncoded = encodeURIComponent(encodeURIComponent(pattern));
     const url = this.AUTOQUEUE_ADD_URL(patternEncoded);
-    const obs = this.restService.sendRequest(url);
-    obs.subscribe({
-      next: (reaction) => {
+    // Update the subject inside the returned pipeline (tap) per the mutating-
+    // service contract: the store updates exactly when the caller subscribes,
+    // with no second internal subscribe. sendRequest already recovers HTTP
+    // errors into a failure WebReaction, so no extra catchError is needed.
+    return this.restService.sendRequest(url).pipe(
+      tap((reaction) => {
         if (reaction.success) {
           const patterns = this.patternsSubject.getValue();
           this.patternsSubject.next([...patterns, { pattern }]);
         }
-      },
-    });
-    return obs;
+      }),
+    );
   }
 
   remove(pattern: string): Observable<WebReaction> {
@@ -83,9 +86,12 @@ export class AutoQueueService {
     // Double-encode the value
     const patternEncoded = encodeURIComponent(encodeURIComponent(pattern));
     const url = this.AUTOQUEUE_REMOVE_URL(patternEncoded);
-    const obs = this.restService.sendRequest(url);
-    obs.subscribe({
-      next: (reaction) => {
+    // Update the subject inside the returned pipeline (tap) per the mutating-
+    // service contract: the store updates exactly when the caller subscribes,
+    // with no second internal subscribe. sendRequest already recovers HTTP
+    // errors into a failure WebReaction, so no extra catchError is needed.
+    return this.restService.sendRequest(url).pipe(
+      tap((reaction) => {
         if (reaction.success) {
           const patterns = this.patternsSubject.getValue();
           const finalIndex = patterns.findIndex((pat) => pat.pattern === pattern);
@@ -96,9 +102,8 @@ export class AutoQueueService {
             ]);
           }
         }
-      },
-    });
-    return obs;
+      }),
+    );
   }
 
   private getPatterns(): void {

--- a/src/angular/src/app/services/files/view-file-capabilities.spec.ts
+++ b/src/angular/src/app/services/files/view-file-capabilities.spec.ts
@@ -27,6 +27,7 @@ describe('view-file-capabilities', () => {
       [ModelFileState.VALIDATING, ViewFileStatus.VALIDATING],
       [ModelFileState.VALIDATED, ViewFileStatus.VALIDATED],
       [ModelFileState.CORRUPT, ViewFileStatus.CORRUPT],
+      [ModelFileState.MOVE_FAILED, ViewFileStatus.MOVE_FAILED],
     ];
 
     for (const [state, expected] of directCases) {
@@ -164,6 +165,19 @@ describe('view-file-capabilities', () => {
     it('does not show a tooltip for a non-validatable status with null remote', () => {
       const caps = deriveCapabilities(ViewFileStatus.QUEUED, 100, 0, 100, null);
       expect(caps.validateTooltip).toBeNull();
+    });
+
+    it('exposes no actions for MOVE_FAILED (surfaced state only; backend auto-retries the move)', () => {
+      const caps = deriveCapabilities(ViewFileStatus.MOVE_FAILED, 100, 100, 100, 100);
+      expect(caps).toEqual({
+        isQueueable: false,
+        isStoppable: false,
+        isExtractable: false,
+        isLocallyDeletable: false,
+        isRemotelyDeletable: false,
+        isValidatable: false,
+        validateTooltip: null,
+      });
     });
   });
 

--- a/src/angular/src/app/services/files/view-file-capabilities.ts
+++ b/src/angular/src/app/services/files/view-file-capabilities.ts
@@ -112,6 +112,8 @@ export function mapState(state: ModelFileState, localSize: number, remoteSize: n
       return ViewFileStatus.VALIDATED;
     case ModelFileState.CORRUPT:
       return ViewFileStatus.CORRUPT;
+    case ModelFileState.MOVE_FAILED:
+      return ViewFileStatus.MOVE_FAILED;
     default:
       return ViewFileStatus.DEFAULT;
   }

--- a/src/angular/src/app/services/files/view-file-command.service.spec.ts
+++ b/src/angular/src/app/services/files/view-file-command.service.spec.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { ViewFileCommandService, ModelFileResolver } from './view-file-command.service';
+import { ModelFileService } from './model-file.service';
+import { ViewFileSelectionService } from './view-file-selection.service';
+import { LoggerService } from '../utils/logger.service';
+import { ModelFile, ModelFileState } from '../../models/model-file';
+import { ViewFile, ViewFileStatus } from '../../models/view-file';
+import { WebReaction } from '../utils/rest.service';
+import { fileKey } from './file-key';
+
+function makeModelFile(overrides: Partial<ModelFile> & { name: string }): ModelFile {
+  return {
+    pair_id: null,
+    is_dir: false,
+    local_size: 0,
+    remote_size: 0,
+    state: ModelFileState.DEFAULT,
+    downloading_speed: 0,
+    eta: 0,
+    full_path: '/path/' + overrides.name,
+    is_extractable: false,
+    local_created_timestamp: null,
+    local_modified_timestamp: null,
+    remote_created_timestamp: null,
+    remote_modified_timestamp: null,
+    children: [],
+    ...overrides,
+  };
+}
+
+function makeViewFile(overrides: Partial<ViewFile> & { name: string }): ViewFile {
+  return {
+    pairId: null,
+    pairName: null,
+    isDir: false,
+    localSize: 0,
+    remoteSize: 0,
+    percentDownloaded: 0,
+    status: ViewFileStatus.DEFAULT,
+    downloadingSpeed: 0,
+    eta: 0,
+    fullPath: '/path/' + overrides.name,
+    isArchive: false,
+    isSelected: false,
+    isChecked: false,
+    isQueueable: false,
+    isStoppable: false,
+    isExtractable: false,
+    isLocallyDeletable: false,
+    isRemotelyDeletable: false,
+    isValidatable: false,
+    validateTooltip: null,
+    localCreatedTimestamp: null,
+    localModifiedTimestamp: null,
+    remoteCreatedTimestamp: null,
+    remoteModifiedTimestamp: null,
+    ...overrides,
+  };
+}
+
+const OK: WebReaction = { success: true, data: null, errorMessage: null };
+
+describe('ViewFileCommandService', () => {
+  let service: ViewFileCommandService;
+  let selection: ViewFileSelectionService;
+  let mockModelFileService: {
+    queue: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    extract: ReturnType<typeof vi.fn>;
+    deleteLocal: ReturnType<typeof vi.fn>;
+    deleteRemote: ReturnType<typeof vi.fn>;
+    validate: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockModelFileService = {
+      queue: vi.fn().mockReturnValue(of(OK)),
+      stop: vi.fn().mockReturnValue(of(OK)),
+      extract: vi.fn().mockReturnValue(of(OK)),
+      deleteLocal: vi.fn().mockReturnValue(of(OK)),
+      deleteRemote: vi.fn().mockReturnValue(of(OK)),
+      validate: vi.fn().mockReturnValue(of(OK)),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        ViewFileCommandService,
+        ViewFileSelectionService,
+        { provide: ModelFileService, useValue: mockModelFileService },
+        {
+          provide: LoggerService,
+          useValue: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+        },
+      ],
+    });
+    service = TestBed.inject(ViewFileCommandService);
+    selection = TestBed.inject(ViewFileSelectionService);
+  });
+
+  /** A resolver backed by a Map, mirroring ViewFileService's prevModelFiles. */
+  function resolverFor(models: ModelFile[]): ModelFileResolver {
+    const map = new Map<string, ModelFile>();
+    for (const m of models) {
+      map.set(fileKey(m.pair_id, m.name), m);
+    }
+    return (key) => map.get(key);
+  }
+
+  // --- single dispatch: resolves ViewFile -> ModelFile ---
+
+  it('queue() resolves the ViewFile to its ModelFile and dispatches it', () => {
+    const mf = makeModelFile({ name: 'file1', remote_size: 100 });
+    const vf = makeViewFile({ name: 'file1', remoteSize: 100 });
+
+    let result: WebReaction | undefined;
+    service.queue(vf, resolverFor([mf])).subscribe((r) => (result = r));
+
+    expect(mockModelFileService.queue).toHaveBeenCalledWith(mf);
+    expect(result).toEqual(OK);
+  });
+
+  it('queue() resolves the correct ModelFile when same-name files differ by pairId', () => {
+    const mfA = makeModelFile({ name: 'movie.mkv', pair_id: 'pair-a', remote_size: 100 });
+    const mfB = makeModelFile({ name: 'movie.mkv', pair_id: 'pair-b', remote_size: 200 });
+    const vfB = makeViewFile({ name: 'movie.mkv', pairId: 'pair-b', remoteSize: 200 });
+
+    service.queue(vfB, resolverFor([mfA, mfB])).subscribe();
+
+    expect(mockModelFileService.queue).toHaveBeenCalledWith(mfB);
+    expect(mockModelFileService.queue).not.toHaveBeenCalledWith(mfA);
+  });
+
+  it('returns a failure reaction (without dispatching) when the ModelFile cannot be resolved', () => {
+    const vf = makeViewFile({ name: 'missing' });
+
+    let result: WebReaction | undefined;
+    service.queue(vf, resolverFor([])).subscribe((r) => (result = r));
+
+    expect(result!.success).toBe(false);
+    expect(result!.errorMessage).toBe("File 'missing' not found");
+    expect(mockModelFileService.queue).not.toHaveBeenCalled();
+  });
+
+  it('maps an action error to a failure reaction rather than erroring the observable', () => {
+    const mf = makeModelFile({ name: 'file1' });
+    const vf = makeViewFile({ name: 'file1' });
+    mockModelFileService.stop.mockReturnValue(throwError(() => new Error('boom')));
+
+    let result: WebReaction | undefined;
+    let errored = false;
+    service.stop(vf, resolverFor([mf])).subscribe({
+      next: (r) => (result = r),
+      error: () => (errored = true),
+    });
+
+    expect(errored).toBe(false);
+    expect(result!.success).toBe(false);
+    expect(result!.errorMessage).toBe('boom');
+  });
+
+  it('each single command delegates to the matching ModelFileService method', () => {
+    const mf = makeModelFile({ name: 'file1' });
+    const vf = makeViewFile({ name: 'file1' });
+    const resolve = resolverFor([mf]);
+
+    service.stop(vf, resolve).subscribe();
+    service.extract(vf, resolve).subscribe();
+    service.deleteLocal(vf, resolve).subscribe();
+    service.deleteRemote(vf, resolve).subscribe();
+    service.validate(vf, resolve).subscribe();
+
+    expect(mockModelFileService.stop).toHaveBeenCalledWith(mf);
+    expect(mockModelFileService.extract).toHaveBeenCalledWith(mf);
+    expect(mockModelFileService.deleteLocal).toHaveBeenCalledWith(mf);
+    expect(mockModelFileService.deleteRemote).toHaveBeenCalledWith(mf);
+    expect(mockModelFileService.validate).toHaveBeenCalledWith(mf);
+  });
+
+  // --- bulk dispatch: checked + capability filter ---
+
+  it('bulkQueue() dispatches only files that are both checked AND queueable', () => {
+    const queueableChecked = makeViewFile({ name: 'a', remoteSize: 100, isQueueable: true });
+    const queueableUnchecked = makeViewFile({ name: 'b', remoteSize: 100, isQueueable: true });
+    const notQueueableChecked = makeViewFile({ name: 'c', remoteSize: 100, isQueueable: false });
+    const files = [queueableChecked, queueableUnchecked, notQueueableChecked];
+
+    // Check 'a' (queueable) and 'c' (not queueable); leave 'b' unchecked.
+    selection.toggle(fileKey(null, 'a'));
+    selection.toggle(fileKey(null, 'c'));
+
+    const models = [
+      makeModelFile({ name: 'a', remote_size: 100 }),
+      makeModelFile({ name: 'b', remote_size: 100 }),
+      makeModelFile({ name: 'c', remote_size: 100 }),
+    ];
+
+    let results: WebReaction[] = [];
+    service.bulkQueue(files, resolverFor(models)).subscribe((r) => (results = r));
+
+    // Only 'a' satisfies checked AND queueable.
+    expect(mockModelFileService.queue).toHaveBeenCalledTimes(1);
+    expect(mockModelFileService.queue).toHaveBeenCalledWith(
+      models.find((m) => m.name === 'a'),
+    );
+    expect(results).toEqual([OK]);
+  });
+
+  it('bulkStop() applies the isStoppable capability filter', () => {
+    const stoppableChecked = makeViewFile({ name: 'dl', isStoppable: true });
+    const stoppedChecked = makeViewFile({ name: 'st', isStoppable: false });
+    const files = [stoppableChecked, stoppedChecked];
+
+    selection.toggle(fileKey(null, 'dl'));
+    selection.toggle(fileKey(null, 'st'));
+
+    const models = [makeModelFile({ name: 'dl' }), makeModelFile({ name: 'st' })];
+
+    service.bulkStop(files, resolverFor(models)).subscribe();
+
+    expect(mockModelFileService.stop).toHaveBeenCalledTimes(1);
+    expect(mockModelFileService.stop).toHaveBeenCalledWith(
+      models.find((m) => m.name === 'dl'),
+    );
+  });
+
+  it('bulk action returns an empty array and dispatches nothing when no file is both checked and capable', () => {
+    const files = [makeViewFile({ name: 'a', isQueueable: true })];
+    // 'a' is queueable but NOT checked.
+
+    let results: WebReaction[] | undefined;
+    service.bulkQueue(files, resolverFor([makeModelFile({ name: 'a' })])).subscribe(
+      (r) => (results = r),
+    );
+
+    expect(results).toEqual([]);
+    expect(mockModelFileService.queue).not.toHaveBeenCalled();
+  });
+
+  it('bulkDeleteRemote() applies the isRemotelyDeletable filter', () => {
+    const deletable = makeViewFile({ name: 'r', remoteSize: 100, isRemotelyDeletable: true });
+    const notDeletable = makeViewFile({ name: 'x', isRemotelyDeletable: false });
+    const files = [deletable, notDeletable];
+
+    selection.checkAll([fileKey(null, 'r'), fileKey(null, 'x')]);
+
+    const models = [
+      makeModelFile({ name: 'r', remote_size: 100 }),
+      makeModelFile({ name: 'x' }),
+    ];
+
+    service.bulkDeleteRemote(files, resolverFor(models)).subscribe();
+
+    expect(mockModelFileService.deleteRemote).toHaveBeenCalledTimes(1);
+    expect(mockModelFileService.deleteRemote).toHaveBeenCalledWith(
+      models.find((m) => m.name === 'r'),
+    );
+  });
+});

--- a/src/angular/src/app/services/files/view-file-command.service.ts
+++ b/src/angular/src/app/services/files/view-file-command.service.ts
@@ -1,0 +1,133 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable, of, from } from 'rxjs';
+import { mergeMap, toArray } from 'rxjs/operators';
+
+import { LoggerService } from '../utils/logger.service';
+import { ModelFileService } from './model-file.service';
+import { WebReaction } from '../utils/rest.service';
+import { ModelFile } from '../../models/model-file';
+import { ViewFile } from '../../models/view-file';
+import { fileKey } from './file-key';
+import { ViewFileSelectionService } from './view-file-selection.service';
+
+function viewFileKey(vf: ViewFile): string {
+  return fileKey(vf.pairId, vf.name);
+}
+
+/** Resolves a view-file key back to its backing {@link ModelFile}, or undefined. */
+export type ModelFileResolver = (key: string) => ModelFile | undefined;
+
+/**
+ * Owns command dispatch (single + bulk) for view files.
+ *
+ * The command slice straddles two owners: it needs the diffing-owned snapshot
+ * of model files (to resolve a {@link ViewFile} back to its {@link ModelFile})
+ * AND the selection-owned checked state (for the bulk checked+capability
+ * filter). Rather than duplicating either, this service is *input-driven*:
+ *  - single dispatch takes a {@link ModelFileResolver} threaded in by the caller
+ *    (so resolution semantics stay identical to the caller's authoritative
+ *    snapshot — e.g. ViewFileService's `prevModelFiles`), and
+ *  - bulk dispatch takes the current display-order view files threaded in by the
+ *    caller, then filters them against {@link ViewFileSelectionService}'s checked
+ *    set plus a per-action capability predicate.
+ *
+ * ViewFileService delegates its command/bulk methods here so consumers keep a
+ * single facade while command logic lives in one focused place (issue #541).
+ */
+@Injectable({ providedIn: 'root' })
+export class ViewFileCommandService {
+  private readonly logger = inject(LoggerService);
+  private readonly modelFileService = inject(ModelFileService);
+  private readonly selection = inject(ViewFileSelectionService);
+
+  queue(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
+    this.logger.debug('Queue view file: ' + file.name);
+    return this.createAction(file, resolve, (f) => this.modelFileService.queue(f));
+  }
+
+  stop(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
+    this.logger.debug('Stop view file: ' + file.name);
+    return this.createAction(file, resolve, (f) => this.modelFileService.stop(f));
+  }
+
+  extract(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
+    this.logger.debug('Extract view file: ' + file.name);
+    return this.createAction(file, resolve, (f) => this.modelFileService.extract(f));
+  }
+
+  deleteLocal(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
+    this.logger.debug('Locally delete view file: ' + file.name);
+    return this.createAction(file, resolve, (f) => this.modelFileService.deleteLocal(f));
+  }
+
+  deleteRemote(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
+    this.logger.debug('Remotely delete view file: ' + file.name);
+    return this.createAction(file, resolve, (f) => this.modelFileService.deleteRemote(f));
+  }
+
+  validate(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
+    this.logger.debug('Validate view file: ' + file.name);
+    return this.createAction(file, resolve, (f) => this.modelFileService.validate(f));
+  }
+
+  bulkQueue(files: readonly ViewFile[], resolve: ModelFileResolver): Observable<WebReaction[]> {
+    return this.bulkAction(files, (f) => f.isQueueable, (f) => this.queue(f, resolve));
+  }
+
+  bulkStop(files: readonly ViewFile[], resolve: ModelFileResolver): Observable<WebReaction[]> {
+    return this.bulkAction(files, (f) => f.isStoppable, (f) => this.stop(f, resolve));
+  }
+
+  bulkDeleteLocal(files: readonly ViewFile[], resolve: ModelFileResolver): Observable<WebReaction[]> {
+    return this.bulkAction(files, (f) => f.isLocallyDeletable, (f) => this.deleteLocal(f, resolve), 4);
+  }
+
+  bulkDeleteRemote(files: readonly ViewFile[], resolve: ModelFileResolver): Observable<WebReaction[]> {
+    return this.bulkAction(files, (f) => f.isRemotelyDeletable, (f) => this.deleteRemote(f, resolve), 4);
+  }
+
+  private bulkAction(
+    files: readonly ViewFile[],
+    filter: (f: ViewFile) => boolean,
+    action: (f: ViewFile) => Observable<WebReaction>,
+    concurrency = Infinity,
+  ): Observable<WebReaction[]> {
+    const checked = files.filter((f) => this.selection.isChecked(viewFileKey(f)) && filter(f));
+    if (checked.length === 0) {
+      return of([]);
+    }
+    return from(checked).pipe(
+      mergeMap((f) => action(f), concurrency),
+      toArray(),
+    );
+  }
+
+  private createAction(
+    file: ViewFile,
+    resolve: ModelFileResolver,
+    action: (file: ModelFile) => Observable<WebReaction>,
+  ): Observable<WebReaction> {
+    return new Observable((observer) => {
+      const key = viewFileKey(file);
+      const modelFile = resolve(key);
+      if (modelFile === undefined) {
+        this.logger.error('File to queue not found: ' + key);
+        observer.next({ success: false, data: null, errorMessage: `File '${file.name}' not found` });
+        observer.complete();
+      } else {
+        action(modelFile).subscribe({
+          next: (reaction) => {
+            this.logger.debug('Received model reaction: %O', reaction);
+            observer.next(reaction);
+            observer.complete();
+          },
+          error: (err) => {
+            this.logger.error('Action failed for file: ' + key, err);
+            observer.next({ success: false, data: null, errorMessage: String(err?.message ?? err) });
+            observer.complete();
+          },
+        });
+      }
+    });
+  }
+}

--- a/src/angular/src/app/services/files/view-file-command.service.ts
+++ b/src/angular/src/app/services/files/view-file-command.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable, of, from } from 'rxjs';
-import { mergeMap, toArray } from 'rxjs/operators';
+import { mergeMap, toArray, tap, catchError } from 'rxjs/operators';
 
 import { LoggerService } from '../utils/logger.service';
 import { ModelFileService } from './model-file.service';
@@ -107,27 +107,22 @@ export class ViewFileCommandService {
     resolve: ModelFileResolver,
     action: (file: ModelFile) => Observable<WebReaction>,
   ): Observable<WebReaction> {
-    return new Observable((observer) => {
-      const key = viewFileKey(file);
-      const modelFile = resolve(key);
-      if (modelFile === undefined) {
-        this.logger.error('File to queue not found: ' + key);
-        observer.next({ success: false, data: null, errorMessage: `File '${file.name}' not found` });
-        observer.complete();
-      } else {
-        action(modelFile).subscribe({
-          next: (reaction) => {
-            this.logger.debug('Received model reaction: %O', reaction);
-            observer.next(reaction);
-            observer.complete();
-          },
-          error: (err) => {
-            this.logger.error('Action failed for file: ' + key, err);
-            observer.next({ success: false, data: null, errorMessage: String(err?.message ?? err) });
-            observer.complete();
-          },
-        });
-      }
-    });
+    const key = viewFileKey(file);
+    const modelFile = resolve(key);
+    if (modelFile === undefined) {
+      this.logger.error('File to queue not found: ' + key);
+      return of<WebReaction>({ success: false, data: null, errorMessage: `File '${file.name}' not found` });
+    }
+    // Return the inner observable's pipeline directly (no manual subscribe) so
+    // the caller's subscription drives the request and unsubscribing cancels the
+    // in-flight HTTP call. Errors are recovered in-pipeline into a failure
+    // WebReaction so the returned observable never errors.
+    return action(modelFile).pipe(
+      tap((reaction) => this.logger.debug('Received model reaction: %O', reaction)),
+      catchError((err) => {
+        this.logger.error('Action failed for file: ' + key, err);
+        return of<WebReaction>({ success: false, data: null, errorMessage: String(err?.message ?? err) });
+      }),
+    );
   }
 }

--- a/src/angular/src/app/services/files/view-file.service.ts
+++ b/src/angular/src/app/services/files/view-file.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, InjectionToken, inject } from '@angular/core';
-import { BehaviorSubject, Observable, of, from } from 'rxjs';
-import { auditTime, mergeMap, toArray } from 'rxjs/operators';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { auditTime } from 'rxjs/operators';
 
 import { LoggerService } from '../utils/logger.service';
 import { ModelFileService } from './model-file.service';
@@ -11,6 +11,7 @@ import { ViewFile } from '../../models/view-file';
 import { fileKey } from './file-key';
 import { mapState, deriveCapabilities } from './view-file-capabilities';
 import { ViewFileSelectionService } from './view-file-selection.service';
+import { ViewFileCommandService } from './view-file-command.service';
 
 /**
  * Coalescing window (ms) for batching incremental SSE model-file emissions before
@@ -44,6 +45,7 @@ export class ViewFileService {
   private readonly pathPairsService = inject(PathPairsService);
   private readonly coalesceMs = inject(VIEW_FILE_COALESCE_MS);
   private readonly selection = inject(ViewFileSelectionService);
+  private readonly commands = inject(ViewFileCommandService);
 
   private pairNameMap = new Map<string, string>();
   private files: ViewFile[] = [];
@@ -52,6 +54,11 @@ export class ViewFileService {
   private indices = new Map<string, number>();
 
   private prevModelFiles = new Map<string, ModelFile>();
+
+  // Resolve a view-file key to its backing ModelFile from the diffing-owned
+  // snapshot. Threaded into ViewFileCommandService so command dispatch keeps the
+  // exact resolution semantics this service has always used (`prevModelFiles`).
+  private readonly resolveModelFile = (key: string): ModelFile | undefined => this.prevModelFiles.get(key);
 
   private filterCriteria: ViewFileFilterCriteria | null = null;
   private sortComparator: ViewFileComparator | null = null;
@@ -146,34 +153,32 @@ export class ViewFileService {
     }
   }
 
+  // Thin facades over ViewFileCommandService — kept so existing consumers (and
+  // the existing spec) target a single service. Command dispatch lives in
+  // ViewFileCommandService (issue #541); this service threads in the
+  // diffing-owned ModelFile resolver.
   queue(file: ViewFile): Observable<WebReaction> {
-    this.logger.debug('Queue view file: ' + file.name);
-    return this.createAction(file, (f) => this.modelFileService.queue(f));
+    return this.commands.queue(file, this.resolveModelFile);
   }
 
   stop(file: ViewFile): Observable<WebReaction> {
-    this.logger.debug('Stop view file: ' + file.name);
-    return this.createAction(file, (f) => this.modelFileService.stop(f));
+    return this.commands.stop(file, this.resolveModelFile);
   }
 
   extract(file: ViewFile): Observable<WebReaction> {
-    this.logger.debug('Extract view file: ' + file.name);
-    return this.createAction(file, (f) => this.modelFileService.extract(f));
+    return this.commands.extract(file, this.resolveModelFile);
   }
 
   deleteLocal(file: ViewFile): Observable<WebReaction> {
-    this.logger.debug('Locally delete view file: ' + file.name);
-    return this.createAction(file, (f) => this.modelFileService.deleteLocal(f));
+    return this.commands.deleteLocal(file, this.resolveModelFile);
   }
 
   deleteRemote(file: ViewFile): Observable<WebReaction> {
-    this.logger.debug('Remotely delete view file: ' + file.name);
-    return this.createAction(file, (f) => this.modelFileService.deleteRemote(f));
+    return this.commands.deleteRemote(file, this.resolveModelFile);
   }
 
   validate(file: ViewFile): Observable<WebReaction> {
-    this.logger.debug('Validate view file: ' + file.name);
-    return this.createAction(file, (f) => this.modelFileService.validate(f));
+    return this.commands.validate(file, this.resolveModelFile);
   }
 
   toggleCheck(file: ViewFile): void {
@@ -219,35 +224,22 @@ export class ViewFileService {
     this.pushViewFiles();
   }
 
+  // Thin facades over ViewFileCommandService — thread in the current display
+  // list so the command service can apply its checked + capability filter.
   bulkQueue(): Observable<WebReaction[]> {
-    return this.bulkAction(f => f.isQueueable, f => this.queue(f));
+    return this.commands.bulkQueue(this.files, this.resolveModelFile);
   }
 
   bulkStop(): Observable<WebReaction[]> {
-    return this.bulkAction(f => f.isStoppable, f => this.stop(f));
+    return this.commands.bulkStop(this.files, this.resolveModelFile);
   }
 
   bulkDeleteLocal(): Observable<WebReaction[]> {
-    return this.bulkAction(f => f.isLocallyDeletable, f => this.deleteLocal(f), 4);
+    return this.commands.bulkDeleteLocal(this.files, this.resolveModelFile);
   }
 
   bulkDeleteRemote(): Observable<WebReaction[]> {
-    return this.bulkAction(f => f.isRemotelyDeletable, f => this.deleteRemote(f), 4);
-  }
-
-  private bulkAction(
-    filter: (f: ViewFile) => boolean,
-    action: (f: ViewFile) => Observable<WebReaction>,
-    concurrency = Infinity
-  ): Observable<WebReaction[]> {
-    const checked = this.files.filter(f => this.selection.isChecked(viewFileKey(f)) && filter(f));
-    if (checked.length === 0) {
-      return of([]);
-    }
-    return from(checked).pipe(
-      mergeMap(f => action(f), concurrency),
-      toArray()
-    );
+    return this.commands.bulkDeleteRemote(this.files, this.resolveModelFile);
   }
 
   setFilterCriteria(criteria: ViewFileFilterCriteria | null): void {
@@ -347,34 +339,6 @@ export class ViewFileService {
     this.pushViewFiles();
     this.prevModelFiles = modelFiles;
     this.logger.debug('New view model: %O', this.files);
-  }
-
-  private createAction(
-    file: ViewFile,
-    action: (file: ModelFile) => Observable<WebReaction>,
-  ): Observable<WebReaction> {
-    return new Observable((observer) => {
-      const key = viewFileKey(file);
-      if (!this.prevModelFiles.has(key)) {
-        this.logger.error('File to queue not found: ' + key);
-        observer.next({ success: false, data: null, errorMessage: `File '${file.name}' not found` });
-        observer.complete();
-      } else {
-        const modelFile = this.prevModelFiles.get(key)!;
-        action(modelFile).subscribe({
-          next: (reaction) => {
-            this.logger.debug('Received model reaction: %O', reaction);
-            observer.next(reaction);
-            observer.complete();
-          },
-          error: (err) => {
-            this.logger.error('Action failed for file: ' + key, err);
-            observer.next({ success: false, data: null, errorMessage: String(err?.message ?? err) });
-            observer.complete();
-          },
-        });
-      }
-    });
   }
 
   private pushViewFiles(): void {

--- a/src/angular/src/app/services/settings/config.service.spec.ts
+++ b/src/angular/src/app/services/settings/config.service.spec.ts
@@ -221,9 +221,10 @@ describe("ConfigService", () => {
     );
     createService();
 
-    // The user enters the real key in Settings.
+    // The user enters the real key in Settings. The mutating-service contract
+    // defers the subject update to caller subscription, so subscribe here.
     mockRestService.sendRequest.mockReturnValueOnce(of({ success: true, data: null, errorMessage: null }));
-    service.set("web", "api_key", "new-key");
+    service.set("web", "api_key", "new-key").subscribe();
     expect(service.configSnapshot?.web?.api_key).toBe("new-key");
 
     // A later config refresh returns the redacted sentinel. It must NOT clobber
@@ -242,9 +243,9 @@ describe("ConfigService", () => {
     );
     createService();
 
-    // The user clears the key.
+    // The user clears the key. Subscribe so the tap-based mutation fires.
     mockRestService.sendRequest.mockReturnValueOnce(of({ success: true, data: null, errorMessage: null }));
-    service.set("web", "api_key", "");
+    service.set("web", "api_key", "").subscribe();
     expect(service.configSnapshot?.web?.api_key).toBe("");
 
     // The backend redacts even an empty key to the sentinel on refresh; the
@@ -380,7 +381,7 @@ describe("ConfigService", () => {
     createService();
     connectedSubject.next(true);
 
-    service.set("web", "api_key", "my/key");
+    service.set("web", "api_key", "my/key").subscribe();
 
     const encoded = encodeURIComponent(encodeURIComponent("my/key"));
     expect(mockRestService.sendRequest).toHaveBeenCalledWith(
@@ -403,7 +404,7 @@ describe("ConfigService", () => {
     createService();
     connectedSubject.next(true);
 
-    service.set("web", "api_key", "");
+    service.set("web", "api_key", "").subscribe();
 
     expect(mockRestService.sendRequest).toHaveBeenCalledWith(
       `/server/config/set/web/api_key/${EMPTY_VALUE_SENTINEL}`,
@@ -427,7 +428,7 @@ describe("ConfigService", () => {
     createService();
     connectedSubject.next(true);
 
-    service.set("web", "api_key", "new-key");
+    service.set("web", "api_key", "new-key").subscribe();
 
     // set() is the only place the real key is available client-side; it is
     // pushed to the stream (but not persisted anywhere).
@@ -449,9 +450,40 @@ describe("ConfigService", () => {
     createService();
     connectedSubject.next(true);
 
-    service.set("web", "api_key", "new-key");
+    // The tap-based contract defers the mutation to caller subscription.
+    let result: WebReaction | undefined;
+    service.set("web", "api_key", "new-key").subscribe((r) => (result = r));
 
+    expect(result!.success).toBe(true);
     expect(service.configSnapshot!.web.api_key).toBe("new-key");
+  });
+
+  it("should update the config subject exactly once per caller subscription", () => {
+    const config = makeConfig({ web: { port: 8080, api_key: "old" } });
+    mockRestService.sendRequest
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: JSON.stringify(config), errorMessage: null }),
+      )
+      .mockReturnValueOnce(
+        of({ success: true, data: null, errorMessage: null }),
+      );
+    createService();
+    connectedSubject.next(true);
+
+    // Count config$ emissions caused by the set(). The subject already holds the
+    // init config, so subscribing first records the baseline emission.
+    const emitted: (Config | null)[] = [];
+    service.config$.subscribe((c) => emitted.push(c));
+    const baseline = emitted.length;
+
+    service.set("web", "api_key", "new-key").subscribe();
+
+    // No second internal subscribe means the subject mutates exactly once.
+    expect(emitted.length - baseline).toBe(1);
+    expect(emitted[emitted.length - 1]!.web.api_key).toBe("new-key");
   });
 
   it("should not update BehaviorSubject when set request fails", () => {
@@ -469,8 +501,10 @@ describe("ConfigService", () => {
     createService();
     connectedSubject.next(true);
 
-    service.set("web", "api_key", "new-key");
+    let result: WebReaction | undefined;
+    service.set("web", "api_key", "new-key").subscribe((r) => (result = r));
 
+    expect(result!.success).toBe(false);
     expect(service.configSnapshot!.web.api_key).toBe("old");
   });
 
@@ -490,7 +524,7 @@ describe("ConfigService", () => {
     connectedSubject.next(true);
     mockStreamDispatch.setApiKey.mockClear();
 
-    service.set("web", "api_key", "new-key");
+    service.set("web", "api_key", "new-key").subscribe();
 
     expect(mockStreamDispatch.setApiKey).toHaveBeenCalledWith("new-key");
   });
@@ -510,7 +544,7 @@ describe("ConfigService", () => {
     createService();
     connectedSubject.next(true);
 
-    service.set("autoqueue", "enabled", true);
+    service.set("autoqueue", "enabled", true).subscribe();
 
     const encoded = encodeURIComponent(encodeURIComponent("true"));
     expect(mockRestService.sendRequest).toHaveBeenCalledWith(
@@ -534,7 +568,7 @@ describe("ConfigService", () => {
     createService();
     connectedSubject.next(true);
 
-    service.set("autoqueue", "enabled", false);
+    service.set("autoqueue", "enabled", false).subscribe();
 
     const encoded = encodeURIComponent(encodeURIComponent("false"));
     expect(mockRestService.sendRequest).toHaveBeenCalledWith(
@@ -558,7 +592,7 @@ describe("ConfigService", () => {
     createService();
     connectedSubject.next(true);
 
-    service.set("lftp", "net_limit_rate", null);
+    service.set("lftp", "net_limit_rate", null).subscribe();
 
     expect(mockRestService.sendRequest).toHaveBeenCalledWith(
       `/server/config/set/lftp/net_limit_rate/${EMPTY_VALUE_SENTINEL}`,
@@ -581,7 +615,7 @@ describe("ConfigService", () => {
     connectedSubject.next(true);
     mockStreamDispatch.setApiKey.mockClear();
 
-    service.set("web", "port", "9090");
+    service.set("web", "port", "9090").subscribe();
 
     expect(mockStreamDispatch.setApiKey).not.toHaveBeenCalled();
   });

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Injector, inject } from '@angular/core';
 import { BehaviorSubject, Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 import { ConnectedService } from '../utils/connected.service';
 import { LoggerService } from '../utils/logger.service';
@@ -79,14 +80,17 @@ export class ConfigService {
     const valueEncoded =
       valueStr.length === 0 ? EMPTY_VALUE_SENTINEL : encodeURIComponent(encodeURIComponent(valueStr));
     const url = this.CONFIG_SET_URL(section, option, valueEncoded);
-    const obs = this.restService.sendRequest(url);
-    obs.subscribe({
-      next: (reaction) => {
+    // Update the subject inside the returned pipeline (tap) per the mutating-
+    // service contract: the store updates exactly when the caller subscribes,
+    // with no second internal subscribe. sendRequest already recovers HTTP
+    // errors into a failure WebReaction, so no extra catchError is needed.
+    return this.restService.sendRequest(url).pipe(
+      tap((reaction) => {
         if (reaction.success) {
           const config = this.configSubject.getValue();
           if (config) {
-            const configRecord = config as unknown as ConfigRecord;
-            const newConfig = { ...config, [section]: { ...configRecord[section], [option]: value } };
+            const updatedRecord = config as unknown as ConfigRecord;
+            const newConfig = { ...config, [section]: { ...updatedRecord[section], [option]: value } };
             this.configSubject.next(newConfig);
             // Propagate API key changes to the SSE stream immediately. set() is
             // the only place the real (un-redacted) key is available client-side.
@@ -96,9 +100,8 @@ export class ConfigService {
             }
           }
         }
-      },
-    });
-    return obs;
+      }),
+    );
   }
 
   private getConfig(): void {


### PR DESCRIPTION
Bundles the three **frontend** audit follow-ups from the tracking issue #531, plus a review-feedback fix and the #536 frontend follow-up. One commit per concern.

> **Stacked PRs:** the backend follow-ups (#555/#535/#536) are stacked on top of this branch in #558. Merge this one first.

## Included

### refactor(angular): tap-based mutating-service contract — Closes #542
- `ConfigService.set` and `AutoQueueService.add/remove` now fold their `BehaviorSubject` mutation into the returned observable via `tap` (no second internal `.subscribe()`), returning the typed `WebReaction`. `RestService.sendRequest`'s internal `catchError` already recovers HTTP errors into a failure `WebReaction`, so no extra `catchError` is added.
- Specs updated to **subscribe before asserting** the subject mutated (the reason this was deferred from #525), plus a new "mutates exactly once per caller subscription" test for each.
- `CLAUDE.md`: removed the now-resolved "Known deviation (tracked)" note — `IntegrationsService` remains the reference.

### refactor(angular): extract ViewFileCommandService — Closes #541
- New `ViewFileCommandService` owns single (`queue`/`stop`/`extract`/`deleteLocal`/`deleteRemote`/`validate`) and bulk (`bulkQueue`/`bulkStop`/`bulkDeleteLocal`/`bulkDeleteRemote`) dispatch.
- Resolves `ModelFile` via a threaded resolver backed by the diffing-owned `prevModelFiles`, and reads the checked snapshot from `ViewFileSelectionService`.
- `ViewFileService` keeps the command/bulk methods as **thin delegating facades**, so consumers and `view-file.service.spec.ts` are unchanged. Focused tests added for the new service.

### perf(angular): logs virtual scroll + batched CD — Closes #539
- Live log list rendered with **CDK fixed-size virtual scroll** — DOM nodes bounded by the viewport rather than the 2000-record cap. Scroll-to-top/bottom + button visibility moved from window scroll to the CDK viewport.
- Incoming SSE records **batched via `auditTime(16ms)`** so change detection runs at most once per frame; auto-scroll-to-bottom preserved by sampling "was at bottom" before applying each batch.
- ⚠️ **Design choice to review:** variable-height rows are handled with **single-line truncation (full text in `title`) + a traceback popover** instead of `@angular/cdk-experimental` autosize (not installed). Long messages truncate and exception tracebacks open in a popover rather than inline; full multi-line content remains in the (unchanged) history/search section.

### refactor(angular): ViewFileCommandService.createAction returns the inner observable (#541 review)
- Addresses inline review feedback: replaced the `new Observable(observer => action(modelFile).subscribe(...))` wrapper (which had **no teardown**, so unsubscribing never cancelled the in-flight HTTP request) with a direct `return action(modelFile).pipe(tap, catchError → failure WebReaction)`, and `of(...)` for the unresolved-ModelFile case. Reactions and log calls are preserved; specs unchanged.
- The reviewer's `bulkAction` ordering finding was **verified and intentionally not changed**: `mergeMap+toArray` is the pre-existing original behavior and the sole consumer (`handleBulkResponse`) aggregates results order-independently, so reordering adds complexity with no observable effect.

### feat(angular): surface backend `move_failed` state — #536 FE follow-up
- The backend (#558) now emits a `move_failed` state. Added `MOVE_FAILED` to `ModelFileState`/`STATE_LOOKUP` and `ViewFileStatus`, mapped it through `view-file-capabilities.mapState`, and render a red-tinted **"Move failed"** badge. Without this the state deserialized to `DEFAULT` and mislabelled as Stopped/queueable (risking an accidental re-download).
- Capabilities are intentionally **all-false** (surfaced state only): the backend auto-retries the move in-session, and delete/extract semantics on a *staging*-path file are out of scope here. Deserialize + mapState + no-action capability tests added.

## Test plan
- `cd src/angular && npx ng lint` → **all files pass**
- `cd src/angular && npx ng test` → **561 passed (42 files)**

Part of #531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)