### PR TITLE
Backend audit follow-ups: #555 #535 #536

### DIFF
--- a/src/python/controller/command_pipeline.py
+++ b/src/python/controller/command_pipeline.py
@@ -14,7 +14,7 @@ import os
 from collections.abc import Callable
 from queue import Queue
 
-from common import AppError, AppProcess, Context, MultiprocessingLogger
+from common import AppError, Context, MultiprocessingLogger
 from lftp import LftpError
 from model import ModelError, ModelFile
 
@@ -28,6 +28,7 @@ from .move import MoveProcess
 from .pair_context import PairContext
 from .persist_keys import persist_key
 from .validate import ValidateProcess, ValidateRequest
+from .worker_supervisor import WorkerSupervisor
 
 
 class CommandPipeline:
@@ -45,8 +46,8 @@ class CommandPipeline:
         context: Context,
         password: str | None,
         mp_logger: MultiprocessingLogger,
-        extract_process: ExtractProcess,
-        validate_process: ValidateProcess,
+        extract_process: WorkerSupervisor[ExtractProcess],
+        validate_process: WorkerSupervisor[ValidateProcess],
         logger: logging.Logger,
         sync_persist_callback: Callable[[], None],
     ):
@@ -392,7 +393,9 @@ class CommandPipeline:
         A move can fail two ways: by raising (propagate_exception) or by
         reporting a MoveFailedResult on its failed queue (silent return paths
         such as a vanished source or a size mismatch). In both cases the moved
-        key is discarded so the next force_scan re-spawns the move (retry).
+        key is discarded so the next model-update cycle re-spawns the move
+        (in-session retry, #536) and the file is surfaced as MOVE_FAILED so it is
+        not silently shown as done. A successful move clears any prior MOVE_FAILED.
         """
         failed = False
         try:
@@ -403,9 +406,18 @@ class CommandPipeline:
         for result in move_process.pop_failed():
             self._logger.error(f"Move failed for '{result.name}': {result.error_message}")
             failed = True
+        move_key = persist_key(move_process.pair_id, move_process.file_name)
         if failed:
-            move_key = persist_key(move_process.pair_id, move_process.file_name)
+            # Discard the moved key so the next cycle re-spawns the move (retry),
+            # and surface the failure as a visible MOVE_FAILED model state.
             self.moved_file_keys.discard(move_key)
+            self._persist.move_failed_file_names.add(move_key)
+            self.sync_persist_callback()
+        else:
+            # Move succeeded -- clear any prior failure so the file proceeds normally.
+            if move_key in self._persist.move_failed_file_names:
+                self._persist.move_failed_file_names.discard(move_key)
+                self.sync_persist_callback()
         # The move only changed the owning pair's local_path, so rescan just that
         # pair; fall back to all pairs only if the owner can't be located.
         owner = next((pc for pc in self._pair_contexts if pc.pair_id == move_process.pair_id), None)
@@ -438,9 +450,6 @@ class CommandPipeline:
         # must degrade that feature only, not kill the whole controller.
         # Isolate each worker so one dead worker doesn't stop the other or
         # halt all downloads.
-        # NOTE: this only ISOLATES the fault — the dead worker is not yet
-        # recreated, so extract/validate stays disabled until the service is
-        # restarted. Automatic worker recreation is tracked in #511's follow-up.
         try:
             self._extract_process.propagate_exception()
         except Exception:
@@ -449,14 +458,24 @@ class CommandPipeline:
             self._validate_process.propagate_exception()
         except Exception:
             self._logger.warning("Validate worker process failed: %s", self._validate_process.name, exc_info=True)
-        # propagate_exception() consumes the queued fault once, so without this a
-        # permanently-dead worker would go silent after the first cycle. Surface
-        # the dead state once at ERROR so the degradation stays visible.
+        # propagate_exception() consumes the queued fault once, so report the dead
+        # state once at ERROR (per supervisor) to keep the degradation visible,
+        # then recreate the worker so extract/validate resumes without a full
+        # service restart (#535). The supervisor swaps in the fresh worker so the
+        # pipeline and updater (which share the same supervisor) both see it.
         self.__report_if_worker_dead(self._extract_process, "Extract")
         self.__report_if_worker_dead(self._validate_process, "Validate")
+        self._extract_process.recreate_if_dead()
+        self._validate_process.recreate_if_dead()
 
-    def __report_if_worker_dead(self, worker: AppProcess, feature: str) -> None:
-        worker_id = id(worker)
+    def __report_if_worker_dead(
+        self, worker: WorkerSupervisor[ExtractProcess] | WorkerSupervisor[ValidateProcess], feature: str
+    ) -> None:
+        # Dedupe on the live worker instance, not the supervisor: the supervisor's
+        # id is stable across recreate_if_dead(), so keying on it would suppress the
+        # ERROR for every death after the first. A recreated worker is a new
+        # instance (new id), so its later death is reported again (#535 follow-up).
+        worker_id = id(worker.worker)
         if worker_id in self.__reported_dead_workers:
             return
         try:
@@ -467,7 +486,7 @@ class CommandPipeline:
         if not alive:
             self.__reported_dead_workers.add(worker_id)
             self._logger.error(
-                "%s worker process %s has died; %s is disabled until the service is restarted.",
+                "%s worker process %s has died and will be restarted; %s will resume automatically.",
                 feature,
                 worker.name,
                 feature.lower(),
@@ -487,28 +506,32 @@ class CommandPipeline:
             return
         self.spawn_move_process(file_name, pc)
 
-    def spawn_move_process(self, file_name: str, pc: PairContext):
-        """
-        Spawn a MoveProcess to move a file from staging to the final local_path
+    def spawn_move_process(self, file_name: str, pc: PairContext) -> bool:
+        """Spawn a MoveProcess to move a file from staging to the final local_path.
+
+        Returns True if a move process was actually spawned, False if the call was
+        a no-op (already moved / in flight, staging disabled, or nothing left in
+        staging). A retry of a failed move uses this to tell a real retry from a
+        resolved no-op so it can clear a stale MOVE_FAILED state (#536 follow-up).
         """
         pair_id = pc.pair_id
         move_key = persist_key(pair_id, file_name)
         if move_key in self.moved_file_keys:
             self._logger.debug(f"Skipping move for {file_name} - already moved")
-            return
+            return False
 
         dest_path = pc.local_path
         staging_source = self._pair_staging_dir(pc)
         if staging_source is None:
             self._logger.debug(f"Skipping move for {file_name} - staging is not enabled")
-            return
+            return False
 
         # Skip if the file doesn't exist in staging (e.g. already moved in a prior session)
         staging_file = os.path.join(staging_source, file_name)
         if not os.path.exists(staging_file):
             self._logger.debug(f"Skipping move for {file_name} - not found in staging")
             self.moved_file_keys.add(move_key)
-            return
+            return False
 
         process = MoveProcess(source_path=staging_source, dest_path=dest_path, file_name=file_name, pair_id=pair_id)
         process.set_mp_log_queue(self._mp_logger.queue, self._mp_logger.log_level)
@@ -520,6 +543,7 @@ class CommandPipeline:
         self.moved_file_keys.add(move_key)
         self.active_move_processes.append(process)
         self._logger.info(f"Spawned move process for {file_name} (staging -> local)")
+        return True
 
     def _get_pair_context_for_command(self, command: Command) -> PairContext | None:
         """Find the pair context for a command based on pair_id."""

--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -23,6 +23,11 @@ from .pair_context import ControllerError, PairContext, configure_lftp, validate
 from .persist_sync import PersistSync
 from .scan import ActiveScanner, LocalScanner, RemoteScanner, ScannerProcess
 from .validate import ValidateProcess
+from .worker_supervisor import WorkerSupervisor
+
+# Anything torn down in Controller.exit(): a raw worker AppProcess or a WorkerSupervisor
+# wrapping one (both expose terminate/join/is_alive/close_queues/name).
+_TerminableWorker = AppProcess | WorkerSupervisor[ExtractProcess] | WorkerSupervisor[ValidateProcess]
 
 
 class Controller:
@@ -59,12 +64,19 @@ class Controller:
         # Build pair contexts (persist state is seeded after updater creation below)
         self.__pair_contexts: list[PairContext] = self._build_pair_contexts()
 
-        # Setup extract process (global -- extraction is local-only)
-        self.__extract_process = ExtractProcess()
+        # Setup extract process (global -- extraction is local-only).
+        # The supervisor holds the live worker plus a factory so a dead worker
+        # can be recreated in place (#535); the pipeline and updater share this
+        # same supervisor, so a swap re-wires all three readers at once.
+        self.__extract_process: WorkerSupervisor[ExtractProcess] = WorkerSupervisor(
+            factory=ExtractProcess, logger=self.logger, feature="Extract"
+        )
         self.__extract_process.set_mp_log_queue(self.__mp_logger.queue, self.__mp_logger.log_level)
 
         # Setup validate process (global -- validation uses SSH to remote)
-        self.__validate_process = ValidateProcess()
+        self.__validate_process: WorkerSupervisor[ValidateProcess] = WorkerSupervisor(
+            factory=ValidateProcess, logger=self.logger, feature="Validate"
+        )
         self.__validate_process.set_mp_log_queue(self.__mp_logger.queue, self.__mp_logger.log_level)
 
         # Persist sync is a standalone collaborator so the pipeline and updater
@@ -235,6 +247,7 @@ class Controller:
         model_builder.set_extract_failed_files(set())
         model_builder.set_validated_files(set())
         model_builder.set_corrupt_files(set())
+        model_builder.set_move_failed_files(set())
         model_builder.set_auto_delete_remote(bool(self.__context.config.autoqueue.auto_delete_remote))  # type: ignore[arg-type]
 
         return PairContext(
@@ -316,7 +329,7 @@ class Controller:
                     getattr(pc, "pair_id", None),
                 )
 
-    def __iter_worker_processes(self) -> Iterator[AppProcess]:
+    def __iter_worker_processes(self) -> Iterator[_TerminableWorker]:
         """All terminable worker processes, in teardown order."""
         for pc in self.__pair_contexts:
             yield pc.active_scan_process
@@ -344,7 +357,7 @@ class Controller:
         except Exception:
             self.logger.exception("Error during controller teardown: %s", description)
 
-    def __bounded_join(self, p: AppProcess) -> None:
+    def __bounded_join(self, p: _TerminableWorker) -> None:
         self.__safe_teardown("join", lambda: p.join(self.__JOIN_TIMEOUT_IN_SECS))
         try:
             still_alive = p.is_alive()

--- a/src/python/controller/controller_persist.py
+++ b/src/python/controller/controller_persist.py
@@ -26,6 +26,7 @@ class ControllerPersist(Persist):
     __KEY_EXTRACT_FAILED_FILE_NAMES = "extract_failed"
     __KEY_VALIDATED_FILE_NAMES = "validated"
     __KEY_CORRUPT_FILE_NAMES = "corrupt"
+    __KEY_MOVE_FAILED_FILE_NAMES = "move_failed"
 
     def __init__(self):
         self.downloaded_file_names: set[str] = set()
@@ -33,6 +34,7 @@ class ControllerPersist(Persist):
         self.extract_failed_file_names: set[str] = set()
         self.validated_file_names: set[str] = set()
         self.corrupt_file_names: set[str] = set()
+        self.move_failed_file_names: set[str] = set()
 
     @staticmethod
     def _migrate_legacy_keys(keys: set[str]) -> set[str]:
@@ -57,6 +59,7 @@ class ControllerPersist(Persist):
             persist.extract_failed_file_names = set(dct.get(ControllerPersist.__KEY_EXTRACT_FAILED_FILE_NAMES, []))
             persist.validated_file_names = set(dct.get(ControllerPersist.__KEY_VALIDATED_FILE_NAMES, []))
             persist.corrupt_file_names = set(dct.get(ControllerPersist.__KEY_CORRUPT_FILE_NAMES, []))
+            persist.move_failed_file_names = set(dct.get(ControllerPersist.__KEY_MOVE_FAILED_FILE_NAMES, []))
             # Migrate any legacy colon-separated keys to unit-separator keys
             persist.downloaded_file_names = ControllerPersist._migrate_legacy_keys(persist.downloaded_file_names)
             persist.extracted_file_names = ControllerPersist._migrate_legacy_keys(persist.extracted_file_names)
@@ -65,6 +68,7 @@ class ControllerPersist(Persist):
             )
             persist.validated_file_names = ControllerPersist._migrate_legacy_keys(persist.validated_file_names)
             persist.corrupt_file_names = ControllerPersist._migrate_legacy_keys(persist.corrupt_file_names)
+            persist.move_failed_file_names = ControllerPersist._migrate_legacy_keys(persist.move_failed_file_names)
             return persist
         except (json.decoder.JSONDecodeError, KeyError) as e:
             raise PersistError(f"Error parsing ControllerPersist - {type(e).__name__}: {e!s}") from e
@@ -77,4 +81,5 @@ class ControllerPersist(Persist):
         dct[ControllerPersist.__KEY_EXTRACT_FAILED_FILE_NAMES] = list(self.extract_failed_file_names)
         dct[ControllerPersist.__KEY_VALIDATED_FILE_NAMES] = list(self.validated_file_names)
         dct[ControllerPersist.__KEY_CORRUPT_FILE_NAMES] = list(self.corrupt_file_names)
+        dct[ControllerPersist.__KEY_MOVE_FAILED_FILE_NAMES] = list(self.move_failed_file_names)
         return json.dumps(dct, indent=Constants.JSON_PRETTY_PRINT_INDENT)

--- a/src/python/controller/model_builder.py
+++ b/src/python/controller/model_builder.py
@@ -39,6 +39,7 @@ class ModelBuilder:
         self.__validate_statuses: dict[str, ValidateStatus] = {}
         self.__validated_files: set[str] = set()
         self.__corrupt_files: set[str] = set()
+        self.__move_failed_files: set[str] = set()
         self.__auto_delete_remote = False
         self.__cached_model: Model | None = None
         self.__smoothed_etas: dict[str, float] = {}
@@ -125,6 +126,13 @@ class ModelBuilder:
         if self.__corrupt_files != prev_corrupt_files:
             self.__cached_model = None
 
+    def set_move_failed_files(self, move_failed_files: set[str]):
+        prev_move_failed_files = self.__move_failed_files
+        self.__move_failed_files = move_failed_files
+        # Invalidate the cache
+        if self.__move_failed_files != prev_move_failed_files:
+            self.__cached_model = None
+
     def set_auto_delete_remote(self, enabled: bool):
         if self.__auto_delete_remote != enabled:
             self.__auto_delete_remote = enabled
@@ -142,6 +150,7 @@ class ModelBuilder:
         self.__validate_statuses.clear()
         self.__validated_files.clear()
         self.__corrupt_files.clear()
+        self.__move_failed_files.clear()
         self.__auto_delete_remote = False
         self.__cached_model = None
         self.__smoothed_etas.clear()
@@ -482,6 +491,19 @@ class ModelBuilder:
             ModelFile.State.VALIDATED,
         ):
             model_file.state = ModelFile.State.CORRUPT
+
+        # finally we check if the staging->final move failed
+        # root is MoveFailed if it is in a post-download state and in the move-failed list.
+        # A failed move leaves the file sitting in staging (still DOWNLOADED/EXTRACTED/
+        # VALIDATED), so without this it would render as silently "done" (#536).
+        if model_file.name in self.__move_failed_files and model_file.state in (
+            ModelFile.State.DOWNLOADED,
+            ModelFile.State.EXTRACTED,
+            ModelFile.State.EXTRACT_FAILED,
+            ModelFile.State.VALIDATED,
+            ModelFile.State.CORRUPT,
+        ):
+            model_file.state = ModelFile.State.MOVE_FAILED
 
     def _check_persist_authority(self, model_file: ModelFile, incomplete_children: bool):
         # next we check persist authority for previously downloaded files

--- a/src/python/controller/model_updater.py
+++ b/src/python/controller/model_updater.py
@@ -31,6 +31,7 @@ from .validate import (
     ValidateRequest,
     ValidateStatusResult,
 )
+from .worker_supervisor import WorkerSupervisor
 
 
 class ModelUpdater:
@@ -40,14 +41,18 @@ class ModelUpdater:
     counterparts — this is a structural extraction, not a refactor.
     """
 
+    # Bound the in-session staging->final move retry so a permanently-failing
+    # move does not re-spawn on every cycle forever (#536).
+    MAX_MOVE_RETRIES = 3
+
     def __init__(
         self,
         pair_contexts: list[PairContext],
         persist: ControllerPersist,
         pipeline: CommandPipeline,
         registry: ModelRegistry,
-        extract_process: ExtractProcess,
-        validate_process: ValidateProcess,
+        extract_process: WorkerSupervisor[ExtractProcess],
+        validate_process: WorkerSupervisor[ValidateProcess],
         context: Context,
         password: str | None,
         logger: logging.Logger,
@@ -66,17 +71,22 @@ class ModelUpdater:
         # is injected; otherwise build one over the same pair_contexts/persist so
         # standalone use (and unit tests) behaves identically.
         self._persist_sync = persist_sync or PersistSync(pair_contexts, persist)
+        # In-memory per-file budget for the in-session staging->final move retry
+        # (#536). Keyed by persist key; bounded by MAX_MOVE_RETRIES so a
+        # permanently-failing move (e.g. a full disk) does not re-spawn forever.
+        # Held in memory only, so a restart grants a fresh budget.
+        self._move_retry_counts: dict[str, int] = {}
 
     def update(self) -> None:
         # Grab the latest extract results (shared)
-        latest_extract_statuses = self._extract_process.pop_latest_statuses()
-        latest_extracted_results = self._extract_process.pop_completed()
-        latest_failed_extractions = self._extract_process.pop_failed()
+        latest_extract_statuses = self._extract_process.worker.pop_latest_statuses()
+        latest_extracted_results = self._extract_process.worker.pop_completed()
+        latest_failed_extractions = self._extract_process.worker.pop_failed()
 
         # Grab the latest validate results (shared)
-        latest_validate_statuses = self._validate_process.pop_latest_statuses()
-        latest_validated_results = self._validate_process.pop_completed()
-        latest_failed_validations = self._validate_process.pop_failed()
+        latest_validate_statuses = self._validate_process.worker.pop_latest_statuses()
+        latest_validated_results = self._validate_process.worker.pop_completed()
+        latest_failed_validations = self._validate_process.worker.pop_failed()
 
         # Process each pair context's scan results and LFTP status
         for pc in self._pair_contexts:
@@ -92,6 +102,7 @@ class ModelUpdater:
         self._prune_stale_persist()
         self._process_extraction_failures(latest_failed_extractions)
         self._process_validation_results(latest_validated_results, latest_failed_validations)
+        self._retry_failed_moves()
         self._update_controller_status()
 
     def _process_extraction_completions(self, latest_extracted_results: list[ExtractCompletedResult]) -> None:
@@ -175,6 +186,8 @@ class ModelUpdater:
             self._persist.extract_failed_file_names.discard(pkey)
             self._persist.validated_file_names.discard(pkey)
             self._persist.corrupt_file_names.discard(pkey)
+            self._persist.move_failed_file_names.discard(pkey)
+            self._move_retry_counts.pop(pkey, None)
             self.sync_persist_to_all_builders()
 
     def _handle_downloaded_file(self, diff: ModelDiff, pc: PairContext | None) -> None:
@@ -299,6 +312,9 @@ class ModelUpdater:
             self._persist.extract_failed_file_names.difference_update(absent_keys)
             self._persist.validated_file_names.difference_update(absent_keys)
             self._persist.corrupt_file_names.difference_update(absent_keys)
+            self._persist.move_failed_file_names.difference_update(absent_keys)
+            for key in absent_keys:
+                self._move_retry_counts.pop(key, None)
             self.sync_persist_to_all_builders()
 
     def _process_extraction_failures(self, latest_failed_extractions: list[ExtractFailedResult]) -> None:
@@ -344,6 +360,55 @@ class ModelUpdater:
                 )
             # Spawn deferred move regardless of failure type -- validation is done
             self._pipeline.spawn_deferred_move(result.pair_id, result.name)
+
+    def _retry_failed_moves(self) -> None:
+        """Re-spawn staging->final moves that previously failed, within the session.
+
+        A failed move leaves the file DOWNLOADED-in-staging with its moved key
+        discarded (no completed move), so a bare force_scan produces no new
+        DOWNLOADED transition and the move would otherwise only retry on restart.
+        Each cycle we re-spawn the move for any file still in
+        move_failed_file_names that is not already moving, bounded by a per-file
+        budget so a permanently-failing move does not re-spawn forever (#536).
+        """
+        cfg = self._context.config.controller
+        if not (cfg.use_staging and cfg.staging_path):
+            return
+        if not self._persist.move_failed_file_names:
+            return
+        for fail_key in list(self._persist.move_failed_file_names):
+            # Skip files whose move is already in flight (its key is re-added to
+            # moved_file_keys by spawn_move_process); we only retry idle ones.
+            if fail_key in self._pipeline.moved_file_keys:
+                continue
+            if self._move_retry_counts.get(fail_key, 0) >= self.MAX_MOVE_RETRIES:
+                continue
+            self._respawn_failed_move(fail_key)
+
+    def _respawn_failed_move(self, fail_key: str) -> None:
+        """Resolve the owning pair for a failed-move key and re-spawn its move."""
+        for pc in self._pair_contexts:
+            bare_name = strip_persist_key(fail_key, pc.pair_id)
+            # strip_persist_key returns the key unchanged when the prefix doesn't
+            # match; for the default pair (pair_id None) it always matches, so
+            # only treat it as this pair's file when the key is actually scoped to
+            # this pair (changed) or this is the default pair.
+            if bare_name == fail_key and pc.pair_id is not None:
+                continue
+            if self._pipeline.spawn_move_process(bare_name, pc):
+                self._move_retry_counts[fail_key] = self._move_retry_counts.get(fail_key, 0) + 1
+                self._logger.info(
+                    f"Retrying failed move for '{bare_name}' (attempt {self._move_retry_counts[fail_key]})"
+                )
+            elif fail_key in self._persist.move_failed_file_names:
+                # Nothing left to move in staging (the move already completed in a
+                # prior session, or the staging copy vanished): no real MoveProcess
+                # will ever complete to clear this, so resolve it now instead of
+                # leaving the file stuck in MOVE_FAILED forever (#536 follow-up).
+                self._persist.move_failed_file_names.discard(fail_key)
+                self.sync_persist_to_all_builders()
+                self._logger.info(f"Cleared MOVE_FAILED for '{bare_name}': nothing to move in staging")
+            return
 
     def _update_controller_status(self) -> None:
         """Update the controller status (use most recent across all pairs).

--- a/src/python/controller/persist_sync.py
+++ b/src/python/controller/persist_sync.py
@@ -45,6 +45,9 @@ class PersistSync:
             pc.model_builder.set_corrupt_files(
                 self._filter_keys_for_pair(self._persist.corrupt_file_names, pc.pair_id, namespaced_prefixes)
             )
+            pc.model_builder.set_move_failed_files(
+                self._filter_keys_for_pair(self._persist.move_failed_file_names, pc.pair_id, namespaced_prefixes)
+            )
 
     @staticmethod
     def _filter_keys_for_pair(keys: set[str], pair_id: str | None, namespaced_prefixes: tuple[str, ...]) -> set[str]:

--- a/src/python/controller/worker_supervisor.py
+++ b/src/python/controller/worker_supervisor.py
@@ -1,0 +1,172 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+"""Supervisor/holder for a recreatable extract/validate worker process.
+
+A ``multiprocessing.Process`` cannot be restarted in place, yet the live
+extract/validate worker is referenced from three collaborators that all read
+its result queues: the :class:`~controller.controller.Controller` (owns and
+starts it), the :class:`~controller.command_pipeline.CommandPipeline`
+(dispatches work to it), and the :class:`~controller.model_updater.ModelUpdater`
+(drains its ``pop_*`` queues).
+
+A dead worker's queues are gone, so "recreating" it means constructing a brand
+new :class:`~common.AppProcess` and re-pointing every reader at it. To avoid
+re-wiring three separate fields, all three hold the *same* supervisor instance
+instead of the raw worker. The supervisor delegates the worker's method surface
+to whatever live instance it currently owns, so swapping in a fresh worker
+re-wires every reader at once (#535, follow-up to #511).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar
+
+from common import AppProcess
+
+W = TypeVar("W", bound=AppProcess)
+
+
+class WorkerSupervisor(Generic[W]):
+    """Owns the current live worker plus a factory that builds a fresh one.
+
+    Delegates the worker method surface (``pop_*``/``propagate_exception``/
+    ``name``/``is_alive``/``exitcode``/``set_mp_log_queue``/``start``/
+    ``terminate``/``join``/``close_queues`` and the request-dispatch method) to
+    the current instance, and can swap in a fresh worker via
+    :meth:`recreate_if_dead` when the current one has died.
+    """
+
+    def __init__(self, factory: Callable[[], W], logger: logging.Logger, feature: str):
+        """
+        :param factory: zero-arg callable that builds a fresh worker instance.
+        :param logger: logger used for recreation messages.
+        :param feature: human-readable feature name (e.g. "Extract") for logs.
+        """
+        self._factory = factory
+        self._logger = logger
+        self._feature = feature
+        self._worker: W = factory()
+        # Captured on set_mp_log_queue() so a recreated worker can be re-wired
+        # to the same cross-process logging queue before it is started.
+        self._mp_log_queue: Any = None
+        self._mp_log_level: int | None = None
+
+    @property
+    def worker(self) -> W:
+        """The current live worker instance (for tests/diagnostics)."""
+        return self._worker
+
+    # --- delegated process attributes ---
+
+    @property
+    def name(self) -> str:
+        return self._worker.name
+
+    @property
+    def exitcode(self) -> int | None:
+        return self._worker.exitcode
+
+    def is_alive(self) -> bool:
+        return self._worker.is_alive()
+
+    def set_mp_log_queue(self, log_queue: Any, log_level: int) -> None:
+        # Remember the wiring so recreate_if_dead() can reapply it to the fresh
+        # worker before starting it.
+        self._mp_log_queue = log_queue
+        self._mp_log_level = log_level
+        self._worker.set_mp_log_queue(log_queue, log_level)
+
+    def start(self) -> None:
+        self._worker.start()
+
+    def terminate(self) -> None:
+        self._worker.terminate()
+
+    def join(self, timeout: float | None = None) -> None:
+        self._worker.join(timeout)
+
+    def close_queues(self) -> None:
+        self._worker.close_queues()
+
+    def propagate_exception(self) -> None:
+        self._worker.propagate_exception()
+
+    # --- delegated worker methods (dynamic) ---
+
+    def __getattr__(self, item: str) -> Any:
+        """Delegate the worker's own methods to the current live instance.
+
+        Covers the result-queue readers (``pop_latest_statuses``/
+        ``pop_completed``/``pop_failed``) and the request-dispatch methods
+        (``extract``/``validate``) — the worker surface that differs between
+        ExtractProcess and ValidateProcess and so cannot be typed on a single
+        ``Generic[W]`` supervisor. Callers that need the concrete return types
+        read them through :attr:`worker` (e.g. ``supervisor.worker.pop_completed()``);
+        ModelUpdater does this.
+
+        Only invoked for attributes not defined on the supervisor itself, so the
+        explicit delegations above always win. ``_worker`` is set in
+        ``__init__``; guard against the recursion that would occur if it is ever
+        accessed before assignment.
+        """
+        if item == "_worker":
+            raise AttributeError(item)
+        return getattr(self._worker, item)
+
+    # --- recreation ---
+
+    def recreate_if_dead(self) -> bool:
+        """Recreate the worker if it has died, re-wiring all readers via ``self``.
+
+        Detects death via ``exitcode``/``is_alive()``: a not-yet-started worker
+        (exitcode is None and never alive) is left alone, while an exited worker
+        is replaced with a fresh instance built from the factory, re-wired to the
+        shared mp-log queue, and started. Returns True iff a new worker was
+        created.
+        """
+        if not self._is_dead():
+            return False
+
+        dead = self._worker
+        self._logger.warning(
+            "%s worker process %s has died (exitcode=%s); restarting it.",
+            self._feature,
+            dead.name,
+            dead.exitcode,
+        )
+
+        fresh = self._factory()
+        if self._mp_log_queue is not None and self._mp_log_level is not None:
+            fresh.set_mp_log_queue(self._mp_log_queue, self._mp_log_level)
+        fresh.start()
+        # Swap before reaping the old worker so a failure releasing the dead
+        # worker's queues still leaves the supervisor pointing at the live one.
+        self._worker = fresh
+        self._reap_dead(dead)
+        self._logger.info("%s worker process restarted as %s", self._feature, fresh.name)
+        return True
+
+    def _is_dead(self) -> bool:
+        """True if the worker was started and has since exited."""
+        try:
+            alive = self._worker.is_alive()
+        except (ValueError, AssertionError):
+            # Already closed — treat as not-running but also not started here.
+            return False
+        if alive:
+            return False
+        # Not alive: distinguish "never started" (exitcode is None) from "exited".
+        return self._worker.exitcode is not None
+
+    def _reap_dead(self, dead: W) -> None:
+        """Best-effort join + queue close on the replaced worker to free FDs."""
+        try:
+            dead.join(0)
+        except Exception:
+            self._logger.debug("Error joining dead %s worker during restart", self._feature, exc_info=True)
+        try:
+            dead.close_queues()
+        except Exception:
+            self._logger.debug("Error closing dead %s worker queues during restart", self._feature, exc_info=True)

--- a/src/python/lftp/job_status_parser.py
+++ b/src/python/lftp/job_status_parser.py
@@ -283,6 +283,14 @@ class LftpJobStatusParser:
         )
 
     @staticmethod
+    def _is_chunk_data_line(line: str) -> bool:
+        """True if ``line`` is a chunk-data line (matches one of the three
+        chunk-data regexes). Used to peek before popping so a non-data line
+        (e.g. the next job's header when a pget emitted no data line) is left
+        in place for the dispatch loop rather than silently consumed."""
+        return bool(_RE_CHUNK_AT.search(line) or _RE_CHUNK_AT2.search(line) or _RE_CHUNK_GOT.search(line))
+
+    @staticmethod
     def _build_chunk_transfer_state(
         result_at: "re.Match[str] | None",
         result_at2: "re.Match[str] | None",
@@ -322,11 +330,14 @@ class LftpJobStatusParser:
             raise ValueError(f"Missing the 'sftp' line for pget header '{result.string}'")
         lines.pop(0)  # pop the 'sftp' line
 
-        # Data line may not exist
+        # Data line may not exist. Peek before popping: only consume the next
+        # line if it is actually a chunk-data line. Otherwise it belongs to the
+        # following job (its header), so leave it for the dispatch loop instead
+        # of silently dropping that job.
         result_at = None
         result_at2 = None
         result_got = None
-        if lines:
+        if lines and LftpJobStatusParser._is_chunk_data_line(lines[0]):
             line = lines.pop(0)  # data line
             result_at = _RE_CHUNK_AT.search(line)
             result_at2 = _RE_CHUNK_AT2.search(line)
@@ -411,6 +422,13 @@ class LftpJobStatusParser:
         name = result.group("name")
         if not lines:
             raise ValueError(f"Missing chunk data for filename '{name}'")
+        # Peek before popping: only consume the next line if it is actually a
+        # chunk-data line. If it is not (e.g. the following job's header when
+        # this transfer emitted no data line), leave it for the dispatch loop
+        # rather than consuming it and dropping that job — and do not register
+        # a transfer state from a non-data line.
+        if not LftpJobStatusParser._is_chunk_data_line(lines[0]):
+            return
         line = lines.pop(0)
         result_at = _RE_CHUNK_AT.search(line)
         result_at2 = _RE_CHUNK_AT2.search(line)
@@ -433,8 +451,6 @@ class LftpJobStatusParser:
                 raise ValueError(
                     "Mismatch: filename '{}' but chunk data for '{}'".format(name, result_got.group("name"))
                 )
-        else:
-            raise ValueError(f"Missing chunk data for filename '{name}'")
         file_status = LftpJobStatusParser._build_chunk_transfer_state(result_at, result_at2, result_got)
         assert prev_job is not None
         prev_job.add_active_file_transfer_state(name, file_status)

--- a/src/python/model/file.py
+++ b/src/python/model/file.py
@@ -30,6 +30,7 @@ class ModelFile:
         VALIDATING = 8
         VALIDATED = 9
         CORRUPT = 10
+        MOVE_FAILED = 11
 
     def __init__(self, name: str, is_dir: bool, pair_id: str | None = None):
         self.__name = name  # file or folder name

--- a/src/python/tests/unittests/test_controller/test_command_pipeline.py
+++ b/src/python/tests/unittests/test_controller/test_command_pipeline.py
@@ -192,6 +192,49 @@ class TestCommandPipelineHelpers(unittest.TestCase):
         pc.local_scan_process.force_scan.assert_called_once()
         self.assertEqual([], pipeline.active_move_processes)
 
+    def test_cleanup_surfaces_move_failure_as_persist_state(self):
+        """A failed move must add its key to move_failed_file_names and sync so the
+        file renders as MOVE_FAILED instead of silently DOWNLOADED (#536)."""
+        pc = self._make_pair_context("pair-1")
+        pipeline = self._make_pipeline([pc])
+        pipeline._persist.move_failed_file_names = set()
+
+        move_key = persist_key("pair-1", "file.txt")
+        pipeline.moved_file_keys.add(move_key)
+
+        failure = MagicMock()
+        failure.name = "file.txt"
+        failure.error_message = "size verification failed"
+        move_process = self._make_move_process("pair-1", "file.txt", failed_results=[failure])
+        pipeline.active_move_processes.append(move_process)
+
+        pipeline.cleanup()
+
+        # Key discarded (so a retry can re-spawn) AND surfaced as failed state
+        self.assertNotIn(move_key, pipeline.moved_file_keys)
+        self.assertIn(move_key, pipeline._persist.move_failed_file_names)
+        pipeline.sync_persist_callback.assert_called()
+
+    def test_cleanup_clears_move_failed_state_on_success(self):
+        """A move that succeeds after a prior failure must clear move_failed_file_names
+        for that key so the file proceeds normally (#536)."""
+        pc = self._make_pair_context("pair-1")
+        pipeline = self._make_pipeline([pc])
+
+        move_key = persist_key("pair-1", "file.txt")
+        pipeline._persist.move_failed_file_names = {move_key}
+        pipeline.moved_file_keys.add(move_key)
+
+        move_process = self._make_move_process("pair-1", "file.txt", failed_results=[])
+        pipeline.active_move_processes.append(move_process)
+
+        pipeline.cleanup()
+
+        self.assertNotIn(move_key, pipeline._persist.move_failed_file_names)
+        pipeline.sync_persist_callback.assert_called()
+        # Successful move keeps its moved key (no retry)
+        self.assertIn(move_key, pipeline.moved_file_keys)
+
     def test_cleanup_discards_key_when_move_raises(self):
         """A move that raises (propagate_exception) must also discard its key."""
         pc = self._make_pair_context("pair-1")
@@ -343,6 +386,24 @@ class TestCommandPipelineHelpers(unittest.TestCase):
         self.assertIn("restarted", dead_reports[0])
         # The live validate worker is never reported dead.
         self.assertFalse(any("Validate worker" in m for m in error_messages))
+
+    def test_propagate_exceptions_reports_dead_worker_again_after_recreation(self):
+        """The dead-worker ERROR dedupe keys on the live worker instance, not the
+        supervisor (whose id is stable across recreate_if_dead). So once a worker
+        is recreated, a later death of the fresh instance is reported again rather
+        than silently suppressed (#535 follow-up)."""
+        pipeline = self._make_pipeline([])
+        pipeline._extract_process.is_alive.return_value = False
+        pipeline._validate_process.is_alive.return_value = True
+
+        pipeline.propagate_exceptions()
+        # Simulate recreate_if_dead() swapping in a fresh worker instance.
+        pipeline._extract_process.worker = MagicMock()
+        pipeline.propagate_exceptions()
+
+        error_messages = [c.args[0] % c.args[1:] for c in pipeline._logger.error.call_args_list]
+        dead_reports = [m for m in error_messages if "has died" in m]
+        self.assertEqual(2, len(dead_reports), error_messages)
 
     def test_propagate_exceptions_reraises_permanent_lftp_error(self):
         """A permanent lftp credential failure must still raise AppError so the

--- a/src/python/tests/unittests/test_controller/test_controller_persist.py
+++ b/src/python/tests/unittests/test_controller/test_controller_persist.py
@@ -174,21 +174,23 @@ class TestControllerPersist(unittest.TestCase):
         )
 
     def test_validated_and_corrupt_round_trip(self):
-        """Validated and corrupt keys should survive serialization round-trip."""
+        """Validated, corrupt, and move-failed keys should survive serialization round-trip."""
         persist = ControllerPersist()
         persist.downloaded_file_names.add("a")
         persist.extracted_file_names.add("b")
         persist.validated_file_names.add("c")
         persist.corrupt_file_names.add("d")
+        persist.move_failed_file_names.add("e")
 
         persist_actual = ControllerPersist.from_str(persist.to_str())
         self.assertEqual({"a"}, persist_actual.downloaded_file_names)
         self.assertEqual({"b"}, persist_actual.extracted_file_names)
         self.assertEqual({"c"}, persist_actual.validated_file_names)
         self.assertEqual({"d"}, persist_actual.corrupt_file_names)
+        self.assertEqual({"e"}, persist_actual.move_failed_file_names)
 
     def test_validated_and_corrupt_missing_keys_default_empty(self):
-        """Old persist files without validated/corrupt keys should load with empty sets."""
+        """Old persist files without validated/corrupt/move_failed keys load empty sets."""
         content = json.dumps(
             {
                 "downloaded": ["a"],
@@ -198,6 +200,24 @@ class TestControllerPersist(unittest.TestCase):
         persist = ControllerPersist.from_str(content)
         self.assertEqual(set(), persist.validated_file_names)
         self.assertEqual(set(), persist.corrupt_file_names)
+        self.assertEqual(set(), persist.move_failed_file_names)
+
+    def test_move_failed_legacy_keys_migrated(self):
+        """Legacy colon-separated keys in move_failed should be migrated (#536)."""
+        uuid1 = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        content = json.dumps(
+            {
+                "downloaded": [],
+                "extracted": [],
+                "move_failed": [f"{uuid1}:stuck.mkv"],
+            }
+        )
+        persist = ControllerPersist.from_str(content)
+        sep = "\x1f"
+        self.assertEqual(
+            {f"{uuid1}{sep}stuck.mkv"},
+            persist.move_failed_file_names,
+        )
 
     def test_validated_corrupt_legacy_keys_migrated(self):
         """Legacy colon-separated keys in validated/corrupt should be migrated."""

--- a/src/python/tests/unittests/test_controller/test_model_builder.py
+++ b/src/python/tests/unittests/test_controller/test_model_builder.py
@@ -1903,6 +1903,77 @@ class TestModelBuilder(unittest.TestCase):
         self.model_builder.set_corrupt_files({"a", "c"})
         self.assertTrue(self.model_builder.has_changes())
 
+    def test_build_state_move_failed(self):
+        # Downloaded + move-failed -> MOVE_FAILED (#536)
+        self.model_builder.clear()
+        self.model_builder.set_remote_files([SystemFile("a", 100, False)])
+        self.model_builder.set_local_files([SystemFile("a", 100, False)])
+        self.model_builder.set_move_failed_files({"a"})
+        model = self.model_builder.build_model()
+        self.assertEqual(ModelFile.State.MOVE_FAILED, model.get_file("a").state)
+
+        # Extracted + move-failed -> MOVE_FAILED
+        self.model_builder.clear()
+        self.model_builder.set_remote_files([SystemFile("a", 100, False)])
+        self.model_builder.set_local_files([SystemFile("a", 100, False)])
+        self.model_builder.set_extracted_files({"a"})
+        self.model_builder.set_move_failed_files({"a"})
+        model = self.model_builder.build_model()
+        self.assertEqual(ModelFile.State.MOVE_FAILED, model.get_file("a").state)
+
+        # Validated + move-failed -> MOVE_FAILED
+        self.model_builder.clear()
+        self.model_builder.set_remote_files([SystemFile("a", 100, False)])
+        self.model_builder.set_local_files([SystemFile("a", 100, False)])
+        self.model_builder.set_validated_files({"a"})
+        self.model_builder.set_move_failed_files({"a"})
+        model = self.model_builder.build_model()
+        self.assertEqual(ModelFile.State.MOVE_FAILED, model.get_file("a").state)
+
+        # Local-only + move-failed -> DEFAULT (move-failed requires a post-download base)
+        self.model_builder.clear()
+        self.model_builder.set_local_files([SystemFile("a", 100, False)])
+        self.model_builder.set_move_failed_files({"a"})
+        model = self.model_builder.build_model()
+        self.assertEqual(ModelFile.State.DEFAULT, model.get_file("a").state)
+
+        # Downloading + move-failed -> DOWNLOADING (active download overrides)
+        self.model_builder.clear()
+        self.model_builder.set_remote_files([SystemFile("a", 100, False)])
+        self.model_builder.set_local_files([SystemFile("a", 50, False)])
+        self.model_builder.set_lftp_statuses(
+            [LftpJobStatus(0, LftpJobStatus.Type.PGET, LftpJobStatus.State.RUNNING, "a", "")]
+        )
+        self.model_builder.set_move_failed_files({"a"})
+        model = self.model_builder.build_model()
+        self.assertEqual(ModelFile.State.DOWNLOADING, model.get_file("a").state)
+
+    def test_build_state_move_failed_overrides_corrupt(self):
+        # Both corrupt + move-failed -> MOVE_FAILED (move-failed checked last)
+        self.model_builder.clear()
+        self.model_builder.set_remote_files([SystemFile("a", 100, False)])
+        self.model_builder.set_local_files([SystemFile("a", 100, False)])
+        self.model_builder.set_corrupt_files({"a"})
+        self.model_builder.set_move_failed_files({"a"})
+        model = self.model_builder.build_model()
+        self.assertEqual(ModelFile.State.MOVE_FAILED, model.get_file("a").state)
+
+    def test_rebuild_on_move_failed_files(self):
+        self.assertTrue(self.model_builder.has_changes())
+
+        # Initial set
+        self.model_builder.set_move_failed_files({"a", "b"})
+        self.model_builder.build_model()
+        self.assertFalse(self.model_builder.has_changes())
+
+        # Does not invalidate on same
+        self.model_builder.set_move_failed_files({"a", "b"})
+        self.assertFalse(self.model_builder.has_changes())
+
+        # Invalidate on different
+        self.model_builder.set_move_failed_files({"a", "c"})
+        self.assertTrue(self.model_builder.has_changes())
+
 
 class TestSharedLocalDeduplication(unittest.TestCase):
     """

--- a/src/python/tests/unittests/test_controller/test_model_updater.py
+++ b/src/python/tests/unittests/test_controller/test_model_updater.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from controller.model_updater import ModelUpdater
-from controller.persist_keys import KEY_SEP
+from controller.persist_keys import KEY_SEP, persist_key
 
 
 class TestSyncPersistToAllBuilders(unittest.TestCase):
@@ -36,7 +36,9 @@ class TestSyncPersistToAllBuilders(unittest.TestCase):
         )
         return updater
 
-    def _make_persist(self, downloaded=None, extracted=None, extract_failed=None, validated=None, corrupt=None):
+    def _make_persist(
+        self, downloaded=None, extracted=None, extract_failed=None, validated=None, corrupt=None, move_failed=None
+    ):
         """Create a mock persist object with the given file name sets."""
         persist = MagicMock()
         persist.downloaded_file_names = downloaded or set()
@@ -44,6 +46,7 @@ class TestSyncPersistToAllBuilders(unittest.TestCase):
         persist.extract_failed_file_names = extract_failed or set()
         persist.validated_file_names = validated or set()
         persist.corrupt_file_names = corrupt or set()
+        persist.move_failed_file_names = move_failed or set()
         return persist
 
     def test_filters_downloaded_keys_by_pair_id_prefix(self):
@@ -123,6 +126,7 @@ class TestSyncPersistToAllBuilders(unittest.TestCase):
             extract_failed={f"abc{KEY_SEP}bad.zip"},
             validated={f"abc{KEY_SEP}good.mkv"},
             corrupt={f"abc{KEY_SEP}corrupt.mkv"},
+            move_failed={f"abc{KEY_SEP}stuck.mkv"},
         )
 
         updater = self._make_updater([pc_abc], persist)
@@ -133,3 +137,155 @@ class TestSyncPersistToAllBuilders(unittest.TestCase):
         pc_abc.model_builder.set_extract_failed_files.assert_called_once_with({"bad.zip"})
         pc_abc.model_builder.set_validated_files.assert_called_once_with({"good.mkv"})
         pc_abc.model_builder.set_corrupt_files.assert_called_once_with({"corrupt.mkv"})
+        pc_abc.model_builder.set_move_failed_files.assert_called_once_with({"stuck.mkv"})
+
+
+class TestRetryFailedMoves(unittest.TestCase):
+    """In-session retry of failed staging->final moves (#536)."""
+
+    def _make_pair_context(self, pair_id):
+        pc = MagicMock()
+        pc.pair_id = pair_id
+        return pc
+
+    def _make_updater(self, pair_contexts, persist, *, use_staging=True, staging_path="/tmp/staging"):
+        pipeline = MagicMock()
+        # moved_file_keys is a real set so the "already moving" check is realistic
+        pipeline.moved_file_keys = set()
+        registry = MagicMock()
+        extract_process = MagicMock()
+        validate_process = MagicMock()
+        context = MagicMock()
+        context.config.controller.use_staging = use_staging
+        context.config.controller.staging_path = staging_path
+        logger = MagicMock()
+
+        updater = ModelUpdater(
+            pair_contexts=pair_contexts,
+            persist=persist,
+            pipeline=pipeline,
+            registry=registry,
+            extract_process=extract_process,
+            validate_process=validate_process,
+            context=context,
+            password=None,
+            logger=logger,
+        )
+        return updater, pipeline
+
+    def _make_persist(self, move_failed=None):
+        persist = MagicMock()
+        persist.move_failed_file_names = move_failed if move_failed is not None else set()
+        return persist
+
+    def test_respawns_move_for_failed_file_on_cycle(self):
+        """A file still in move_failed_file_names that is not currently moving must
+        be re-spawned on the next update cycle (not only on restart)."""
+        pc = self._make_pair_context("pair-1")
+        fail_key = persist_key("pair-1", "file.txt")
+        persist = self._make_persist(move_failed={fail_key})
+        updater, pipeline = self._make_updater([pc], persist)
+
+        updater._retry_failed_moves()
+
+        pipeline.spawn_move_process.assert_called_once_with("file.txt", pc)
+
+    def test_clears_move_failed_when_nothing_to_move(self):
+        """A retry whose staging copy is gone (the move already completed in a
+        prior session, or the file vanished) spawns no MoveProcess; treat that
+        no-op as resolved and clear MOVE_FAILED instead of leaving the file stuck
+        forever (no real move will ever complete to clear it) (#536 follow-up)."""
+        pc = self._make_pair_context("pair-1")
+        fail_key = persist_key("pair-1", "file.txt")
+        persist = self._make_persist(move_failed={fail_key})
+        updater, pipeline = self._make_updater([pc], persist)
+        updater._persist_sync = MagicMock()  # isolate from real PersistSync wiring
+        pipeline.spawn_move_process.return_value = False  # nothing in staging -> no-op
+
+        updater._retry_failed_moves()
+
+        pipeline.spawn_move_process.assert_called_once_with("file.txt", pc)
+        self.assertNotIn(fail_key, persist.move_failed_file_names)
+
+    def test_does_not_respawn_when_move_already_in_flight(self):
+        """If the move's key is already in moved_file_keys (a move is in flight or
+        just re-spawned), do not spawn another."""
+        pc = self._make_pair_context("pair-1")
+        fail_key = persist_key("pair-1", "file.txt")
+        persist = self._make_persist(move_failed={fail_key})
+        updater, pipeline = self._make_updater([pc], persist)
+        pipeline.moved_file_keys.add(fail_key)
+
+        updater._retry_failed_moves()
+
+        pipeline.spawn_move_process.assert_not_called()
+
+    def test_retry_budget_caps_respawns(self):
+        """A permanently-failing move must stop re-spawning after MAX_MOVE_RETRIES
+        so it doesn't loop forever."""
+        pc = self._make_pair_context("pair-1")
+        fail_key = persist_key("pair-1", "file.txt")
+        persist = self._make_persist(move_failed={fail_key})
+        updater, pipeline = self._make_updater([pc], persist)
+
+        # Each cycle the move "fails" again, so the key never enters moved_file_keys.
+        for _ in range(ModelUpdater.MAX_MOVE_RETRIES + 5):
+            updater._retry_failed_moves()
+
+        self.assertEqual(ModelUpdater.MAX_MOVE_RETRIES, pipeline.spawn_move_process.call_count)
+
+    def test_no_retry_when_staging_disabled(self):
+        """Without staging there are no moves to retry."""
+        pc = self._make_pair_context("pair-1")
+        fail_key = persist_key("pair-1", "file.txt")
+        persist = self._make_persist(move_failed={fail_key})
+        updater, pipeline = self._make_updater([pc], persist, use_staging=False, staging_path=None)
+
+        updater._retry_failed_moves()
+
+        pipeline.spawn_move_process.assert_not_called()
+
+    def test_no_retry_when_no_failed_moves(self):
+        pc = self._make_pair_context("pair-1")
+        persist = self._make_persist(move_failed=set())
+        updater, pipeline = self._make_updater([pc], persist)
+
+        updater._retry_failed_moves()
+
+        pipeline.spawn_move_process.assert_not_called()
+
+    def test_default_pair_failed_move_retries(self):
+        """A failed move on the default (pair_id=None) pair is also retried."""
+        pc = self._make_pair_context(None)
+        fail_key = persist_key(None, "file.txt")  # bare name for default pair
+        persist = self._make_persist(move_failed={fail_key})
+        updater, pipeline = self._make_updater([pc], persist)
+
+        updater._retry_failed_moves()
+
+        pipeline.spawn_move_process.assert_called_once_with("file.txt", pc)
+
+    def test_respawn_resumes_when_move_clears_in_flight_key(self):
+        """When a re-spawned move starts (key enters moved_file_keys) the budget
+        is not consumed on subsequent cycles; once it succeeds and clears the
+        failed set, no further spawns occur (clears state on success)."""
+        pc = self._make_pair_context("pair-1")
+        fail_key = persist_key("pair-1", "file.txt")
+        persist = self._make_persist(move_failed={fail_key})
+        updater, pipeline = self._make_updater([pc], persist)
+
+        # Cycle 1: re-spawn, simulate the move starting (key added).
+        updater._retry_failed_moves()
+        self.assertEqual(1, pipeline.spawn_move_process.call_count)
+        pipeline.moved_file_keys.add(fail_key)
+
+        # Cycle 2: move in flight -> no new spawn.
+        updater._retry_failed_moves()
+        self.assertEqual(1, pipeline.spawn_move_process.call_count)
+
+        # Move succeeds: finalize clears the failed set (simulated here).
+        persist.move_failed_file_names.discard(fail_key)
+
+        # Cycle 3: nothing left to retry.
+        updater._retry_failed_moves()
+        self.assertEqual(1, pipeline.spawn_move_process.call_count)

--- a/src/python/tests/unittests/test_controller/test_persist_sync.py
+++ b/src/python/tests/unittests/test_controller/test_persist_sync.py
@@ -16,13 +16,16 @@ class TestPersistSync(unittest.TestCase):
         pc.pair_id = pair_id
         return pc
 
-    def _make_persist(self, downloaded=None, extracted=None, extract_failed=None, validated=None, corrupt=None):
+    def _make_persist(
+        self, downloaded=None, extracted=None, extract_failed=None, validated=None, corrupt=None, move_failed=None
+    ):
         persist = MagicMock()
         persist.downloaded_file_names = downloaded or set()
         persist.extracted_file_names = extracted or set()
         persist.extract_failed_file_names = extract_failed or set()
         persist.validated_file_names = validated or set()
         persist.corrupt_file_names = corrupt or set()
+        persist.move_failed_file_names = move_failed or set()
         return persist
 
     def test_filters_keys_by_pair_id_prefix(self):
@@ -76,6 +79,7 @@ class TestPersistSync(unittest.TestCase):
             extract_failed={f"abc{KEY_SEP}bad.zip"},
             validated={f"abc{KEY_SEP}good.mkv"},
             corrupt={f"abc{KEY_SEP}corrupt.mkv"},
+            move_failed={f"abc{KEY_SEP}stuck.mkv"},
         )
 
         PersistSync([pc_abc], persist).sync()
@@ -85,6 +89,7 @@ class TestPersistSync(unittest.TestCase):
         pc_abc.model_builder.set_extract_failed_files.assert_called_once_with({"bad.zip"})
         pc_abc.model_builder.set_validated_files.assert_called_once_with({"good.mkv"})
         pc_abc.model_builder.set_corrupt_files.assert_called_once_with({"corrupt.mkv"})
+        pc_abc.model_builder.set_move_failed_files.assert_called_once_with({"stuck.mkv"})
 
     def test_filter_keys_for_pair_static(self):
         result = PersistSync._filter_keys_for_pair(

--- a/src/python/tests/unittests/test_controller/test_worker_supervisor.py
+++ b/src/python/tests/unittests/test_controller/test_worker_supervisor.py
@@ -1,0 +1,258 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+"""Tests for WorkerSupervisor: recreating dead extract/validate workers (#535).
+
+A ``multiprocessing.Process`` cannot be restarted in place. The supervisor holds
+the current live worker plus a factory and, on detecting a dead worker, builds a
+fresh one (set_mp_log_queue + start) and swaps it in. Because the Controller,
+CommandPipeline, and ModelUpdater all hold the *same* supervisor, one swap
+re-wires all three readers at once.
+
+These tests use MagicMock workers and a fake factory: they assert a new instance
+is created, that set_mp_log_queue + start are called on it, and that the three
+readers (dispatch + the two pop_* drains) then see the fresh worker.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from controller.command_pipeline import CommandPipeline
+from controller.model_updater import ModelUpdater
+from controller.worker_supervisor import WorkerSupervisor
+
+
+def _make_worker(name="Worker", *, alive=True, exitcode=None):
+    """A worker AppProcess-like mock with the full delegated surface."""
+    worker = MagicMock()
+    worker.name = name
+    worker.is_alive.return_value = alive
+    worker.exitcode = exitcode
+    worker.pop_latest_statuses.return_value = None
+    worker.pop_completed.return_value = []
+    worker.pop_failed.return_value = []
+    worker.propagate_exception.return_value = None
+    return worker
+
+
+class _FakeFactory:
+    """A callable that hands out a queue of pre-built workers, recording calls."""
+
+    def __init__(self, workers):
+        self._workers = list(workers)
+        self.created: list = []
+
+    def __call__(self):
+        worker = self._workers.pop(0)
+        self.created.append(worker)
+        return worker
+
+
+class TestWorkerSupervisorRecreation(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        # initial (will die) + replacement
+        self.initial = _make_worker("Worker-1", alive=True, exitcode=None)
+        self.replacement = _make_worker("Worker-2", alive=True, exitcode=None)
+        self.factory = _FakeFactory([self.initial, self.replacement])
+        self.sup: WorkerSupervisor = WorkerSupervisor(factory=self.factory, logger=self.logger, feature="Extract")
+
+    def test_factory_builds_initial_worker(self):
+        # The first factory call happens in __init__.
+        self.assertIs(self.initial, self.sup.worker)
+        self.assertEqual([self.initial], self.factory.created)
+
+    def test_set_mp_log_queue_delegates_to_current_worker(self):
+        self.sup.set_mp_log_queue("queue", 10)
+        self.initial.set_mp_log_queue.assert_called_once_with("queue", 10)
+
+    def test_delegates_start_terminate_join_close(self):
+        self.sup.start()
+        self.sup.terminate()
+        self.sup.join(2)
+        self.sup.close_queues()
+        self.initial.start.assert_called_once()
+        self.initial.terminate.assert_called_once()
+        self.initial.join.assert_called_once_with(2)
+        self.initial.close_queues.assert_called_once()
+
+    def test_delegates_unknown_method_via_getattr(self):
+        # extract()/validate() are forwarded through __getattr__.
+        req = MagicMock()
+        self.sup.extract(req)
+        self.initial.extract.assert_called_once_with(req)
+
+    def test_delegates_pop_readers(self):
+        self.sup.pop_latest_statuses()
+        self.sup.pop_completed()
+        self.sup.pop_failed()
+        self.initial.pop_latest_statuses.assert_called_once()
+        self.initial.pop_completed.assert_called_once()
+        self.initial.pop_failed.assert_called_once()
+
+    def test_recreate_noop_when_alive(self):
+        self.initial.is_alive.return_value = True
+        created = self.sup.recreate_if_dead()
+        self.assertFalse(created)
+        self.assertIs(self.initial, self.sup.worker)
+        self.assertEqual([self.initial], self.factory.created)
+
+    def test_recreate_noop_when_never_started(self):
+        # Not alive but exitcode is None => never started, leave it alone.
+        self.initial.is_alive.return_value = False
+        self.initial.exitcode = None
+        created = self.sup.recreate_if_dead()
+        self.assertFalse(created)
+        self.assertIs(self.initial, self.sup.worker)
+
+    def test_recreate_swaps_in_fresh_worker_with_logging_and_start(self):
+        # Wire up logging so the supervisor reapplies it to the fresh worker.
+        self.sup.set_mp_log_queue("log-queue", 20)
+        # The worker exited (exitcode set, not alive).
+        self.initial.is_alive.return_value = False
+        self.initial.exitcode = 1
+
+        created = self.sup.recreate_if_dead()
+
+        self.assertTrue(created)
+        # A NEW instance was built from the factory and swapped in.
+        self.assertIs(self.replacement, self.sup.worker)
+        self.assertEqual([self.initial, self.replacement], self.factory.created)
+        # The fresh worker was re-wired to the shared mp-log queue and started.
+        self.replacement.set_mp_log_queue.assert_called_once_with("log-queue", 20)
+        self.replacement.start.assert_called_once()
+        # The dead worker's queues were released to avoid FD leaks.
+        self.initial.join.assert_called_once()
+        self.initial.close_queues.assert_called_once()
+        # Death logged at WARNING, restart confirmed at INFO.
+        self.logger.warning.assert_called()
+        self.logger.info.assert_called()
+
+    def test_subsequent_dispatch_goes_to_fresh_worker(self):
+        self.initial.is_alive.return_value = False
+        self.initial.exitcode = 1
+        self.sup.recreate_if_dead()
+
+        # After recreation, dispatch + pop go to the fresh worker, not the dead one.
+        req = MagicMock()
+        self.sup.extract(req)
+        self.sup.pop_completed()
+
+        self.replacement.extract.assert_called_once_with(req)
+        self.replacement.pop_completed.assert_called_once()
+        self.initial.extract.assert_not_called()
+
+    def test_recreate_survives_dead_worker_close_failure(self):
+        # Releasing the dead worker's queues must not abort the swap.
+        self.initial.is_alive.return_value = False
+        self.initial.exitcode = 1
+        self.initial.close_queues.side_effect = RuntimeError("already closed")
+
+        created = self.sup.recreate_if_dead()
+
+        self.assertTrue(created)
+        self.assertIs(self.replacement, self.sup.worker)
+        self.replacement.start.assert_called_once()
+
+
+class TestSupervisorSharedByReaders(unittest.TestCase):
+    """A single supervisor is shared by CommandPipeline + ModelUpdater so one
+    swap re-wires both readers at once (the Controller holds the same ref)."""
+
+    def _make_pipeline(self, supervisor, logger=None):
+        return CommandPipeline(
+            pair_contexts=[],
+            registry=MagicMock(),
+            persist=MagicMock(),
+            context=MagicMock(),
+            password=None,
+            mp_logger=MagicMock(),
+            extract_process=supervisor,
+            validate_process=MagicMock(),
+            logger=logger or MagicMock(),
+            sync_persist_callback=MagicMock(),
+        )
+
+    def _make_updater(self, supervisor, pipeline):
+        # Persist categories and the registry must be iterable for the prune
+        # passes in update(); give them empty collections.
+        persist = MagicMock()
+        persist.downloaded_file_names = set()
+        persist.extracted_file_names = set()
+        persist.extract_failed_file_names = set()
+        persist.validated_file_names = set()
+        persist.corrupt_file_names = set()
+        registry = MagicMock()
+        registry.get_all_files.return_value = []
+        # Validate worker pop_* must yield empty results so update() can iterate.
+        validate = _make_worker("Validate", alive=True)
+        return ModelUpdater(
+            pair_contexts=[],
+            persist=persist,
+            pipeline=pipeline,
+            registry=registry,
+            extract_process=supervisor,
+            validate_process=validate,
+            context=MagicMock(),
+            password=None,
+            logger=MagicMock(),
+            persist_sync=MagicMock(),
+        )
+
+    def test_pipeline_recreate_rewires_updater_reads(self):
+        sup_logger = MagicMock()
+        pipeline_logger = MagicMock()
+        initial = _make_worker("Extract-1", alive=False, exitcode=2)
+        replacement = _make_worker("Extract-2", alive=True, exitcode=None)
+        factory = _FakeFactory([initial, replacement])
+        supervisor: WorkerSupervisor = WorkerSupervisor(factory=factory, logger=sup_logger, feature="Extract")
+        supervisor.set_mp_log_queue("q", 10)
+
+        pipeline = self._make_pipeline(supervisor, logger=pipeline_logger)
+        updater = self._make_updater(supervisor, pipeline)
+
+        # The controller cycle: propagate_exceptions detects the dead worker,
+        # reports it once at ERROR, then recreates it via the shared supervisor.
+        pipeline.propagate_exceptions()
+
+        # The fresh worker is live and is what the supervisor now delegates to.
+        self.assertIs(replacement, supervisor.worker)
+        replacement.start.assert_called_once()
+
+        # A single ERROR-on-death was emitted (via the pipeline logger),
+        # mentioning a restart (preserved from #511 while we now also recreate).
+        error_messages = [c.args[0] % c.args[1:] for c in pipeline_logger.error.call_args_list]
+        dead_reports = [m for m in error_messages if "has died" in m]
+        self.assertEqual(1, len(dead_reports), error_messages)
+        self.assertIn("restarted", dead_reports[0])
+        # The supervisor logged the actual restart at WARNING/INFO.
+        sup_logger.warning.assert_called()
+        sup_logger.info.assert_called()
+
+        # ModelUpdater.update() now drains the FRESH worker's queues, not the
+        # dead one's — the swap re-wired the updater through the shared supervisor.
+        updater.update()
+        replacement.pop_latest_statuses.assert_called()
+        replacement.pop_completed.assert_called()
+        replacement.pop_failed.assert_called()
+        initial.pop_completed.assert_not_called()
+
+    def test_pipeline_dispatch_after_recreate_targets_fresh_worker(self):
+        logger = MagicMock()
+        initial = _make_worker("Extract-1", alive=False, exitcode=2)
+        replacement = _make_worker("Extract-2", alive=True, exitcode=None)
+        factory = _FakeFactory([initial, replacement])
+        supervisor: WorkerSupervisor = WorkerSupervisor(factory=factory, logger=logger, feature="Extract")
+        pipeline = self._make_pipeline(supervisor)
+        pipeline.propagate_exceptions()
+
+        # Dispatch an extract through the pipeline's private handler; it must go
+        # to the fresh worker the supervisor swapped in.
+        supervisor.extract(MagicMock())
+        replacement.extract.assert_called_once()
+        initial.extract.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/python/tests/unittests/test_lftp/test_job_status_parser.py
+++ b/src/python/tests/unittests/test_lftp/test_job_status_parser.py
@@ -953,6 +953,39 @@ class TestLftpJobStatusParser(unittest.TestCase):
         statuses_jobs = [j for j in statuses if j.state == LftpJobStatus.State.RUNNING]
         self.assertEqual(golden_jobs, statuses_jobs)
 
+    def test_pget_no_data_line_followed_by_job_header(self):
+        """Regression for #555: a pget header with no data line (just connected,
+        nothing transferred yet) immediately followed by another job's header
+        must NOT consume that successor header.
+
+        Before the fix '_parse_pget_header_block' unconditionally popped the line
+        after 'sftp' as the data line, so the next job's '[2] mirror ...' header
+        was silently dropped and only one job was parsed.
+        """
+        output = """
+        [0] queue (sftp://someone:@localhost)
+        sftp://someone:@localhost/home/someone
+        Now executing: [1] pget -c /tmp/test_lftp/remote/c -o /tmp/test_lftp/local/
+        -[2] mirror -c /tmp/test_lftp/remote/a /tmp/test_lftp/local/
+        [1] pget -c /tmp/test_lftp/remote/c -o /tmp/test_lftp/local/
+        sftp://someone:@localhost/home/someone
+        [2] mirror -c /tmp/test_lftp/remote/a /tmp/test_lftp/local/
+        cd `/tmp/test_lftp/remote/a' [Connecting...]
+        """
+        parser = LftpJobStatusParser()
+        statuses = parser.parse(output)
+        golden_job1 = LftpJobStatus(
+            job_id=1, job_type=LftpJobStatus.Type.PGET, state=LftpJobStatus.State.RUNNING, name="c", flags="-c"
+        )
+        golden_job1.total_transfer_state = LftpJobStatus.TransferState(None, None, None, None, None)
+        golden_job2 = LftpJobStatus(
+            job_id=2, job_type=LftpJobStatus.Type.MIRROR, state=LftpJobStatus.State.RUNNING, name="a", flags="-c"
+        )
+        golden_jobs = [golden_job1, golden_job2]
+        self.assertEqual(len(golden_jobs), len(statuses))
+        statuses_jobs = [j for j in statuses if j.state == LftpJobStatus.State.RUNNING]
+        self.assertEqual(golden_jobs, statuses_jobs)
+
     def test_raises_error_on_bad_status(self):
         output = """
         [0] queue (sftp://someone:@localhost) 

--- a/src/python/tests/unittests/test_web/test_serialize/test_serialize_model.py
+++ b/src/python/tests/unittests/test_web/test_serialize/test_serialize_model.py
@@ -123,10 +123,12 @@ class TestSerializeModel(unittest.TestCase):
         i.state = ModelFile.State.VALIDATED
         j = ModelFile("j", False)
         j.state = ModelFile.State.CORRUPT
-        files = [a, b, c, d, e, f, g, h, i, j]
+        k = ModelFile("k", False)
+        k.state = ModelFile.State.MOVE_FAILED
+        files = [a, b, c, d, e, f, g, h, i, j, k]
         out = parse_stream(serialize.model(files))
         data = json.loads(out["data"])
-        self.assertEqual(10, len(data))
+        self.assertEqual(11, len(data))
         self.assertEqual("default", data[0]["state"])
         self.assertEqual("downloading", data[1]["state"])
         self.assertEqual("queued", data[2]["state"])
@@ -137,6 +139,7 @@ class TestSerializeModel(unittest.TestCase):
         self.assertEqual("validating", data[7]["state"])
         self.assertEqual("validated", data[8]["state"])
         self.assertEqual("corrupt", data[9]["state"])
+        self.assertEqual("move_failed", data[10]["state"])
 
     def test_remote_size(self):
         serialize = SerializeModel()

--- a/src/python/web/serialize/serialize_model.py
+++ b/src/python/web/serialize/serialize_model.py
@@ -53,6 +53,7 @@ class SerializeModel(Serialize):
         ModelFile.State.VALIDATING: "validating",
         ModelFile.State.VALIDATED: "validated",
         ModelFile.State.CORRUPT: "corrupt",
+        ModelFile.State.MOVE_FAILED: "move_failed",
     }
     __KEY_FILE_REMOTE_SIZE = "remote_size"
     __KEY_FILE_LOCAL_SIZE = "local_size"


### PR DESCRIPTION
Bundles the three **backend** audit follow-ups from the tracking issue #531.

> **⚠️ Stacked PR.** This is stacked on top of #557 (frontend follow-ups). Its base is `feat/audit-frontend-followups`, so the diff shows **only backend changes**. Merge #557 first; GitHub will then auto-retarget this PR to `develop`.

## Included

### fix(lftp): peek before consuming chunk-data line — Closes #555
- `_parse_pget_header_block` and `_parse_filename_chunk` previously popped the line after the `sftp` line **unconditionally** as the "data line". A pget with **no** data line followed immediately by another job's header would consume and silently drop that successor header.
- Now both **peek** and only pop when the next line is actually a chunk-data line (`_RE_CHUNK_AT`/`_RE_CHUNK_AT2`/`_RE_CHUNK_GOT`), via a small `_is_chunk_data_line` helper; otherwise it's left for the dispatch loop.
- The existing **100** parser cases pass unchanged; a regression test reproduces the no-data-line-followed-by-job scenario (fails before, passes after).

### fix(controller): recreate dead extract/validate workers — Closes #535
- New `WorkerSupervisor` holder owns the live worker + a factory and delegates the worker surface (`extract`/`validate`, `pop_completed`/`pop_failed`/`pop_latest_statuses`, `propagate_exception`, lifecycle).
- `Controller` constructs one supervisor per worker and passes the **same reference** into `CommandPipeline` and `ModelUpdater`. `recreate_if_dead()` (run each cycle in `propagate_exceptions()`) detects a dead worker via `is_alive()`/`exitcode`, builds a fresh instance, re-applies the mp-log queue, starts it, and swaps it in — re-wiring all three readers at once.
- Extraction/validation resumes after a transient worker fault **without a full service restart**. Existing fault-isolation + single ERROR-on-death preserved (restart logged at WARNING/INFO).

### fix(controller): surface failed moves + in-session retry — Closes #536
- A failed staging→final move now routes its `MoveFailedResult` into a new persisted **`move_failed_file_names`** set, rendering the file as the new **`ModelFile.State.MOVE_FAILED`** (serialized `"move_failed"`) instead of silently `DOWNLOADED` — mirroring the `extract_failed`/`corrupt` wiring across `model_builder`/persist/`persist_sync`/serialize.
- `ModelUpdater._retry_failed_moves()` re-spawns the move on the next update cycle (not only on restart), bounded by an in-memory `MAX_MOVE_RETRIES` budget; the state clears on success.
- ✅ **Frontend handling shipped in #557** (parent PR): the `move_failed` state renders a "Move failed" badge and is excluded from the queueable/action capability lists.

## Test plan
- `cd src/python && PYTHONPATH=. uv run pytest tests/unittests` → **926 passed**, 59 skipped (+13 new BE tests). The single failure, `test_scanner.py::test_scan_file_with_latin_chars`, is **pre-existing and macOS-only** (APFS rejects latin-1 filenames — `Errno 92`); it fails identically on the base branch and passes in CI's Linux/Docker test-image.
- `uv run ruff check .` and `uv run ruff check --select C901 .` → **all checks pass**.

Part of #531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automatic retry mechanism for files that fail to move from staging to final location (up to 3 retries per file)
  * New file state "Move Failed" indicates files unable to complete the staging-to-final transfer
  * Extract and validate workers now automatically recover from crashes without requiring service restart

* **Bug Fixes**
  * Fixed LFTP job status parser handling when chunk data lines are missing, preventing misalignment of subsequent job headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->