### PR TITLE
fix(ssh): remove unsupported GSSAPIAuthentication flag (Alpine crash on startup)

### DIFF
--- a/src/python/ssh/sshcp.py
+++ b/src/python/ssh/sshcp.py
@@ -260,12 +260,14 @@ class Sshcp:
             "ServerAliveInterval=15",
             "-o",
             "ServerAliveCountMax=3",
-            # Skip GSSAPI/Kerberos negotiation. Some servers (especially those
-            # doing reverse-DNS lookups on connect) delay the auth prompt by
-            # tens of seconds while GSSAPI is attempted; we never use it.
-            "-o",
-            "GSSAPIAuthentication=no",
         ]
+        # NOTE: do NOT add ``-o GSSAPIAuthentication=no`` here. The runtime
+        # image's Alpine openssh-client is built without GSSAPI, so ssh rejects
+        # the option ("command-line line 0: Unsupported option
+        # gssapiauthentication") and that text pollutes the captured error,
+        # which the classifier then surfaces as a failure. GSSAPI is never
+        # negotiated on that build, so there is nothing to disable. (Reverts the
+        # flag added in #562 — it broke shell detection on the Alpine image.)
 
         if self.__password is None:
             command_args += ["-o", "PasswordAuthentication=no"]

--- a/src/python/tests/unittests/test_ssh/test_sshcp_run_command.py
+++ b/src/python/tests/unittests/test_ssh/test_sshcp_run_command.py
@@ -15,7 +15,8 @@ class TestSshcpRunCommand(unittest.TestCase):
     SSH server by patching pexpect.spawn. These guard two fixes:
       * the password-prompt wait must use the full __TIMEOUT_SECS, not
         pexpect's silent 30s default;
-      * GSSAPI auth is disabled to avoid slow auth-prompt delays.
+      * the ``-o GSSAPIAuthentication=no`` flag must NOT be set — the Alpine
+        openssh-client lacks GSSAPI and rejects it as an unsupported option.
     """
 
     __TIMEOUT = Sshcp._Sshcp__TIMEOUT_SECS
@@ -61,11 +62,14 @@ class TestSshcpRunCommand(unittest.TestCase):
         self.assertEqual(1, len(expect_calls))
         self.assertEqual(self.__TIMEOUT, expect_calls[0].kwargs.get("timeout"))
 
-    def test_gssapi_auth_disabled(self):
+    def test_gssapi_option_not_set(self):
+        # The Alpine openssh-client in the runtime image is built without GSSAPI,
+        # so passing ``-o GSSAPIAuthentication=no`` is rejected as an unsupported
+        # option and breaks shell detection (#562 regression). It must NOT appear.
         for password in ("secret", None):
             with self.subTest(password=password):
                 command, _ = self._run(password=password)
-                self.assertIn("GSSAPIAuthentication=no", command)
+                self.assertNotIn("GSSAPIAuthentication", command)
 
     def test_password_auth_disables_pubkey(self):
         command, _ = self._run(password="secret")


### PR DESCRIPTION
## Problem

On the released image the controller crash-loops on startup with:

\`\`\`
ScannerError: ... 'Unknown error - command-line line 0: Unsupported option "gssapiauthentication"
ssh: connect to host <host> port 22: Network unreachable'
\`\`\`

The `-o GSSAPIAuthentication=no` flag (added in #562 to skip GSSAPI auth delays) is **rejected by the Alpine `openssh-client`**, which is built without GSSAPI. ssh prints `command-line line 0: Unsupported option "gssapiauthentication"`; `sshcp` captures that text and its classifier reports it as a failure, breaking `RemoteScanner.detect_shell()`.

Reproduced in `alpine:3.23` (OpenSSH 10.2p1): the option triggers the unsupported-option error; without it, ssh connects normally.

## Fix

Remove the `GSSAPIAuthentication=no` flag from `sshcp.__run_command` (with a NOTE so it isn't re-added). GSSAPI is never negotiated on a build without it, so there is nothing to disable — the option was pure downside on Alpine.

## Tests

- `test_gssapi_auth_disabled` → `test_gssapi_option_not_set`: now asserts the flag is **absent**.
- `pytest tests/unittests/test_ssh` ✅; full unit suite ✅ (only the known macOS/APFS pre-existing failure); ruff + ruff format + strict pyright clean.
- Verified end-to-end in a real `alpine:3.23` container: the sshcp-shaped command without the flag reaches auth cleanly.

## Note

This fixes the spurious GSSAPI error. The `Network unreachable` line in the report is a **separate** connection failure (the host has an AAAA record → likely the container attempting IPv6 with no route); tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSH command construction to improve compatibility with Alpine Linux's openssh-client build. Removed specific authentication options that would cause SSH to reject commands and corrupt error output, affecting shell detection behavior. Tests updated to verify correct behavior across authentication methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->