### PR TITLE
fix: MoveProcess lftp temp-file race + FTPS settings UI section

### DIFF
--- a/src/angular/src/app/pages/settings/options-list.spec.ts
+++ b/src/angular/src/app/pages/settings/options-list.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { getConfigValue, OPTIONS_CONTEXT_SERVER, IOption } from './options-list';
+import { getConfigValue, OPTIONS_CONTEXT_FTPS, IOption } from './options-list';
 import { OptionType } from './option.component';
 import { Config, DEFAULT_CONFIG } from '../../models/config';
 
-function findServerOption(section: string, option: string): IOption {
-  const found = OPTIONS_CONTEXT_SERVER.options.find(
+function findFtpsOption(section: string, option: string): IOption {
+  const found = OPTIONS_CONTEXT_FTPS.options.find(
     (o) => o.valuePath[0] === section && o.valuePath[1] === option,
   );
   expect(found).toBeDefined();
@@ -35,23 +35,23 @@ describe('getConfigValue', () => {
   });
 });
 
-describe('OPTIONS_CONTEXT_SERVER FTPS options', () => {
+describe('OPTIONS_CONTEXT_FTPS options', () => {
   it('renders the transfer protocol as a Select of sftp/ftps requiring restart', () => {
-    const protocol = findServerOption('lftp', 'protocol');
+    const protocol = findFtpsOption('lftp', 'protocol');
     expect(protocol.type).toBe(OptionType.Select);
     expect(protocol.choices).toEqual(['sftp', 'ftps']);
     expect(protocol.requiresRestart).toBe(true);
   });
 
   it('renders Remote FTP Port as a text field requiring restart', () => {
-    const port = findServerOption('lftp', 'remote_ftp_port');
+    const port = findFtpsOption('lftp', 'remote_ftp_port');
     expect(port.type).toBe(OptionType.Text);
     expect(port.label).toBe('Remote FTP Port');
     expect(port.requiresRestart).toBe(true);
   });
 
   it('renders the FTPS certificate verification as a Checkbox requiring restart', () => {
-    const verify = findServerOption('lftp', 'ftp_ssl_verify_certificate');
+    const verify = findFtpsOption('lftp', 'ftp_ssl_verify_certificate');
     expect(verify.type).toBe(OptionType.Checkbox);
     expect(verify.requiresRestart).toBe(true);
   });

--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -127,13 +127,26 @@ export const OPTIONS_CONTEXT_SERVER: IOptionsContext = {
         'Set this if your seedbox has a custom Python install (e.g. "~/python3/bin/python3").',
       requiresRestart: true,
     },
+  ],
+};
+
+/**
+ * Dedicated FTPS section (rendered top-right, above Connections) so the
+ * transfer-protocol choice and its FTPS-only options are discoverable instead
+ * of being buried among the SSH server fields.
+ */
+export const OPTIONS_CONTEXT_FTPS: IOptionsContext = {
+  header: 'FTPS',
+  id: 'ftps',
+  options: [
     {
       type: OptionType.Select,
       label: 'Transfer Protocol',
       valuePath: ['lftp', 'protocol'],
       description:
-        'Protocol used for bulk file transfers. File discovery always uses SSH, ' +
-        'so SSH access is required even when FTPS is selected.',
+        'SFTP (default) or FTPS for bulk file transfers. FTPS can be substantially faster ' +
+        'on high-latency links. File discovery always uses SSH, so SSH access is required ' +
+        'even when FTPS is selected.',
       choices: ['sftp', 'ftps'],
       requiresRestart: true,
     },

--- a/src/angular/src/app/pages/settings/settings-page.component.html
+++ b/src/angular/src/app/pages/settings/settings-page.component.html
@@ -31,6 +31,10 @@
     </div>
     <div id="right">
       <ng-container
+        *ngTemplateOutlet="optionsList; context: ftpsContext">
+      </ng-container>
+
+      <ng-container
         *ngTemplateOutlet="optionsList; context: OPTIONS_CONTEXT_CONNECTIONS">
       </ng-container>
 

--- a/src/angular/src/app/pages/settings/settings-page.component.spec.ts
+++ b/src/angular/src/app/pages/settings/settings-page.component.spec.ts
@@ -4,15 +4,16 @@ import { SettingsPageComponent } from './settings-page.component';
 import { FTPS_ONLY_NOTE, IOptionsContext } from './options-list';
 
 interface SettingsPageStatics {
-  buildServerContext(hasEnabledPairs: boolean, protocolIsSftp: boolean): IOptionsContext;
+  buildServerContext(hasEnabledPairs: boolean): IOptionsContext;
+  buildFtpsContext(protocolIsSftp: boolean): IOptionsContext;
   buildAutoqueueContext(hasEnabledPairs: boolean): IOptionsContext;
   OVERRIDE_NOTE: string;
 }
 const settingsStatics = SettingsPageComponent as unknown as SettingsPageStatics;
-// protocolIsSftp defaults to false (ftps) so the pre-existing pairs-greying
-// tests below see the FTP-only options enabled and unaffected.
-const buildServerContext = (hasEnabledPairs: boolean, protocolIsSftp = false): IOptionsContext =>
-  settingsStatics.buildServerContext(hasEnabledPairs, protocolIsSftp);
+const buildServerContext = (hasEnabledPairs: boolean): IOptionsContext =>
+  settingsStatics.buildServerContext(hasEnabledPairs);
+const buildFtpsContext = (protocolIsSftp: boolean): IOptionsContext =>
+  settingsStatics.buildFtpsContext(protocolIsSftp);
 const buildAutoqueueContext = (hasEnabledPairs: boolean): IOptionsContext =>
   settingsStatics.buildAutoqueueContext(hasEnabledPairs);
 const OVERRIDE_NOTE = settingsStatics.OVERRIDE_NOTE;
@@ -50,11 +51,11 @@ describe('SettingsPageComponent.buildServerContext', () => {
   });
 });
 
-describe('SettingsPageComponent.buildServerContext FTPS greying', () => {
+describe('SettingsPageComponent.buildFtpsContext', () => {
   const ftpOnlyPaths = ['remote_ftp_port', 'ftp_ssl_verify_certificate'];
 
   it('disables the FTP-only options when the protocol is sftp', () => {
-    const ctx = buildServerContext(false, true);
+    const ctx = buildFtpsContext(true);
     for (const path of ftpOnlyPaths) {
       const option = ctx.options.find((o) => o.valuePath[1] === path)!;
       expect(option.disabled).toBe(true);
@@ -63,7 +64,7 @@ describe('SettingsPageComponent.buildServerContext FTPS greying', () => {
   });
 
   it('enables the FTP-only options when the protocol is ftps', () => {
-    const ctx = buildServerContext(false, false);
+    const ctx = buildFtpsContext(false);
     for (const path of ftpOnlyPaths) {
       const option = ctx.options.find((o) => o.valuePath[1] === path)!;
       expect(option.disabled).toBeFalsy();
@@ -71,7 +72,7 @@ describe('SettingsPageComponent.buildServerContext FTPS greying', () => {
   });
 
   it('never disables the protocol selector itself', () => {
-    const protocol = buildServerContext(false, true).options.find((o) => o.valuePath[1] === 'protocol')!;
+    const protocol = buildFtpsContext(true).options.find((o) => o.valuePath[1] === 'protocol')!;
     expect(protocol.disabled).toBeFalsy();
   });
 });

--- a/src/angular/src/app/pages/settings/settings-page.component.ts
+++ b/src/angular/src/app/pages/settings/settings-page.component.ts
@@ -23,6 +23,7 @@ import {
   OVERRIDE_NOTE,
   getConfigValue,
   OPTIONS_CONTEXT_SERVER,
+  OPTIONS_CONTEXT_FTPS,
   OPTIONS_CONTEXT_DISCOVERY,
   OPTIONS_CONTEXT_CONNECTIONS,
   OPTIONS_CONTEXT_OTHER,
@@ -52,16 +53,9 @@ import {
 })
 export class SettingsPageComponent implements OnInit {
   serverContext: IOptionsContext = OPTIONS_CONTEXT_SERVER;
+  ftpsContext: IOptionsContext = OPTIONS_CONTEXT_FTPS;
   autoqueueContext: IOptionsContext = OPTIONS_CONTEXT_AUTOQUEUE;
   validateContext: IOptionsContext = OPTIONS_CONTEXT_VALIDATE;
-
-  // Latest inputs to the server-context disable rules. The server options are
-  // greyed by two independent streams — Path Pairs (hasEnabledPairs) and the
-  // transfer protocol (protocolIsSftp) — so both are tracked here and the
-  // context is rebuilt whenever either changes. Defaults match a fresh load
-  // (no enabled pairs; sftp).
-  private hasEnabledPairs = false;
-  private protocolIsSftp = true;
   readonly OPTIONS_CONTEXT_DISCOVERY = OPTIONS_CONTEXT_DISCOVERY;
   readonly OPTIONS_CONTEXT_CONNECTIONS = OPTIONS_CONTEXT_CONNECTIONS;
   readonly OPTIONS_CONTEXT_OTHER = OPTIONS_CONTEXT_OTHER;
@@ -119,8 +113,7 @@ export class SettingsPageComponent implements OnInit {
       distinctUntilChanged(),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((hasEnabledPairs) => {
-      this.hasEnabledPairs = hasEnabledPairs;
-      this.serverContext = SettingsPageComponent.buildServerContext(hasEnabledPairs, this.protocolIsSftp);
+      this.serverContext = SettingsPageComponent.buildServerContext(hasEnabledPairs);
       this.autoqueueContext = SettingsPageComponent.buildAutoqueueContext(hasEnabledPairs);
       this.cdr.markForCheck();
     });
@@ -135,9 +128,8 @@ export class SettingsPageComponent implements OnInit {
       ),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe(({ validateEnabled, protocolIsSftp }) => {
-      this.protocolIsSftp = protocolIsSftp;
       this.validateContext = SettingsPageComponent.buildValidateContext(validateEnabled);
-      this.serverContext = SettingsPageComponent.buildServerContext(this.hasEnabledPairs, protocolIsSftp);
+      this.ftpsContext = SettingsPageComponent.buildFtpsContext(protocolIsSftp);
       this.cdr.markForCheck();
     });
   }
@@ -166,9 +158,17 @@ export class SettingsPageComponent implements OnInit {
     };
   }
 
-  private static buildServerContext(hasEnabledPairs: boolean, protocolIsSftp: boolean): IOptionsContext {
+  private static buildServerContext(hasEnabledPairs: boolean): IOptionsContext {
     return SettingsPageComponent.applyDisableRules(OPTIONS_CONTEXT_SERVER, {
       pairsEnabled: hasEnabledPairs,
+      validateDisabled: false,
+      protocolSftp: false,
+    });
+  }
+
+  private static buildFtpsContext(protocolIsSftp: boolean): IOptionsContext {
+    return SettingsPageComponent.applyDisableRules(OPTIONS_CONTEXT_FTPS, {
+      pairsEnabled: false,
       validateDisabled: false,
       protocolSftp: protocolIsSftp,
     });

--- a/src/python/controller/move/move_process.py
+++ b/src/python/controller/move/move_process.py
@@ -9,7 +9,7 @@ import os
 import queue
 import shutil
 
-from common import AppOneShotProcess, overrides
+from common import AppOneShotProcess, Constants, overrides
 
 
 class MoveFailedResult:
@@ -84,6 +84,19 @@ class MoveProcess(AppOneShotProcess):
                     total += os.path.getsize(dst_file)
         return total
 
+    @staticmethod
+    def _has_lftp_temp_files(src: str) -> bool:
+        """True if the source tree still contains lftp temp files (``*.lftp``).
+
+        lftp writes each download to ``<name>.lftp`` and renames it to the final
+        name on completion. A staging tree that still holds temp files has not
+        been finalized — moving it would race lftp's in-flight rename.
+        """
+        suffix = Constants.LFTP_TEMP_FILE_SUFFIX
+        if os.path.isfile(src):
+            return src.endswith(suffix)
+        return any(any(f.endswith(suffix) for f in filenames) for _root, _dirs, filenames in os.walk(src))
+
     def _report_failure(self, message: str) -> None:
         """Log and publish a move failure so the controller can surface it."""
         self.logger.error(message)
@@ -102,6 +115,19 @@ class MoveProcess(AppOneShotProcess):
 
         if not os.path.exists(src):
             self._report_failure(f"Move failed: source does not exist: {src}")
+            return
+
+        # Defer while lftp is still finalizing the staging tree. lftp renames
+        # "<name>.lftp" -> "<name>" on completion; copying (or renaming the
+        # whole tree) while a rename is in flight races — copytree lists the
+        # ".lftp" entry, lftp renames it, and the copy then fails with ENOENT
+        # (which used to crash this process). A tree that still has temp files is
+        # not ready, so report a recoverable failure and retry once lftp finishes.
+        if self._has_lftp_temp_files(src):
+            self._report_failure(
+                f"Move deferred for {self.__file_name}: download not finalized "
+                "(lftp temp files still present in staging). Will retry."
+            )
             return
 
         self.logger.info(f"Moving {src} -> {dst}")
@@ -127,10 +153,18 @@ class MoveProcess(AppOneShotProcess):
         # Cross-device fallback: copy, verify size, then remove source
         source_size = self._get_total_size(src)
 
-        if os.path.isfile(src):
-            shutil.copy2(src, dst)
-        else:
-            shutil.copytree(src, dst, dirs_exist_ok=True)
+        try:
+            if os.path.isfile(src):
+                shutil.copy2(src, dst)
+            else:
+                shutil.copytree(src, dst, dirs_exist_ok=True)
+        except (shutil.Error, OSError) as e:
+            # A *.lftp temp file can still be renamed by lftp during the copy (a
+            # narrow window the pre-check above doesn't fully close). Report a
+            # recoverable failure and keep the source intact so the move is
+            # retried — never crash the controller.
+            self._report_failure(f"Move copy failed for {self.__file_name}: {e}. Source NOT deleted.")
+            return
 
         # Verify only the copied subtree (ignore pre-existing files under dst)
         copied_size = self._get_copied_size(src, dst)

--- a/src/python/tests/unittests/test_controller/test_move_process.py
+++ b/src/python/tests/unittests/test_controller/test_move_process.py
@@ -258,6 +258,55 @@ class TestMoveProcess(unittest.TestCase):
             with self.assertRaises(OSError):
                 self._run_process(process)
 
+    def test_move_defers_when_lftp_temp_files_present(self):
+        """A staging tree still holding *.lftp temp files is not finalized: the
+        move must defer (recoverable failure) without copying or deleting, so it
+        is retried once lftp finishes renaming."""
+        src_subdir = os.path.join(self.src_dir, "mydir")
+        os.makedirs(src_subdir)
+        with open(os.path.join(src_subdir, "done.mkv"), "w") as f:
+            f.write("finished")
+        # An in-flight lftp temp file makes the tree non-quiescent.
+        with open(os.path.join(src_subdir, "inprogress.mkv.lftp"), "w") as f:
+            f.write("partial")
+
+        process = self._make_process(
+            source_path=self.src_dir, dest_path=self.dst_dir, file_name="mydir", pair_id="pair-3"
+        )
+        self._run_process(process)
+
+        failures = process.pop_failed()
+        self.assertEqual(1, len(failures))
+        self.assertIn("not finalized", failures[0].error_message)
+        # Nothing copied or deleted: source intact, dest not created.
+        self.assertTrue(os.path.exists(src_subdir))
+        self.assertFalse(os.path.exists(os.path.join(self.dst_dir, "mydir")))
+
+    def test_move_copy_error_reports_failure_and_keeps_source(self):
+        """A copy error (e.g. an lftp temp file renamed mid-copy) must be reported
+        as a recoverable failure with the source kept — never raised/crashing the
+        controller."""
+        src_subdir = os.path.join(self.src_dir, "mydir")
+        os.makedirs(src_subdir)
+        with open(os.path.join(src_subdir, "a.txt"), "w") as f:
+            f.write("payload")
+
+        process = self._make_process(
+            source_path=self.src_dir, dest_path=self.dst_dir, file_name="mydir", pair_id="pair-4"
+        )
+        with (
+            mock.patch("controller.move.move_process.os.rename", side_effect=OSError(errno.EXDEV, "cross-device")),
+            mock.patch("controller.move.move_process.shutil.copytree", side_effect=shutil.Error("boom")),
+        ):
+            # Must not raise.
+            self._run_process(process)
+
+        failures = process.pop_failed()
+        self.assertEqual(1, len(failures))
+        self.assertIn("copy failed", failures[0].error_message)
+        # Source must remain intact.
+        self.assertTrue(os.path.exists(src_subdir))
+
     def test_get_copied_size_ignores_preexisting_dest_files(self):
         """_get_copied_size sums only files that exist in the source subtree"""
         src_subdir = os.path.join(self.src_dir, "mydir")


### PR DESCRIPTION
Two fixes bundled per request.

---

## 1. fix(move): defer staging→final move while lftp temp files present

**Problem:** the controller logs a crashing `MoveProcess` + repeated tracebacks during downloads:

\`\`\`
File ".../move_process.py", line 133, in run_once
  shutil.copytree(src, dst, dirs_exist_ok=True)
shutil.Error: [('/data/lftpsync/.../S15E01...mkv.lftp', ..., "[Errno 2] No such file or directory: ...mkv.lftp")]
\`\`\`

The cross-device copy fallback races lftp: `copytree` lists a `<name>.lftp` temp file, lftp renames it to the final name mid-copy, the copy fails with `ENOENT`, and the uncaught `shutil.Error` kills the MoveProcess child (then `_finalize_move_process` catches it, retries, and re-races).

**Fix (`MoveProcess.run_once`):**
- **Defer** (recoverable failure → retry) when the staging tree still holds `*.lftp` temp files — don't race the rename. Only fires in the race/anomaly window (normally lftp has renamed by the `DOWNLOADED` state).
- **Catch** `shutil.Error`/`OSError` around the copy as a backstop → recoverable failure, **source kept** (no data loss), controller never crashes; existing `MOVE_FAILED` retry then succeeds once lftp finishes.
- Tests: `test_move_defers_when_lftp_temp_files_present`, `test_move_copy_error_reports_failure_and_keeps_source`.

---

## 2. feat(settings): move FTPS options into a dedicated section

The transfer-protocol choice and its FTPS-only options were buried in the Server card and easy to miss. Pull them into their own **FTPS** section rendered top-right above **Connections** so the feature is discoverable:

- New `OPTIONS_CONTEXT_FTPS` (Transfer Protocol selector + Remote FTP Port + Verify FTPS certificate); removed from the Server group.
- New `buildFtpsContext` carries the protocol-driven greying (port + verify greyed while protocol = sftp); `serverContext` no longer depends on protocol (component simplified).
- Specs updated (greying → `buildFtpsContext`, option assertions → FTPS context).

---

## Validation
Full Python unit suite passes (only the known macOS/APFS pre-existing failure); `ng lint` + `ng test` (567) pass; ruff + ruff format + strict pyright clean. The two changes touch disjoint files (Python backend vs Angular settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)