### PR TITLE
fix(lftp): stop overriding Connections settings under FTPS

### DIFF
--- a/src/python/controller/pair_context.py
+++ b/src/python/controller/pair_context.py
@@ -138,27 +138,18 @@ def validate_config(context: Context) -> None:
 def configure_lftp(lftp: Lftp, config: Config) -> None:
     """Apply shared LFTP configuration settings.
 
-    The parallelism profile is protocol-aware: under ``ftps`` the validated
-    FTPS profile (file-level parallelism with pget-n low) is derived from the
-    protocol at apply-time, overriding the persisted SFTP-tuned values. This
-    closes the migration gap for upgraders and hand-edited configs that switch
-    to FTPS without retuning. Under ``sftp`` the persisted values pass through
-    unchanged (today's behavior).
+    Parallelism comes from the persisted Connections settings for both
+    protocols. FTPS previously overrode these with a fixed profile derived at
+    apply-time, which silently ignored the user's Connections settings (the
+    Settings UI showed values that were never applied); that override has been
+    removed so what the UI shows is what lftp runs.
     """
     cfg = config.lftp
     lftp.num_parallel_jobs = cfg.num_max_parallel_downloads  # type: ignore[assignment]
-    if cfg.protocol == "ftps":
-        # Validated FTPS profile (design §11.3): mirror:parallel-transfer-count=4,
-        # mirror:use-pget-n=1, pget:default-n=4, net:connection-limit=8.
-        lftp.num_parallel_files = 4
-        lftp.num_connections_per_dir_file = 1
-        lftp.num_connections_per_root_file = 4
-        lftp.num_max_total_connections = 8
-    else:
-        lftp.num_parallel_files = cfg.num_max_parallel_files_per_download  # type: ignore[assignment]
-        lftp.num_connections_per_root_file = cfg.num_max_connections_per_root_file  # type: ignore[assignment]
-        lftp.num_connections_per_dir_file = cfg.num_max_connections_per_dir_file  # type: ignore[assignment]
-        lftp.num_max_total_connections = cfg.num_max_total_connections  # type: ignore[assignment]
+    lftp.num_parallel_files = cfg.num_max_parallel_files_per_download  # type: ignore[assignment]
+    lftp.num_connections_per_root_file = cfg.num_max_connections_per_root_file  # type: ignore[assignment]
+    lftp.num_connections_per_dir_file = cfg.num_max_connections_per_dir_file  # type: ignore[assignment]
+    lftp.num_max_total_connections = cfg.num_max_total_connections  # type: ignore[assignment]
     lftp.use_temp_file = cfg.use_temp_file  # type: ignore[assignment]
     lftp.temp_file_name = "*" + Constants.LFTP_TEMP_FILE_SUFFIX
     if cfg.net_limit_rate:

--- a/src/python/tests/unittests/test_controller/test_pair_context.py
+++ b/src/python/tests/unittests/test_controller/test_pair_context.py
@@ -313,14 +313,18 @@ class TestConfigureLftp(unittest.TestCase):
         self.assertEqual(lftp.num_connections_per_dir_file, 20)
         self.assertEqual(lftp.num_max_total_connections, 0)
 
-    def test_ftps_profile_overrides_persisted_sftp_tuning(self):
-        """Under ftps, the validated FTPS profile (§11.3) is applied regardless of
-        the persisted SFTP-tuned values: parallel-files=4, use-pget-n=1,
-        pget:default-n=4, connection-limit=8."""
+    def test_ftps_passes_persisted_values_through(self):
+        """Under ftps, persisted Connections values pass through unchanged.
+
+        The former fixed FTPS profile (parallel-files=4, dir-pget=1, root-pget=4,
+        connection-limit=8) silently overrode the user's Connections settings; it
+        has been removed. The persisted values below are deliberately all distinct
+        from that old profile, so asserting they reach lftp proves the override is
+        gone.
+        """
         lftp = MagicMock()
         config = Config()
         config.lftp.protocol = "ftps"
-        # Persisted SFTP-tuned values that should be overridden under ftps
         config.lftp.num_max_parallel_downloads = 2
         config.lftp.num_max_parallel_files_per_download = 3
         config.lftp.num_max_connections_per_root_file = 20
@@ -332,8 +336,8 @@ class TestConfigureLftp(unittest.TestCase):
 
         # num_parallel_jobs is protocol-agnostic (queue parallelism)
         self.assertEqual(lftp.num_parallel_jobs, 2)
-        # FTPS profile overrides
-        self.assertEqual(lftp.num_parallel_files, 4)
-        self.assertEqual(lftp.num_connections_per_dir_file, 1)
-        self.assertEqual(lftp.num_connections_per_root_file, 4)
-        self.assertEqual(lftp.num_max_total_connections, 8)
+        # Persisted Connections values reach lftp unchanged under ftps
+        self.assertEqual(lftp.num_parallel_files, 3)
+        self.assertEqual(lftp.num_connections_per_root_file, 20)
+        self.assertEqual(lftp.num_connections_per_dir_file, 20)
+        self.assertEqual(lftp.num_max_total_connections, 0)


### PR DESCRIPTION
## Summary

`configure_lftp()` hard-coded a fixed parallelism profile (`parallel-files=4`, `dir-pget=1`, `root-pget=4`, `connection-limit=8`) whenever `protocol=ftps`, **silently ignoring the user's Connections settings** — the Settings UI showed values that were never applied under FTPS.

This removes the override so the persisted Connections values apply for **both** protocols. What the UI shows is now what lftp runs.

### Why
Empirical throughput testing against a live seedbox (FTPS, ~3.2 GB file, 138 ms RTT) showed the forced profile was not just invisible to the user but actively counterproductive on an aggregate-throttled account:

| pget streams | throughput |
|---|---|
| n=1 | **44.9 MB/s** |
| n=4 | 41.3 MB/s |
| n=8 | 37.3 MB/s |

More streams = *lower* throughput — the signature of a fixed aggregate cap on the seedbox side, where extra connections only add per-stream overhead. SFTP and FTPS hit the same ~45 MB/s ceiling, so the forced FTPS parallelism profile could never help and the user couldn't tune it away because the UI values weren't being applied.

## Changes
- `controller/pair_context.py` — delete the `if cfg.protocol == "ftps":` branch; parallelism is taken from persisted Connections settings unconditionally. Docstring updated to explain the removal (and warn against re-adding it).
- `tests/unittests/test_controller/test_pair_context.py` — `test_ftps_profile_overrides_persisted_sftp_tuning` → `test_ftps_passes_persisted_values_through`. Persisted values (`3 / 20 / 20 / 0`) are deliberately all distinct from the old profile (`4 / 4 / 1 / 8`), so asserting they reach lftp proves the override is gone.

## Test plan
- [x] `test_pair_context.py` — 20/20 pass
- [x] Full controller unittest suite — 489 pass
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] Grepped all other `protocol == "ftps"` sites — all are connection/port/scheme setup (`controller.py`, `lftp.py`, `validate_config` port check); none touch parallelism, so nothing else depended on the forced profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FTPS connections now apply persisted parallelism and connection limit settings instead of using protocol-specific defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->