### PR TITLE
feat(settings): rename FTPS section to "Transfer Protocol"

### DIFF
--- a/src/angular/src/app/pages/settings/options-list.ts
+++ b/src/angular/src/app/pages/settings/options-list.ts
@@ -131,12 +131,12 @@ export const OPTIONS_CONTEXT_SERVER: IOptionsContext = {
 };
 
 /**
- * Dedicated FTPS section (rendered top-right, above Connections) so the
- * transfer-protocol choice and its FTPS-only options are discoverable instead
- * of being buried among the SSH server fields.
+ * Dedicated Transfer Protocol section (rendered top-right, above Connections)
+ * so the transfer-protocol choice and its FTPS-only options are discoverable
+ * instead of being buried among the SSH server fields.
  */
 export const OPTIONS_CONTEXT_FTPS: IOptionsContext = {
-  header: 'FTPS',
+  header: 'Transfer Protocol',
   id: 'ftps',
   options: [
     {


### PR DESCRIPTION
## Summary

Renames the dedicated settings section that groups the transfer-protocol choice and its FTPS-only options from **"FTPS"** to **"Transfer Protocol"**. The section reads as a protocol chooser (SFTP/FTPS) rather than implying FTPS is the only or active option.

- `options-list.ts` — `OPTIONS_CONTEXT_FTPS.header`: `'FTPS'` → `'Transfer Protocol'`; section doc-comment updated to match.
- Functional strings are intentionally **unchanged**: the `sftp`/`ftps` choice, "Remote FTP Port", "Verify FTPS certificate", the `FTPS_ONLY_NOTE` helper text, and the section `id` (`'ftps'`) — so no other code references break.

This is a label-only cosmetic change with no behavior change.

## Test plan

- `npx ng lint` — clean.
- `npx ng test` — 567/567 pass (42 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)