### PR TITLE
Fix recurring mobile file-list scrolling (#370)

### DIFF
--- a/src/angular/src/app/pages/files/file-list.component.html
+++ b/src/angular/src/app/pages/files/file-list.component.html
@@ -22,41 +22,33 @@
         </app-bulk-action-bar>
       }
     }
+    <ng-template #fileRow let-file let-isEven="isEven">
+        <div class="file-row" [class.even]="isEven">
+            <app-file
+                [file]="file"
+                [options]="options"
+                (click)="onSelect(file)"
+                (checkEvent)="onCheck($event)"
+                (queueEvent)="onQueue($event)"
+                (stopEvent)="onStop($event)"
+                (extractEvent)="onExtract($event)"
+                (validateEvent)="onValidate($event)"
+                (deleteLocalEvent)="onDeleteLocal($event)"
+                (deleteRemoteEvent)="onDeleteRemote($event)">
+            </app-file>
+        </div>
+    </ng-template>
     @if (useNativeScrolling()) {
         <div class="file-viewport native-file-viewport">
             @for (file of files | async; track identify($index, file); let isEven = $even) {
-                <div class="file-row" [class.even]="isEven">
-                    <app-file
-                        [file]="file"
-                        [options]="options"
-                        (click)="onSelect(file)"
-                        (checkEvent)="onCheck($event)"
-                        (queueEvent)="onQueue($event)"
-                        (stopEvent)="onStop($event)"
-                        (extractEvent)="onExtract($event)"
-                        (validateEvent)="onValidate($event)"
-                        (deleteLocalEvent)="onDeleteLocal($event)"
-                        (deleteRemoteEvent)="onDeleteRemote($event)">
-                    </app-file>
-                </div>
+                <ng-container [ngTemplateOutlet]="fileRow" [ngTemplateOutletContext]="{$implicit: file, isEven: isEven}" />
             }
         </div>
     } @else {
         <cdk-virtual-scroll-viewport itemSize="82" class="file-viewport">
-            <div *cdkVirtualFor="let file of files; trackBy: identify; let isEven = even" class="file-row" [class.even]="isEven">
-                <app-file
-                    [file]="file"
-                    [options]="options"
-                    (click)="onSelect(file)"
-                    (checkEvent)="onCheck($event)"
-                    (queueEvent)="onQueue($event)"
-                    (stopEvent)="onStop($event)"
-                    (extractEvent)="onExtract($event)"
-                    (validateEvent)="onValidate($event)"
-                    (deleteLocalEvent)="onDeleteLocal($event)"
-                    (deleteRemoteEvent)="onDeleteRemote($event)">
-                </app-file>
-            </div>
+            <ng-container *cdkVirtualFor="let file of files; trackBy: identify; let isEven = even">
+                <ng-container [ngTemplateOutlet]="fileRow" [ngTemplateOutletContext]="{$implicit: file, isEven: isEven}" />
+            </ng-container>
         </cdk-virtual-scroll-viewport>
     }
 </div>

--- a/src/angular/src/app/pages/files/file-list.component.html
+++ b/src/angular/src/app/pages/files/file-list.component.html
@@ -22,20 +22,41 @@
         </app-bulk-action-bar>
       }
     }
-    <cdk-virtual-scroll-viewport itemSize="82" class="file-viewport">
-        <div *cdkVirtualFor="let file of files; trackBy: identify; let isEven = even" class="file-row" [class.even]="isEven">
-            <app-file
-                [file]="file"
-                [options]="options"
-                (click)="onSelect(file)"
-                (checkEvent)="onCheck($event)"
-                (queueEvent)="onQueue($event)"
-                (stopEvent)="onStop($event)"
-                (extractEvent)="onExtract($event)"
-                (validateEvent)="onValidate($event)"
-                (deleteLocalEvent)="onDeleteLocal($event)"
-                (deleteRemoteEvent)="onDeleteRemote($event)">
-            </app-file>
+    @if (useNativeScrolling()) {
+        <div class="file-viewport native-file-viewport">
+            @for (file of files | async; track identify($index, file); let isEven = $even) {
+                <div class="file-row" [class.even]="isEven">
+                    <app-file
+                        [file]="file"
+                        [options]="options"
+                        (click)="onSelect(file)"
+                        (checkEvent)="onCheck($event)"
+                        (queueEvent)="onQueue($event)"
+                        (stopEvent)="onStop($event)"
+                        (extractEvent)="onExtract($event)"
+                        (validateEvent)="onValidate($event)"
+                        (deleteLocalEvent)="onDeleteLocal($event)"
+                        (deleteRemoteEvent)="onDeleteRemote($event)">
+                    </app-file>
+                </div>
+            }
         </div>
-    </cdk-virtual-scroll-viewport>
+    } @else {
+        <cdk-virtual-scroll-viewport itemSize="82" class="file-viewport">
+            <div *cdkVirtualFor="let file of files; trackBy: identify; let isEven = even" class="file-row" [class.even]="isEven">
+                <app-file
+                    [file]="file"
+                    [options]="options"
+                    (click)="onSelect(file)"
+                    (checkEvent)="onCheck($event)"
+                    (queueEvent)="onQueue($event)"
+                    (stopEvent)="onStop($event)"
+                    (extractEvent)="onExtract($event)"
+                    (validateEvent)="onValidate($event)"
+                    (deleteLocalEvent)="onDeleteLocal($event)"
+                    (deleteRemoteEvent)="onDeleteRemote($event)">
+                </app-file>
+            </div>
+        </cdk-virtual-scroll-viewport>
+    }
 </div>

--- a/src/angular/src/app/pages/files/file-list.component.scss
+++ b/src/angular/src/app/pages/files/file-list.component.scss
@@ -16,6 +16,16 @@
     height: calc(100vh - var(--file-list-chrome-height, 160px));
     height: calc(100dvh - var(--file-list-chrome-height, 160px));
     min-height: 200px;
+    overflow-anchor: none;
+    scroll-behavior: auto;
+}
+
+/* Mobile rows wrap and can expand to show details/actions, so they cannot use
+   CDK's fixed-size virtual scroll strategy. Keep the same bounded viewport and
+   let the browser scroll the naturally-sized rows instead. */
+.native-file-viewport {
+    overflow-y: auto;
+    overscroll-behavior-y: contain;
 }
 
 /* striped rows — use template-driven .even class instead of :nth-child

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -175,6 +175,31 @@ describe('FileListComponent', () => {
     expect(fixture.nativeElement.querySelectorAll('app-file').length).toBe(3);
   });
 
+  it('should render naturally-sized rows instead of fixed virtual rows on mobile', () => {
+    fixture.destroy();
+    fixture = TestBed.createComponent(FileListComponent);
+    component = fixture.componentInstance;
+    component.useNativeScrolling.set(true);
+    filteredFilesSubject.next(Array.from(
+      { length: 25 },
+      (_, index) => makeViewFile({ name: `file-${index}.mkv` }),
+    ));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('cdk-virtual-scroll-viewport')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.native-file-viewport')).not.toBeNull();
+    expect(fixture.nativeElement.querySelectorAll('.file-row').length).toBe(25);
+  });
+
+  it('should retain virtual scrolling outside the mobile breakpoint', () => {
+    component.useNativeScrolling.set(false);
+    fixture.detectChanges();
+
+    const viewport = fixture.nativeElement.querySelector('cdk-virtual-scroll-viewport');
+    expect(viewport).not.toBeNull();
+    expect(viewport.getAttribute('itemsize')).toBe('82');
+  });
+
   // --- Header ---
 
   it('should render the header row with column labels', () => {

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -175,6 +175,49 @@ describe('FileListComponent', () => {
     expect(fixture.nativeElement.querySelectorAll('app-file').length).toBe(3);
   });
 
+  it('should follow the mobile media query and remove its listener on destroy', () => {
+    fixture.destroy();
+    const mediaQueryTarget = new EventTarget();
+    const addEventListener = vi.spyOn(mediaQueryTarget, 'addEventListener');
+    const removeEventListener = vi.spyOn(mediaQueryTarget, 'removeEventListener');
+    const mediaQueryList = Object.assign(mediaQueryTarget, {
+      matches: true,
+      media: '(max-width: 600px)',
+      onchange: null,
+    }) as unknown as MediaQueryList;
+    const matchMedia = vi.fn().mockReturnValue(mediaQueryList);
+    const originalDescriptor = Object.getOwnPropertyDescriptor(window, 'matchMedia');
+    Object.defineProperty(window, 'matchMedia', {
+      value: matchMedia,
+      configurable: true,
+    });
+
+    try {
+      fixture = TestBed.createComponent(FileListComponent);
+      component = fixture.componentInstance;
+
+      expect(matchMedia).toHaveBeenCalledWith('(max-width: 600px)');
+      expect(component.useNativeScrolling()).toBe(true);
+      expect(addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+      const listener = addEventListener.mock.calls[0][1] as (event: MediaQueryListEvent) => void;
+      const changeEvent = new Event('change') as MediaQueryListEvent;
+      Object.defineProperty(changeEvent, 'matches', { value: false });
+      mediaQueryList.dispatchEvent(changeEvent);
+      expect(component.useNativeScrolling()).toBe(false);
+
+      fixture.destroy();
+      expect(removeEventListener).toHaveBeenCalledWith('change', listener);
+    } finally {
+      if (!fixture.componentRef.hostView.destroyed) fixture.destroy();
+      if (originalDescriptor) {
+        Object.defineProperty(window, 'matchMedia', originalDescriptor);
+      } else {
+        delete (window as unknown as { matchMedia?: typeof window.matchMedia }).matchMedia;
+      }
+    }
+  });
+
   it('should render naturally-sized rows instead of fixed virtual rows on mobile', () => {
     fixture.destroy();
     fixture = TestBed.createComponent(FileListComponent);

--- a/src/angular/src/app/pages/files/file-list.component.ts
+++ b/src/angular/src/app/pages/files/file-list.component.ts
@@ -11,7 +11,7 @@ import {
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { Observable } from 'rxjs';
 import { CdkVirtualScrollViewport, CdkFixedSizeVirtualScroll, CdkVirtualForOf } from '@angular/cdk/scrolling';
 
@@ -32,7 +32,7 @@ const MOBILE_FILE_LIST_QUERY = '(max-width: 600px)';
 @Component({
   selector: 'app-file-list',
   standalone: true,
-  imports: [AsyncPipe, FileComponent, BulkActionBarComponent, CdkVirtualScrollViewport, CdkFixedSizeVirtualScroll, CdkVirtualForOf],
+  imports: [AsyncPipe, NgTemplateOutlet, FileComponent, BulkActionBarComponent, CdkVirtualScrollViewport, CdkFixedSizeVirtualScroll, CdkVirtualForOf],
   templateUrl: './file-list.component.html',
   styleUrls: ['./file-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/angular/src/app/pages/files/file-list.component.ts
+++ b/src/angular/src/app/pages/files/file-list.component.ts
@@ -8,6 +8,7 @@ import {
   OnDestroy,
   ViewChild,
   inject,
+  signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AsyncPipe } from '@angular/common';
@@ -25,6 +26,8 @@ import { NotificationLevel, createNotification } from '../../models/notification
 import { fileKey } from '../../services/files/file-key';
 import { FileComponent, FileActionEvent } from './file.component';
 import { BulkActionBarComponent } from './bulk-action-bar.component';
+
+const MOBILE_FILE_LIST_QUERY = '(max-width: 600px)';
 
 @Component({
   selector: 'app-file-list',
@@ -47,11 +50,22 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
 
   private resizeObserver: ResizeObserver | null = null;
   private pendingFrame: number | null = null;
+  private mobileMediaQuery: MediaQueryList | null = null;
+
+  readonly useNativeScrolling = signal(false);
 
   files: Observable<ViewFile[]> = this.viewFileService.filteredFiles$;
   options: Observable<ViewFileOptions> = this.viewFileOptionsService.options$;
   checked$ = this.viewFileService.checked$;
   identify = FileListComponent.identify;
+
+  constructor() {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+
+    this.mobileMediaQuery = window.matchMedia(MOBILE_FILE_LIST_QUERY);
+    this.useNativeScrolling.set(this.mobileMediaQuery.matches);
+    this.mobileMediaQuery.addEventListener('change', this.onMobileMediaChange);
+  }
 
   static identify(_index: number, item: ViewFile): string {
     return fileKey(item.pairId, item.name);
@@ -62,6 +76,8 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.mobileMediaQuery?.removeEventListener('change', this.onMobileMediaChange);
+    this.mobileMediaQuery = null;
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
     if (this.pendingFrame !== null) {
@@ -79,12 +95,12 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
   // (everything stacked above it flows into that offset) and expose it to CSS.
   private installChromeHeightObserver(): void {
     if (typeof ResizeObserver === 'undefined') return;
-    const viewportEl = this.viewport?.elementRef.nativeElement as HTMLElement | undefined;
-    if (!viewportEl) return;
 
     this.zone.runOutsideAngular(() => {
       const update = (): void => {
         this.pendingFrame = null;
+        const viewportEl = this.elRef.nativeElement.querySelector<HTMLElement>('.file-viewport');
+        if (!viewportEl) return;
         const top = viewportEl.getBoundingClientRect().top + window.scrollY;
         const chrome = Math.max(0, Math.ceil(top));
         document.documentElement.style.setProperty(
@@ -115,6 +131,10 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
       schedule();
     });
   }
+
+  private readonly onMobileMediaChange = (event: MediaQueryListEvent): void => {
+    this.useNativeScrolling.set(event.matches);
+  };
 
   onSelect(file: ViewFile): void {
     if (file.isSelected) {


### PR DESCRIPTION
## Summary
- use native scrolling for the mobile file list where rows wrap and expand dynamically
- retain CDK fixed-size virtualization on wider viewports for large-library performance
- preserve dynamic viewport-height measurement across both rendering paths
- disable browser scroll anchoring and smooth-scroll interference on the file viewport

## Root cause
The CDK viewport was configured with a fixed 82px item size, but mobile rows are not fixed-height: they wrap and can expand for details and actions. The resulting offset drift causes rows to be skipped during scrolling. Angular/CDK patch updates address a separate scroll-anchoring regression but cannot correct this layout mismatch.

Addresses the recurrence reported in #370.

## Validation
- `npx ng test --watch=false --include=src/app/pages/files/file-list.component.spec.ts` (39 passed)
- `npx ng lint`
- `npx ng build`

The full local suite reached 562/569 tests under Node 26; the remaining seven failures are the existing `localStorage` test-environment incompatibility and are unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file-list scrolling on mobile devices with naturally sized rows and native scrolling.
  * Automatically switches between native scrolling on smaller screens and virtual scrolling on larger screens.
  * Adapts scrolling behavior when the viewport size changes.

* **Bug Fixes**
  * Improved scrolling stability and prevented unwanted overscroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->