### PR TITLE
Fix #654: pipe-backed multiprocessing primitives (musl 256-semaphore cap crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.3] - 2026-08-10
+
+### Fixed
+
+- **Crash after download completes: "OSError: [Errno 24] No file descriptors available"** — Not a file-descriptor leak: musl libc (Alpine base image) caps named POSIX semaphores at 256 per process, and every `multiprocessing.Queue` costs 3 semaphores / every `Event` costs 5, so a config with ~4 path pairs sat at the cap and the first staging→final `MoveProcess` after a download pushed it over (with 6+ pairs the container crashed at startup). Single-producer/single-consumer result queues and wake/terminate events are now backed by pipes (`PipeStream`/`PipeFlag`, 0 semaphores each), taking the main process from ~250 semaphores at 4 pairs to ~21 — and ~3 per pair instead of ~51, so large path-pair configs now work. `mp.Queue` remains only for parent→child dispatch and the multi-process log queue. Pipe ends unused by each process are closed after spawn, so a peer that dies mid-operation now yields EOF instead of a hung read/write — hardening inherited from review, not present in the old queue-based code. (#654)
+
 ## [1.0.2] - 2026-07-27
 
 ### Fixed

--- a/src/angular/package.json
+++ b/src/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedsync",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/python/common/__init__.py
+++ b/src/python/common/__init__.py
@@ -16,6 +16,7 @@ from .status import (
     IStatusComponentListener as IStatusComponentListener,
 )
 from .app_process import AppProcess as AppProcess, AppOneShotProcess as AppOneShotProcess
+from .pipe_primitives import PipeStream as PipeStream, PipeFlag as PipeFlag
 from .remote_path_utils import (
     escape_remote_path_single as escape_remote_path_single,
     escape_remote_path_double as escape_remote_path_double,

--- a/src/python/common/app_process.py
+++ b/src/python/common/app_process.py
@@ -3,18 +3,21 @@
 from __future__ import annotations
 
 import logging
-import queue
 import signal
 import sys
 import threading
 import time
 from abc import abstractmethod
 from datetime import datetime
-from multiprocessing import Event, Process, Queue
+from multiprocessing import Process, Queue
 
 import tblib.pickling_support
 
 from common import ServiceExit, overrides
+
+# Direct submodule import: common/__init__ imports app_process before
+# pipe_primitives, so "from common import PipeStream" would be circular
+from common.pipe_primitives import PipeFlag, PipeStream
 
 tblib.pickling_support.install()
 
@@ -52,13 +55,33 @@ class AppProcess(Process):
         self._mp_log_queue = None
         self._mp_log_level = None
         self.logger = logging.getLogger(self.__name)
-        self.__exception_queue: Queue[ExceptionWrapper] = Queue()
-        self._terminate = Event()
+        self.__exception_stream = PipeStream()
+        self._terminate: PipeFlag | None = PipeFlag()
+        # Child-local exit flag: a child cannot set the parent->child
+        # _terminate PipeFlag, so one-shot processes set this instead
+        self._done = False
 
     def set_mp_log_queue(self, log_queue: Queue[logging.LogRecord], log_level: int):
         """Configure cross-process logging. Must be called before start()."""
         self._mp_log_queue = log_queue
         self._mp_log_level = log_level
+
+    def __pipes(self):
+        # Every PipeStream/PipeFlag in this codebase is a direct attribute of
+        # the process (incl. name-mangled subclass ones), so scanning vars()
+        # closes unused ends for all subclasses in one place
+        for value in vars(self).values():
+            if isinstance(value, (PipeStream, PipeFlag)):
+                yield value
+
+    @overrides(Process)
+    def start(self):
+        super().start()
+        # The child already holds fd copies (spawn pickling / fork). Drop the
+        # parent's unused ends so a child killed mid-send leaves EOF — pop_all
+        # returns — instead of a partial message that blocks recv() forever
+        for pipe in self.__pipes():
+            pipe.close_unused_in_parent()
 
     @overrides(Process)
     def run(self):
@@ -67,6 +90,12 @@ class AppProcess(Process):
         # is changed back to fork.
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
         signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+        # Drop the child's unused pipe ends: put() then raises BrokenPipeError
+        # instead of blocking forever if the parent dies without terminate(),
+        # and a dead parent reads as a set terminate flag (EOF is pollable)
+        for pipe in self.__pipes():
+            pipe.close_unused_in_child()
 
         # Set the thread name for convenience
         threading.current_thread().name = self.__name
@@ -88,14 +117,14 @@ class AppProcess(Process):
 
         try:
             assert self._terminate is not None
-            while not self._terminate.is_set():
+            while not self._done and not self._terminate.is_set():
                 self.run_loop()
             self.logger.debug("Process received terminate flag")
         except ServiceExit:
             self.logger.debug("Process received a ServiceExit")
         except Exception as e:
             self.logger.debug("Process caught an exception")
-            self.__exception_queue.put(ExceptionWrapper(e))
+            self.__exception_stream.put(ExceptionWrapper(e))
             raise
         finally:
             self.run_cleanup()
@@ -127,9 +156,9 @@ class AppProcess(Process):
         Must be called after the process has been joined. Subclasses should
         override to close their own queues and call super().
         """
-        self.__exception_queue.close()
-        self.__exception_queue.join_thread()
-        # Release multiprocessing primitives that hold semaphore FDs
+        self.__exception_stream.close()
+        if self._terminate is not None:
+            self._terminate.close()
         self._terminate = None
         self._mp_log_queue = None
 
@@ -138,11 +167,9 @@ class AppProcess(Process):
         Raises any exception that was caught by the process
         :return:
         """
-        try:
-            exc = self.__exception_queue.get(block=False)
-            raise exc.re_raise()
-        except queue.Empty:
-            pass
+        wrappers = self.__exception_stream.pop_all()
+        if wrappers:
+            wrappers[0].re_raise()
 
     @abstractmethod
     def run_init(self):
@@ -179,8 +206,7 @@ class AppOneShotProcess(AppProcess):
 
     def run_loop(self):
         self.run_once()
-        assert self._terminate is not None
-        self._terminate.set()
+        self._done = True
 
     def run_cleanup(self):
         pass

--- a/src/python/common/pipe_primitives.py
+++ b/src/python/common/pipe_primitives.py
@@ -1,0 +1,112 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+from __future__ import annotations
+
+import contextlib
+import multiprocessing
+from typing import Any
+
+
+class PipeStream:
+    """
+    SPSC mp.Queue replacement backed by mp.Pipe. Costs 0 semaphores.
+    put() is called from the child process, pop_all() from the parent.
+
+    Each process must drop its unused end after the fork/spawn point
+    (AppProcess does this) so the other process's death turns into EOF
+    instead of a permanent block: without it, a child killed mid-send
+    leaves a partial message whose recv() hangs the parent forever, and
+    an orphaned child's put() blocks forever on a full pipe.
+    """
+
+    def __init__(self):
+        self.__recv_conn, self.__send_conn = multiprocessing.Pipe(duplex=False)
+
+    def put(self, obj: Any):
+        # Raises BrokenPipeError once every recv fd is closed (parent gone),
+        # so an orphaned child dies instead of hanging in send
+        self.__send_conn.send(obj)
+
+    def pop_all(self) -> list[Any]:
+        # EOFError: sender gone and buffer drained — a dead child's buffered
+        # results remain readable until then (#571 contract).
+        # OSError: message truncated by a child killed mid-send; only
+        # observable (instead of a blocking recv) because the parent dropped
+        # its send-end copy via close_unused_in_parent().
+        items = []
+        with contextlib.suppress(EOFError, OSError):
+            while self.__recv_conn.poll():
+                items.append(self.__recv_conn.recv())
+        return items
+
+    def close_unused_in_parent(self):
+        """Parent calls after start(): drops the parent's send-end copy so a
+        dead child yields EOF rather than a partial message that blocks recv()."""
+        if not self.__send_conn.closed:
+            self.__send_conn.close()
+
+    def close_unused_in_child(self):
+        """Child calls at the top of run(): drops the child's recv-end copy so
+        put() raises BrokenPipeError when the parent dies without terminate()."""
+        if not self.__recv_conn.closed:
+            self.__recv_conn.close()
+
+    def close(self):
+        if not self.__send_conn.closed:
+            self.__send_conn.close()
+        if not self.__recv_conn.closed:
+            self.__recv_conn.close()
+
+
+class PipeFlag:
+    """
+    Parent-set/child-read mp.Event replacement. Costs 0 semaphores.
+    Level-triggered: bytes accumulate until clear(); is_set()/wait() poll
+    without consuming.
+
+    After close_unused_in_child(), a dead parent reads as a set flag on the
+    child side: EOF makes poll() return True, so the child exits its run
+    loop instead of running orphaned forever.
+    """
+
+    def __init__(self):
+        self.__recv_conn, self.__send_conn = multiprocessing.Pipe(duplex=False)
+
+    def set(self):
+        # Dedup via poll only while this process still holds the recv end;
+        # the parent drops it after start(), so parent sets always send a
+        # byte — bounded, since the child's clear() drains accumulation
+        if not self.__recv_conn.closed and self.__recv_conn.poll(0):
+            return
+        with contextlib.suppress(BrokenPipeError):
+            self.__send_conn.send_bytes(b"\x01")
+
+    def is_set(self) -> bool:
+        return self.__recv_conn.poll(0)
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self.__recv_conn.poll(timeout)
+
+    def clear(self):
+        # On EOF (sender gone) poll() stays True and recv_bytes raises
+        # EOFError — suppressed, leaving the flag permanently set
+        with contextlib.suppress(EOFError):
+            while self.__recv_conn.poll():
+                self.__recv_conn.recv_bytes()
+
+    def close_unused_in_parent(self):
+        """Parent calls after start(): drops the parent's recv-end copy."""
+        if not self.__recv_conn.closed:
+            self.__recv_conn.close()
+
+    def close_unused_in_child(self):
+        """Child calls at the top of run(): drops the child's send-end copy so
+        parent death produces EOF (reads as set) on the child's recv end."""
+        if not self.__send_conn.closed:
+            self.__send_conn.close()
+
+    def close(self):
+        if not self.__send_conn.closed:
+            self.__send_conn.close()
+        if not self.__recv_conn.closed:
+            self.__recv_conn.close()

--- a/src/python/common/pipe_primitives.py
+++ b/src/python/common/pipe_primitives.py
@@ -33,7 +33,7 @@ class PipeStream:
         # OSError: message truncated by a child killed mid-send; only
         # observable (instead of a blocking recv) because the parent dropped
         # its send-end copy via close_unused_in_parent().
-        items = []
+        items: list[Any] = []
         with contextlib.suppress(EOFError, OSError):
             while self.__recv_conn.poll():
                 items.append(self.__recv_conn.recv())

--- a/src/python/common/pipe_primitives.py
+++ b/src/python/common/pipe_primitives.py
@@ -73,9 +73,10 @@ class PipeFlag:
         self.__recv_conn, self.__send_conn = multiprocessing.Pipe(duplex=False)
 
     def set(self):
-        # Dedup via poll only while this process still holds the recv end;
-        # the parent drops it after start(), so parent sets always send a
-        # byte — bounded, since the child's clear() drains accumulation
+        # Dedup: poll does not consume, and once the child recvs the pending
+        # byte the poll goes false again — so repeated sets against a busy or
+        # stopped child coalesce into at most one buffered byte instead of
+        # accumulating toward a pipe-buffer block of the setting thread
         if not self.__recv_conn.closed and self.__recv_conn.poll(0):
             return
         with contextlib.suppress(BrokenPipeError):
@@ -95,9 +96,14 @@ class PipeFlag:
                 self.__recv_conn.recv_bytes()
 
     def close_unused_in_parent(self):
-        """Parent calls after start(): drops the parent's recv-end copy."""
-        if not self.__recv_conn.closed:
-            self.__recv_conn.close()
+        """Parent calls after start(): keeps BOTH ends, unlike PipeStream.
+
+        The recv end is retained so set()'s dedup poll stays usable — without
+        it every set() sends a byte and repeated force_scan() against a busy
+        or stopped child accumulates toward a pipe-buffer block of the
+        setting thread. Retaining it does not weaken orphan detection: the
+        child's EOF-reads-as-set depends only on send fds closing, and parent
+        death closes every parent fd anyway."""
 
     def close_unused_in_child(self):
         """Child calls at the top of run(): drops the child's send-end copy so

--- a/src/python/controller/extract/extract_process.py
+++ b/src/python/controller/extract/extract_process.py
@@ -8,7 +8,7 @@ import queue
 import time
 from datetime import datetime
 
-from common import AppProcess, overrides
+from common import AppProcess, PipeStream, overrides
 
 from .dispatch import ExtractDispatch, ExtractDispatchError, ExtractListener, ExtractStatus
 from .extract_request import ExtractRequest
@@ -43,8 +43,8 @@ class ExtractProcess(AppProcess):
         def __init__(
             self,
             logger: logging.Logger,
-            completed_queue: multiprocessing.Queue[ExtractCompletedResult],
-            failed_queue: multiprocessing.Queue[ExtractFailedResult],
+            completed_queue: PipeStream,
+            failed_queue: PipeStream,
         ):
             self.logger = logger
             self.completed_queue = completed_queue
@@ -65,9 +65,9 @@ class ExtractProcess(AppProcess):
     def __init__(self):
         super().__init__(name=self.__class__.__name__)
         self.__command_queue: multiprocessing.Queue[ExtractRequest] = multiprocessing.Queue()
-        self.__status_result_queue: multiprocessing.Queue[ExtractStatusResult] = multiprocessing.Queue()
-        self.__completed_result_queue: multiprocessing.Queue[ExtractCompletedResult] = multiprocessing.Queue()
-        self.__failed_result_queue: multiprocessing.Queue[ExtractFailedResult] = multiprocessing.Queue()
+        self.__status_result_queue = PipeStream()
+        self.__completed_result_queue = PipeStream()
+        self.__failed_result_queue = PipeStream()
         self.__dispatch: ExtractDispatch | None = None
 
     @overrides(AppProcess)
@@ -124,11 +124,8 @@ class ExtractProcess(AppProcess):
         self.__command_queue.close()
         self.__command_queue.join_thread()
         self.__status_result_queue.close()
-        self.__status_result_queue.join_thread()
         self.__completed_result_queue.close()
-        self.__completed_result_queue.join_thread()
         self.__failed_result_queue.close()
-        self.__failed_result_queue.join_thread()
         super().close_queues()
 
     def extract(self, req: ExtractRequest):
@@ -146,13 +143,8 @@ class ExtractProcess(AppProcess):
         this method was called
         :return:
         """
-        latest_result = None
-        try:
-            while True:
-                latest_result = self.__status_result_queue.get(block=False)
-        except queue.Empty:
-            pass
-        return latest_result
+        results = self.__status_result_queue.pop_all()
+        return results[-1] if results else None
 
     def pop_completed(self) -> list[ExtractCompletedResult]:
         """
@@ -161,14 +153,7 @@ class ExtractProcess(AppProcess):
         last time this method was called.
         :return:
         """
-        completed: list[ExtractCompletedResult] = []
-        try:
-            while True:
-                result = self.__completed_result_queue.get(block=False)
-                completed.append(result)
-        except queue.Empty:
-            pass
-        return completed
+        return self.__completed_result_queue.pop_all()
 
     def pop_failed(self) -> list[ExtractFailedResult]:
         """
@@ -176,11 +161,4 @@ class ExtractProcess(AppProcess):
         Returns an empty list if no new failures since the last call.
         :return:
         """
-        failed: list[ExtractFailedResult] = []
-        try:
-            while True:
-                result = self.__failed_result_queue.get(block=False)
-                failed.append(result)
-        except queue.Empty:
-            pass
-        return failed
+        return self.__failed_result_queue.pop_all()

--- a/src/python/controller/move/move_process.py
+++ b/src/python/controller/move/move_process.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import datetime
 import errno
-import multiprocessing
 import os
-import queue
 import shutil
 
-from common import AppOneShotProcess, Constants, overrides
+from common import AppOneShotProcess, Constants, PipeStream, overrides
 
 
 class MoveFailedResult:
@@ -42,7 +40,7 @@ class MoveProcess(AppOneShotProcess):
         self.__dest_path = dest_path
         self.__file_name = file_name
         self._pair_id = pair_id
-        self.__failed_result_queue: multiprocessing.Queue[MoveFailedResult] = multiprocessing.Queue()
+        self.__failed_result_stream = PipeStream()
 
     @property
     def file_name(self) -> str:
@@ -100,7 +98,7 @@ class MoveProcess(AppOneShotProcess):
     def _report_failure(self, message: str) -> None:
         """Log and publish a move failure so the controller can surface it."""
         self.logger.error(message)
-        self.__failed_result_queue.put(
+        self.__failed_result_stream.put(
             MoveFailedResult(
                 timestamp=datetime.datetime.now(),
                 name=self.__file_name,
@@ -186,16 +184,9 @@ class MoveProcess(AppOneShotProcess):
 
     def pop_failed(self) -> list[MoveFailedResult]:
         """Process-safe method to retrieve any move failures."""
-        failed: list[MoveFailedResult] = []
-        try:
-            while True:
-                failed.append(self.__failed_result_queue.get(block=False))
-        except queue.Empty:
-            pass
-        return failed
+        return self.__failed_result_stream.pop_all()
 
     @overrides(AppOneShotProcess)
     def close_queues(self):
-        self.__failed_result_queue.close()
-        self.__failed_result_queue.join_thread()
+        self.__failed_result_stream.close()
         super().close_queues()

--- a/src/python/controller/scan/scanner_process.py
+++ b/src/python/controller/scan/scanner_process.py
@@ -2,12 +2,10 @@
 from __future__ import annotations
 
 import logging
-import multiprocessing
-import queue
 from abc import ABC, abstractmethod
 from datetime import datetime
 
-from common import AppError, AppProcess, overrides
+from common import AppError, AppProcess, PipeFlag, PipeStream, overrides
 from system import SystemFile
 
 
@@ -66,8 +64,8 @@ class ScannerProcess(AppProcess):
         :param interval_in_ms: Minimum interval (in ms) between results
         """
         super().__init__(name=scanner.__class__.__name__)
-        self.__queue: multiprocessing.Queue[ScannerResult] = multiprocessing.Queue()
-        self.__wake_event = multiprocessing.Event()
+        self.__queue = PipeStream()
+        self.__wake_event = PipeFlag()
         self.__scanner = scanner
         self.__interval_in_ms = interval_in_ms
         self.verbose = verbose
@@ -113,18 +111,13 @@ class ScannerProcess(AppProcess):
         this method was called
         :return:
         """
-        latest_scan = None
-        try:
-            while True:
-                latest_scan = self.__queue.get(block=False)
-        except queue.Empty:
-            pass
-        return latest_scan
+        results = self.__queue.pop_all()
+        return results[-1] if results else None
 
     @overrides(AppProcess)
     def close_queues(self):
         self.__queue.close()
-        self.__queue.join_thread()
+        self.__wake_event.close()
         super().close_queues()
 
     def force_scan(self) -> None:

--- a/src/python/controller/validate/validate_process.py
+++ b/src/python/controller/validate/validate_process.py
@@ -11,7 +11,7 @@ import time
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from common import AppProcess, escape_remote_path_double, escape_remote_path_single, overrides
+from common import AppProcess, PipeStream, escape_remote_path_double, escape_remote_path_single, overrides
 
 if TYPE_CHECKING:
     from ssh import Sshcp
@@ -112,9 +112,9 @@ class ValidateProcess(AppProcess):
     def __init__(self):
         super().__init__(name=self.__class__.__name__)
         self.__command_queue: multiprocessing.Queue[ValidateRequest] = multiprocessing.Queue()
-        self.__status_result_queue: multiprocessing.Queue[ValidateStatusResult] = multiprocessing.Queue()
-        self.__completed_result_queue: multiprocessing.Queue[ValidateCompletedResult] = multiprocessing.Queue()
-        self.__failed_result_queue: multiprocessing.Queue[ValidateFailedResult] = multiprocessing.Queue()
+        self.__status_result_queue = PipeStream()
+        self.__completed_result_queue = PipeStream()
+        self.__failed_result_queue = PipeStream()
         self.__active_validations: dict[tuple[str | None, str], ValidateRequest] = {}
 
     @overrides(AppProcess)
@@ -380,11 +380,8 @@ class ValidateProcess(AppProcess):
         self.__command_queue.close()
         self.__command_queue.join_thread()
         self.__status_result_queue.close()
-        self.__status_result_queue.join_thread()
         self.__completed_result_queue.close()
-        self.__completed_result_queue.join_thread()
         self.__failed_result_queue.close()
-        self.__failed_result_queue.join_thread()
         super().close_queues()
 
     def validate(self, req: ValidateRequest):
@@ -393,32 +390,13 @@ class ValidateProcess(AppProcess):
 
     def pop_latest_statuses(self) -> ValidateStatusResult | None:
         """Process-safe method to retrieve latest validation status."""
-        latest_result = None
-        try:
-            while True:
-                latest_result = self.__status_result_queue.get(block=False)
-        except queue.Empty:
-            pass
-        return latest_result
+        results = self.__status_result_queue.pop_all()
+        return results[-1] if results else None
 
     def pop_completed(self) -> list[ValidateCompletedResult]:
         """Process-safe method to retrieve newly completed validations."""
-        completed: list[ValidateCompletedResult] = []
-        try:
-            while True:
-                result = self.__completed_result_queue.get(block=False)
-                completed.append(result)
-        except queue.Empty:
-            pass
-        return completed
+        return self.__completed_result_queue.pop_all()
 
     def pop_failed(self) -> list[ValidateFailedResult]:
         """Process-safe method to retrieve newly failed validations."""
-        failed: list[ValidateFailedResult] = []
-        try:
-            while True:
-                result = self.__failed_result_queue.get(block=False)
-                failed.append(result)
-        except queue.Empty:
-            pass
-        return failed
+        return self.__failed_result_queue.pop_all()

--- a/src/python/tests/unittests/test_common/test_app_process.py
+++ b/src/python/tests/unittests/test_common/test_app_process.py
@@ -192,7 +192,11 @@ class TestAppProcess(unittest.TestCase):
         # send-end copy) instead of blocking forever in recv()
         self.process = FloodProcess()
         self.process.start()
-        time.sleep(0.3)  # let the child fill the pipe and block in send
+        # Wait until the child's first send is observable (poll does not
+        # consume). A 1MB payload cannot fit the ~64KB pipe buffer, so once
+        # data appears the child is deterministically blocked mid-send —
+        # a fixed sleep could terminate before the child ever entered put()
+        self.assertTrue(self.process.stream._PipeStream__recv_conn.poll(10))
         self.process.terminate()
         self.process.join()
         self.process.stream.pop_all()  # hangs without the fix

--- a/src/python/tests/unittests/test_common/test_app_process.py
+++ b/src/python/tests/unittests/test_common/test_app_process.py
@@ -9,7 +9,7 @@ from multiprocessing import Value
 
 import timeout_decorator
 
-from common import AppOneShotProcess, AppProcess
+from common import AppOneShotProcess, AppProcess, PipeStream
 
 
 class DummyException(Exception):
@@ -74,6 +74,24 @@ class LongRunningThreadProcess(AppProcess):
         print("Thread task started")
         while True:
             pass
+
+
+class FloodProcess(AppProcess):
+    """Floods its result stream with large payloads so terminate()'s SIGTERM
+    kills it mid-send, leaving a partial message in the pipe."""
+
+    def __init__(self):
+        super().__init__(name=self.__class__.__name__)
+        self.stream = PipeStream()
+
+    def run_init(self):
+        pass
+
+    def run_loop(self):
+        self.stream.put(b"x" * (1024 * 1024))
+
+    def run_cleanup(self):
+        pass
 
 
 class DummyOneShotProcess(AppOneShotProcess):
@@ -165,6 +183,20 @@ class TestAppProcess(unittest.TestCase):
         time.sleep(0.2)
         self.process.terminate()
         self.process.join()
+        self.process = None
+
+    @timeout_decorator.timeout(15)
+    def test_pop_after_kill_mid_send_does_not_block(self):
+        # A child killed mid-send of a large payload leaves a partial message.
+        # The parent's subsequent pop_all must return (EOF via the closed
+        # send-end copy) instead of blocking forever in recv()
+        self.process = FloodProcess()
+        self.process.start()
+        time.sleep(0.3)  # let the child fill the pipe and block in send
+        self.process.terminate()
+        self.process.join()
+        self.process.stream.pop_all()  # hangs without the fix
+        self.process.stream.close()
         self.process = None
 
 

--- a/src/python/tests/unittests/test_common/test_pipe_primitives.py
+++ b/src/python/tests/unittests/test_common/test_pipe_primitives.py
@@ -150,6 +150,7 @@ class TestPipeFlag(unittest.TestCase):
         flag.close()
         flag.close()
 
+    @timeout_decorator.timeout(5)
     def test_repeated_sets_coalesce_after_start(self):
         # After start() (close_unused_in_parent), the parent keeps its recv
         # end so the dedup poll works: repeated sets against a busy/stopped

--- a/src/python/tests/unittests/test_common/test_pipe_primitives.py
+++ b/src/python/tests/unittests/test_common/test_pipe_primitives.py
@@ -31,6 +31,7 @@ class TestPipeStream(unittest.TestCase):
     @timeout_decorator.timeout(20)
     def test_put_and_pop_all_across_processes(self):
         stream = PipeStream()
+        self.addCleanup(stream.close)
         process = PutterProcess(stream, ["a", {"b": 2}, 3])
         process.start()
         items = []
@@ -40,25 +41,26 @@ class TestPipeStream(unittest.TestCase):
             time.sleep(0.01)
         process.join()
         self.assertEqual(["a", {"b": 2}, 3], items)
-        stream.close()
 
     @timeout_decorator.timeout(20)
     def test_pop_all_after_child_death(self):
         # Buffered results must remain readable after the child exits (#571)
         stream = PipeStream()
+        self.addCleanup(stream.close)
         process = PutterProcess(stream, [1, 2, 3])
         process.start()
         process.join()
         self.assertEqual([1, 2, 3], stream.pop_all())
-        stream.close()
 
     def test_pop_all_empty_returns_empty_list(self):
         stream = PipeStream()
+        self.addCleanup(stream.close)
         self.assertEqual([], stream.pop_all())
-        stream.close()
 
     def test_close_is_idempotent(self):
+        # The explicit double-close IS the assertion; addCleanup adds a third
         stream = PipeStream()
+        self.addCleanup(stream.close)
         stream.close()
         stream.close()
 
@@ -68,79 +70,83 @@ class TestPipeStream(unittest.TestCase):
         # has dropped its send-end copy, pop_all must return the complete
         # messages instead of blocking forever in recv() on the partial one.
         stream = PipeStream()
+        self.addCleanup(stream.close)
         stream.put("complete")
         # Fake a truncated message: header claims 100 bytes, body has 7
         send_conn = stream._PipeStream__send_conn
         os.write(send_conn.fileno(), struct.pack("!i", 100) + b"partial")
         stream.close_unused_in_parent()
         self.assertEqual(["complete"], stream.pop_all())
-        stream.close()
 
     @timeout_decorator.timeout(5)
     def test_put_raises_broken_pipe_when_receiver_gone(self):
         # An orphaned child (parent died without terminate()) must get a
         # BrokenPipeError from put() instead of blocking forever
         stream = PipeStream()
+        self.addCleanup(stream.close)
         stream.close_unused_in_child()
         with self.assertRaises(BrokenPipeError):
             stream.put("x")
-        stream.close()
 
     def test_pop_all_after_close_returns_empty_list(self):
         stream = PipeStream()
-        stream.close()
+        self.addCleanup(stream.close)
+        stream.close()  # the arrange step under test, not cleanup
         self.assertEqual([], stream.pop_all())
 
 
 class TestPipeFlag(unittest.TestCase):
     def test_initially_not_set(self):
         flag = PipeFlag()
+        self.addCleanup(flag.close)
         self.assertFalse(flag.is_set())
-        flag.close()
 
     def test_set_and_is_set_does_not_consume(self):
         flag = PipeFlag()
+        self.addCleanup(flag.close)
         flag.set()
         self.assertTrue(flag.is_set())
         self.assertTrue(flag.is_set())
-        flag.close()
 
     def test_wait_returns_promptly_when_set(self):
         flag = PipeFlag()
+        self.addCleanup(flag.close)
         flag.set()
         start = time.time()
         self.assertTrue(flag.wait(5))
         self.assertLess(time.time() - start, 1)
         # wait does not consume
         self.assertTrue(flag.is_set())
-        flag.close()
 
     def test_wait_times_out_when_not_set(self):
         flag = PipeFlag()
-        start = time.time()
+        self.addCleanup(flag.close)
+        start = time.monotonic()
         self.assertFalse(flag.wait(0.2))
-        self.assertGreaterEqual(time.time() - start, 0.2)
-        flag.close()
+        # Tolerance: poll() may return marginally early on timer resolution
+        self.assertGreaterEqual(time.monotonic() - start, 0.15)
 
     def test_clear_resets_flag(self):
         flag = PipeFlag()
+        self.addCleanup(flag.close)
         flag.set()
         flag.set()  # no-op while already set
         flag.clear()
         self.assertFalse(flag.is_set())
         self.assertFalse(flag.wait(0.05))
-        flag.close()
 
     def test_set_after_clear_works(self):
         flag = PipeFlag()
+        self.addCleanup(flag.close)
         flag.set()
         flag.clear()
         flag.set()
         self.assertTrue(flag.is_set())
-        flag.close()
 
     def test_close_is_idempotent(self):
+        # The explicit double-close IS the assertion; addCleanup adds a third
         flag = PipeFlag()
+        self.addCleanup(flag.close)
         flag.close()
         flag.close()
 
@@ -150,21 +156,21 @@ class TestPipeFlag(unittest.TestCase):
         # child must leave at most ONE pending byte, never accumulate toward
         # a pipe-buffer block of the setting thread
         flag = PipeFlag()
+        self.addCleanup(flag.close)
         flag.close_unused_in_parent()
         for _ in range(100):
             flag.set()
         recv_conn = flag._PipeFlag__recv_conn
         recv_conn.recv_bytes()  # consume the single pending byte
         self.assertFalse(recv_conn.poll(0))  # nothing accumulated behind it
-        flag.close()
 
     def test_reads_as_set_when_sender_gone(self):
         # A dead parent closes the last send fd; EOF is pollable, so the
         # child sees the terminate flag as permanently set and exits
         flag = PipeFlag()
+        self.addCleanup(flag.close)
         flag.close_unused_in_child()
         self.assertTrue(flag.is_set())
         self.assertTrue(flag.wait(0.1))
         flag.clear()  # must not spin or raise on EOF
         self.assertTrue(flag.is_set())
-        flag.close()

--- a/src/python/tests/unittests/test_common/test_pipe_primitives.py
+++ b/src/python/tests/unittests/test_common/test_pipe_primitives.py
@@ -1,0 +1,165 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import multiprocessing
+import os
+import struct
+import time
+import unittest
+
+import timeout_decorator
+
+from common import PipeFlag, PipeStream
+
+# Module-level so the class pickles through the spawn start method
+_ctx = multiprocessing.get_context("spawn")
+
+
+class PutterProcess(_ctx.Process):
+    """Puts the given items on the stream, then exits."""
+
+    def __init__(self, stream: PipeStream, items: list):
+        super().__init__()
+        self.stream = stream
+        self.items = items
+
+    def run(self):
+        for item in self.items:
+            self.stream.put(item)
+
+
+class TestPipeStream(unittest.TestCase):
+    @timeout_decorator.timeout(20)
+    def test_put_and_pop_all_across_processes(self):
+        stream = PipeStream()
+        process = PutterProcess(stream, ["a", {"b": 2}, 3])
+        process.start()
+        items = []
+        end_time = time.time() + 10
+        while len(items) < 3 and time.time() < end_time:
+            items += stream.pop_all()
+            time.sleep(0.01)
+        process.join()
+        self.assertEqual(["a", {"b": 2}, 3], items)
+        stream.close()
+
+    @timeout_decorator.timeout(20)
+    def test_pop_all_after_child_death(self):
+        # Buffered results must remain readable after the child exits (#571)
+        stream = PipeStream()
+        process = PutterProcess(stream, [1, 2, 3])
+        process.start()
+        process.join()
+        self.assertEqual([1, 2, 3], stream.pop_all())
+        stream.close()
+
+    def test_pop_all_empty_returns_empty_list(self):
+        stream = PipeStream()
+        self.assertEqual([], stream.pop_all())
+        stream.close()
+
+    def test_close_is_idempotent(self):
+        stream = PipeStream()
+        stream.close()
+        stream.close()
+
+    @timeout_decorator.timeout(5)
+    def test_pop_all_does_not_block_on_partial_message(self):
+        # A child killed mid-send leaves a truncated message. Once the parent
+        # has dropped its send-end copy, pop_all must return the complete
+        # messages instead of blocking forever in recv() on the partial one.
+        stream = PipeStream()
+        stream.put("complete")
+        # Fake a truncated message: header claims 100 bytes, body has 7
+        send_conn = stream._PipeStream__send_conn
+        os.write(send_conn.fileno(), struct.pack("!i", 100) + b"partial")
+        stream.close_unused_in_parent()
+        self.assertEqual(["complete"], stream.pop_all())
+        stream.close()
+
+    @timeout_decorator.timeout(5)
+    def test_put_raises_broken_pipe_when_receiver_gone(self):
+        # An orphaned child (parent died without terminate()) must get a
+        # BrokenPipeError from put() instead of blocking forever
+        stream = PipeStream()
+        stream.close_unused_in_child()
+        with self.assertRaises(BrokenPipeError):
+            stream.put("x")
+        stream.close()
+
+    def test_pop_all_after_close_returns_empty_list(self):
+        stream = PipeStream()
+        stream.close()
+        self.assertEqual([], stream.pop_all())
+
+
+class TestPipeFlag(unittest.TestCase):
+    def test_initially_not_set(self):
+        flag = PipeFlag()
+        self.assertFalse(flag.is_set())
+        flag.close()
+
+    def test_set_and_is_set_does_not_consume(self):
+        flag = PipeFlag()
+        flag.set()
+        self.assertTrue(flag.is_set())
+        self.assertTrue(flag.is_set())
+        flag.close()
+
+    def test_wait_returns_promptly_when_set(self):
+        flag = PipeFlag()
+        flag.set()
+        start = time.time()
+        self.assertTrue(flag.wait(5))
+        self.assertLess(time.time() - start, 1)
+        # wait does not consume
+        self.assertTrue(flag.is_set())
+        flag.close()
+
+    def test_wait_times_out_when_not_set(self):
+        flag = PipeFlag()
+        start = time.time()
+        self.assertFalse(flag.wait(0.2))
+        self.assertGreaterEqual(time.time() - start, 0.2)
+        flag.close()
+
+    def test_clear_resets_flag(self):
+        flag = PipeFlag()
+        flag.set()
+        flag.set()  # no-op while already set
+        flag.clear()
+        self.assertFalse(flag.is_set())
+        self.assertFalse(flag.wait(0.05))
+        flag.close()
+
+    def test_set_after_clear_works(self):
+        flag = PipeFlag()
+        flag.set()
+        flag.clear()
+        flag.set()
+        self.assertTrue(flag.is_set())
+        flag.close()
+
+    def test_close_is_idempotent(self):
+        flag = PipeFlag()
+        flag.close()
+        flag.close()
+
+    def test_set_does_not_raise_after_parent_drops_recv_end(self):
+        # The parent drops its recv-end copy after start(); set() must still
+        # work (no dedup poll on a closed conn, no error on repeated sets)
+        flag = PipeFlag()
+        flag.close_unused_in_parent()
+        flag.set()
+        flag.set()
+        flag.close()
+
+    def test_reads_as_set_when_sender_gone(self):
+        # A dead parent closes the last send fd; EOF is pollable, so the
+        # child sees the terminate flag as permanently set and exits
+        flag = PipeFlag()
+        flag.close_unused_in_child()
+        self.assertTrue(flag.is_set())
+        self.assertTrue(flag.wait(0.1))
+        flag.clear()  # must not spin or raise on EOF
+        self.assertTrue(flag.is_set())
+        flag.close()

--- a/src/python/tests/unittests/test_common/test_pipe_primitives.py
+++ b/src/python/tests/unittests/test_common/test_pipe_primitives.py
@@ -144,13 +144,18 @@ class TestPipeFlag(unittest.TestCase):
         flag.close()
         flag.close()
 
-    def test_set_does_not_raise_after_parent_drops_recv_end(self):
-        # The parent drops its recv-end copy after start(); set() must still
-        # work (no dedup poll on a closed conn, no error on repeated sets)
+    def test_repeated_sets_coalesce_after_start(self):
+        # After start() (close_unused_in_parent), the parent keeps its recv
+        # end so the dedup poll works: repeated sets against a busy/stopped
+        # child must leave at most ONE pending byte, never accumulate toward
+        # a pipe-buffer block of the setting thread
         flag = PipeFlag()
         flag.close_unused_in_parent()
-        flag.set()
-        flag.set()
+        for _ in range(100):
+            flag.set()
+        recv_conn = flag._PipeFlag__recv_conn
+        recv_conn.recv_bytes()  # consume the single pending byte
+        self.assertFalse(recv_conn.poll(0))  # nothing accumulated behind it
         flag.close()
 
     def test_reads_as_set_when_sender_gone(self):

--- a/src/python/tests/unittests/test_controller/test_move_process.py
+++ b/src/python/tests/unittests/test_controller/test_move_process.py
@@ -2,24 +2,12 @@
 
 import errno
 import os
-import queue
 import shutil
 import tempfile
 import unittest
 from unittest import mock
 
 from controller.move.move_process import MoveFailedResult, MoveProcess
-
-
-class _SyncQueue(queue.Queue):
-    """A queue.Queue with close/join_thread stubs so it can replace
-    multiprocessing.Queue in single-process tests (no feeder-thread race)."""
-
-    def close(self):
-        pass
-
-    def join_thread(self):
-        pass
 
 
 class TestMoveProcess(unittest.TestCase):
@@ -35,11 +23,9 @@ class TestMoveProcess(unittest.TestCase):
         shutil.rmtree(self.dst_dir, ignore_errors=True)
 
     def _make_process(self, **kwargs):
-        # Replace multiprocessing.Queue with a synchronous queue so that
-        # pop_failed() in these single-process tests never races the feeder
-        # thread (mirrors the validate/extract process test pattern).
-        with mock.patch("controller.move.move_process.multiprocessing.Queue", _SyncQueue):
-            process = MoveProcess(**kwargs)
+        # The failed-result PipeStream is synchronous in-process (no feeder
+        # thread), so pop_failed() needs no fake in these single-process tests.
+        process = MoveProcess(**kwargs)
         self._processes.append(process)
         return process
 

--- a/src/python/tests/unittests/test_controller/test_semaphore_diet.py
+++ b/src/python/tests/unittests/test_controller/test_semaphore_diet.py
@@ -1,0 +1,62 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import logging
+import multiprocessing
+import os
+import shutil
+import tempfile
+import unittest
+
+from controller import IScanner, ScannerProcess
+from controller.move.move_process import MoveProcess
+
+
+class TrivialScanner(IScanner):
+    """Picklable no-op scanner (survives spawn)."""
+
+    def scan(self):
+        return []
+
+    def set_base_logger(self, base_logger: logging.Logger):
+        pass
+
+
+class TestSemaphoreDiet(unittest.TestCase):
+    """Regression test for #654: process primitives must not consume named
+    POSIX semaphores.
+
+    musl libc (Alpine) caps named semaphores at 256 per process
+    (SEM_NSEMS_MAX); each mp.Lock costs one, so with ~240 held below, any
+    process class still built on mp.Queue/mp.Event (3-5 sems each) blows the
+    cap with OSError "No file descriptors available". Only meaningful on musl
+    -- glibc/macOS have no such cap, so this is trivially green there; CI runs
+    it in the Alpine test image.
+    """
+
+    def test_processes_start_with_240_semaphores_held(self):
+        locks = [multiprocessing.Lock() for _ in range(240)]
+        try:
+            # ScannerProcess: construct + start + terminate + join + close
+            scanner_process = ScannerProcess(scanner=TrivialScanner(), interval_in_ms=50)
+            scanner_process.start()
+            scanner_process.terminate()
+            scanner_process.join(timeout=5)
+            self.assertFalse(scanner_process.is_alive())
+            scanner_process.close_queues()
+
+            # MoveProcess (one-shot): construct + start + join + close
+            src_dir = tempfile.mkdtemp()
+            dst_dir = tempfile.mkdtemp()
+            try:
+                with open(os.path.join(src_dir, "test.txt"), "w") as f:
+                    f.write("payload")
+                move_process = MoveProcess(source_path=src_dir, dest_path=dst_dir, file_name="test.txt")
+                move_process.start()
+                move_process.join(timeout=5)
+                self.assertFalse(move_process.is_alive())
+                move_process.close_queues()
+            finally:
+                shutil.rmtree(src_dir, ignore_errors=True)
+                shutil.rmtree(dst_dir, ignore_errors=True)
+        finally:
+            del locks


### PR DESCRIPTION
## Summary

Fixes #654 — the container crash-looping with `OSError: [Errno 24] No file descriptors available` once a download completes.

**Root cause: not a file-descriptor leak.** musl libc (Alpine base image) caps named POSIX semaphores at 256 per process, and its error string for `EMFILE` is "No file descriptors available". Every `multiprocessing.Queue` costs 3 named semaphores and every `multiprocessing.Event` costs 5, so the main process paid **~51 semaphores per path pair** (3 scanner processes + active scanner) plus ~45 baseline. At 4 path pairs (the reporter's config) it idled at ~250; the first staging→final `MoveProcess` after a download allocated the 257th semaphore and crashed the controller. With 6+ pairs it crashed at startup — the cap was silently limiting the path-pairs feature. Reproduced byte-for-byte on stock `1.0.2` with an fd ulimit of 1,048,576. The crash surfaced in 1.0.0 because #510's per-move failed-result queue raised the per-move cost from 8 to 11 semaphores, consuming the last of the headroom; #510 is not at fault and is preserved.

## Fix

New `common/pipe_primitives.py`:
- **`PipeStream`** — SPSC `mp.Queue` replacement over `mp.Pipe(duplex=False)`: 0 semaphores, 2 fds. Adopted for all child→parent result streams: scanner results, move/extract/validate completed/failed/status, and the `AppProcess` exception channel.
- **`PipeFlag`** — parent-set/child-read `mp.Event` replacement: terminate flag and scanner wake. `AppOneShotProcess` now exits via a child-local `_done` bool (it previously set the terminate event from the child side).

`mp.Queue` remains only where its non-blocking feeder-thread `put` matters (extract/validate command dispatch, active-files queue) and for the multi-producer log queue.

**Budget: ~250 → ~21 semaphores at 4 pairs; ~3 per additional pair instead of ~51** (headroom to ~75 pairs).

Hardening out of adversarial review: after spawn, each process closes the pipe ends it doesn't use, so a peer dying mid-operation yields EOF/`BrokenPipeError` instead of a permanent block. (The old `mp.Queue` code had the same hang exposure on a child killed mid-write — verified empirically — so this is strictly better, not just parity.)

Public surfaces (`pop_*`, `propagate_exception`, `close_queues`, `terminate`, `force_scan`) are unchanged — `Controller`, `CommandPipeline`, `ModelUpdater`, and `WorkerSupervisor` needed zero changes, and the #571 dead-worker drain contract is preserved (a dead child's buffered results stay readable until `close_queues()`, now without the feeder-thread race).

Design doc: `fix-654-semaphore-diet-design.md` (committed).

## Test plan

- [x] New unit tests for `PipeStream`/`PipeFlag`: real spawned-child put/pop, drain-after-child-death (EOF), partial-message-after-kill does not block, orphaned-child `BrokenPipeError`, level-triggered flag semantics, close idempotency
- [x] New #654 regression test (`test_semaphore_diet.py`): holds 240 `mp.Lock()`s then starts/stops a `ScannerProcess` + `MoveProcess` — fails on musl before this fix, passes after (trivially green on glibc/macOS; CI's Alpine test image is where it bites)
- [x] Move tests migrated off the `_SyncQueue` patch (real `PipeStream` is synchronous in-process; behavioral assertions untouched)
- [x] Full unit suite: 987 passed — only the known pre-existing macOS-only `test_scan_file_with_latin_chars` fails locally
- [x] `ruff check` + `ruff format --check` clean
- [x] Docker image builds; in-image probe `[mp.Lock() for _ in range(250)]` passes
- [x] E2E: 6-pair + staging config (crashes v1.0.2 at boot) boots, downloads, and completes the staging→final move on the fixed image

## Release

CHANGELOG + `src/angular/package.json` bumped to 1.0.3. Tag/release to follow the standard release process after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pipe-based communication for process status, completion, and error reporting.
  * Improved process communication reliability with EOF detection and non-blocking result retrieval.
* **Bug Fixes**
  * Reduced reliance on system semaphores in constrained environments.
  * Ensured communication endpoints close correctly when processes start or exit.
* **Chores**
  * Updated the package version to 1.0.3.
  * Added regression coverage for interrupted transfers, process cleanup, and semaphore exhaustion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->