### PR TITLE
ci: handle workflow_dispatch on tag refs; docs deploy note

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,6 +493,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
+            type=ref,event=tag
 
       - name: Create multi-arch manifest and push
         working-directory: /tmp/digests

--- a/website/README.md
+++ b/website/README.md
@@ -28,4 +28,5 @@ npm run build
 ## Deploy
 
 Deployment is automated: the `docs-pages.yml` GitHub Actions workflow builds
-the site and publishes it to GitHub Pages whenever `website/` changes.
+the site and publishes it to GitHub Pages when changes under `website/` are
+pushed to `master`.


### PR DESCRIPTION
Addresses two CodeRabbit findings from #694 (fixed here on `develop` so `master` never gets ahead; rides into #695).

- `ci.yml`: manual-dispatch metadata now also emits `type=ref,event=tag`, so a dispatch on `refs/tags/*` still yields an image tag for the manifest step (previously the last-run dispatch step overwrote release metadata with an empty tag list).
- `website/README.md`: deploy note now states the docs workflow publishes only when `website/` changes are pushed to `master`.

Skipped from the same review: `threading.Lock` annotation → `_thread.LockType` (valid class on the 3.13 runtime, pyright strict passes); `latestChecked` spec subscription (outside diff, test-only, no behavioral effect).

## Test plan
- [x] YAML unchanged apart from the one added line; existing dispatch-on-branch path unaffected
- [ ] CI