### PR TITLE
refactor(python): convert hand-written data/result classes to dataclasses (#667)

### DIFF
--- a/src/python/controller/extract/dispatch.py
+++ b/src/python/controller/extract/dispatch.py
@@ -7,6 +7,7 @@ import re
 import threading
 import time
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from enum import Enum
 
 from common import AppError
@@ -29,6 +30,7 @@ class ExtractListener(ABC):
         pass
 
 
+@dataclass(frozen=True)
 class ExtractStatus:
     """
     Represents the status of a single extraction request
@@ -37,43 +39,21 @@ class ExtractStatus:
     class State(Enum):
         EXTRACTING = 0
 
-    def __init__(self, name: str, is_dir: bool, state: State, pair_id: str | None = None):
-        self.__name = name
-        self.__is_dir = is_dir
-        self.__state = state
-        self.__pair_id = pair_id
-
-    @property
-    def name(self) -> str:
-        return self.__name
-
-    @property
-    def is_dir(self) -> bool:
-        return self.__is_dir
-
-    @property
-    def state(self) -> State:
-        return self.__state
-
-    @property
-    def pair_id(self) -> str | None:
-        return self.__pair_id
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ExtractStatus):
-            return NotImplemented
-        return self.__dict__ == other.__dict__
+    name: str
+    is_dir: bool
+    state: State
+    pair_id: str | None = None
 
 
 class ExtractDispatch:
     __WORKER_SLEEP_INTERVAL_IN_SECS = 0.5
 
+    @dataclass
     class _Task:
-        def __init__(self, root_name: str, root_is_dir: bool, pair_id: str | None = None):
-            self.root_name = root_name
-            self.root_is_dir = root_is_dir
-            self.pair_id = pair_id
-            self.archive_paths: list[tuple[str, str]] = []
+        root_name: str
+        root_is_dir: bool
+        pair_id: str | None = None
+        archive_paths: list[tuple[str, str]] = field(default_factory=list[tuple[str, str]])
 
         def add_archive(self, archive_path: str, out_dir_path: str):
             self.archive_paths.append((archive_path, out_dir_path))
@@ -156,7 +136,8 @@ class ExtractDispatch:
                             curr_file.full_path, req.local_path, req.local_path_fallback
                         )
                         if archive_full_path:
-                            base_out = req.out_dir_path_fallback if is_fallback else req.out_dir_path
+                            fallback_out = req.out_dir_path_fallback or req.out_dir_path
+                            base_out = fallback_out if is_fallback else req.out_dir_path
                             out_dir_path = os.path.join(base_out, os.path.dirname(curr_file.full_path))
                             task.add_archive(archive_path=archive_full_path, out_dir_path=out_dir_path)
 
@@ -177,7 +158,7 @@ class ExtractDispatch:
             )
             if not archive_full_path:
                 raise ExtractDispatchError(f"File is not an archive: {model_file.name}")
-            base_out = req.out_dir_path_fallback if is_fallback else req.out_dir_path
+            base_out = (req.out_dir_path_fallback or req.out_dir_path) if is_fallback else req.out_dir_path
             task.add_archive(archive_path=archive_full_path, out_dir_path=base_out)
             self.__task_queue.put(task)
 

--- a/src/python/controller/extract/extract_process.py
+++ b/src/python/controller/extract/extract_process.py
@@ -7,6 +7,7 @@ import multiprocessing
 import queue
 import threading
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from typing import override
 
@@ -16,26 +17,26 @@ from .dispatch import ExtractDispatch, ExtractDispatchError, ExtractListener, Ex
 from .extract_request import ExtractRequest
 
 
+@dataclass
 class ExtractStatusResult:
-    def __init__(self, timestamp: datetime, statuses: list[ExtractStatus]):
-        self.timestamp = timestamp
-        self.statuses = statuses
+    timestamp: datetime
+    statuses: list[ExtractStatus]
 
 
+@dataclass
 class ExtractCompletedResult:
-    def __init__(self, timestamp: datetime, name: str, is_dir: bool, pair_id: str | None = None):
-        self.timestamp = timestamp
-        self.name = name
-        self.is_dir = is_dir
-        self.pair_id = pair_id
+    timestamp: datetime
+    name: str
+    is_dir: bool
+    pair_id: str | None = None
 
 
+@dataclass
 class ExtractFailedResult:
-    def __init__(self, timestamp: datetime, name: str, is_dir: bool, pair_id: str | None = None):
-        self.timestamp = timestamp
-        self.name = name
-        self.is_dir = is_dir
-        self.pair_id = pair_id
+    timestamp: datetime
+    name: str
+    is_dir: bool
+    pair_id: str | None = None
 
 
 class ExtractProcess(AppProcess):

--- a/src/python/controller/extract/extract_request.py
+++ b/src/python/controller/extract/extract_request.py
@@ -1,23 +1,17 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
+from dataclasses import dataclass
+
 from model import ModelFile
 
 
+@dataclass
 class ExtractRequest:
     """Bundles a ModelFile with the pair-specific paths needed for extraction."""
 
-    def __init__(
-        self,
-        model_file: ModelFile,
-        local_path: str,
-        out_dir_path: str,
-        pair_id: str | None = None,
-        local_path_fallback: str | None = None,
-        out_dir_path_fallback: str | None = None,
-    ):
-        self.model_file = model_file
-        self.pair_id = pair_id
-        self.local_path = local_path
-        self.out_dir_path = out_dir_path
-        self.local_path_fallback = local_path_fallback
-        self.out_dir_path_fallback = out_dir_path_fallback or out_dir_path
+    model_file: ModelFile
+    local_path: str
+    out_dir_path: str
+    pair_id: str | None = None
+    local_path_fallback: str | None = None
+    out_dir_path_fallback: str | None = None

--- a/src/python/controller/move/move_process.py
+++ b/src/python/controller/move/move_process.py
@@ -6,25 +6,20 @@ import datetime
 import errno
 import os
 import shutil
+from dataclasses import dataclass
 from typing import override
 
 from common import AppOneShotProcess, Constants, PipeStream
 
 
+@dataclass
 class MoveFailedResult:
     """Result reported when a staging->final move fails."""
 
-    def __init__(
-        self,
-        timestamp: datetime.datetime,
-        name: str,
-        pair_id: str | None = None,
-        error_message: str | None = None,
-    ):
-        self.timestamp = timestamp
-        self.name = name
-        self.pair_id = pair_id
-        self.error_message = error_message
+    timestamp: datetime.datetime
+    name: str
+    pair_id: str | None = None
+    error_message: str | None = None
 
 
 class MoveProcess(AppOneShotProcess):

--- a/src/python/controller/pair_context.py
+++ b/src/python/controller/pair_context.py
@@ -8,6 +8,8 @@ Extracted from controller.py as part of the controller decomposition
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 from common import AppError, Config, Constants, Context
 from lftp import Lftp
 
@@ -23,53 +25,38 @@ class ControllerError(AppError):
     pass
 
 
+@dataclass
 class PairContext:
     """
     Holds all per-pair state: LFTP instance, scanners, scanner processes,
     model builder, and download tracking.
     """
 
-    def __init__(
-        self,
-        pair_id: str | None,
-        name: str,
-        remote_path: str,
-        local_path: str,
-        effective_local_path: str,
-        lftp: Lftp,
-        active_scanner: ActiveScanner,
-        local_scanner: LocalScanner,
-        remote_scanner: RemoteScanner,
-        active_scan_process: ScannerProcess,
-        local_scan_process: ScannerProcess,
-        remote_scan_process: ScannerProcess,
-        model_builder: ModelBuilder,
-    ):
-        self.pair_id = pair_id
-        self.name = name
-        self.remote_path = remote_path
-        self.local_path = local_path
-        self.effective_local_path = effective_local_path
-        self.lftp = lftp
-        self.active_scanner = active_scanner
-        self.local_scanner = local_scanner
-        self.remote_scanner = remote_scanner
-        self.active_scan_process = active_scan_process
-        self.local_scan_process = local_scan_process
-        self.remote_scan_process = remote_scan_process
-        self.model_builder = model_builder
+    pair_id: str | None
+    name: str
+    remote_path: str
+    local_path: str
+    effective_local_path: str
+    lftp: Lftp
+    active_scanner: ActiveScanner
+    local_scanner: LocalScanner
+    remote_scanner: RemoteScanner
+    active_scan_process: ScannerProcess
+    local_scan_process: ScannerProcess
+    remote_scan_process: ScannerProcess
+    model_builder: ModelBuilder
 
-        # Per-pair tracking state
-        self.active_downloading_file_names: list[str] = []
-        self.active_extracting_file_names: list[str] = []
-        self.prev_downloading_file_names: set[str] = set()
-        self.pending_completion: set[str] = set()
-        self.remote_scan_received: bool = False
-        self.local_scan_received: bool = False
+    # Per-pair tracking state
+    active_downloading_file_names: list[str] = field(default_factory=list[str])
+    active_extracting_file_names: list[str] = field(default_factory=list[str])
+    prev_downloading_file_names: set[str] = field(default_factory=set[str])
+    pending_completion: set[str] = field(default_factory=set[str])
+    remote_scan_received: bool = False
+    local_scan_received: bool = False
 
-        # Temporary storage for latest scan results (set during ModelUpdater._update_pair_model_state)
-        self.latest_remote_scan: ScannerResult | None = None
-        self.latest_local_scan: ScannerResult | None = None
+    # Temporary storage for latest scan results (set during ModelUpdater._update_pair_model_state)
+    latest_remote_scan: ScannerResult | None = None
+    latest_local_scan: ScannerResult | None = None
 
 
 def validate_config(context: Context) -> None:
@@ -95,9 +82,9 @@ def validate_config(context: Context) -> None:
         "num_max_total_connections",
         "protocol",
     ]
-    for field in lftp_fields:
-        if getattr(config.lftp, field) is None:
-            missing.append(f"Lftp.{field}")
+    for name in lftp_fields:
+        if getattr(config.lftp, name) is None:
+            missing.append(f"Lftp.{name}")
 
     # FTP port: when protocol is ftps, remote_ftp_port must be set
     if config.lftp.protocol == "ftps" and config.lftp.remote_ftp_port is None:
@@ -109,9 +96,9 @@ def validate_config(context: Context) -> None:
         "interval_ms_local_scan",
         "interval_ms_downloading_scan",
     ]
-    for field in controller_fields:
-        if getattr(config.controller, field) is None:
-            missing.append(f"Controller.{field}")
+    for name in controller_fields:
+        if getattr(config.controller, name) is None:
+            missing.append(f"Controller.{name}")
 
     # Extract path: when use_local_path_as_extract_path is False, extract_path must be set
     if config.controller.use_local_path_as_extract_path is None:

--- a/src/python/controller/scan/scanner_process.py
+++ b/src/python/controller/scan/scanner_process.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from typing import override
 
@@ -39,18 +40,16 @@ class IScanner(ABC):
         pass
 
 
+@dataclass
 class ScannerResult:
     """
     Results of a system scan
     """
 
-    def __init__(
-        self, timestamp: datetime, files: list[SystemFile], failed: bool = False, error_message: str | None = None
-    ):
-        self.timestamp = timestamp
-        self.files = files
-        self.failed = failed
-        self.error_message = error_message
+    timestamp: datetime
+    files: list[SystemFile]
+    failed: bool = False
+    error_message: str | None = None
 
 
 class ScannerProcess(AppProcess):

--- a/src/python/controller/validate/validate_process.py
+++ b/src/python/controller/validate/validate_process.py
@@ -8,6 +8,7 @@ import multiprocessing
 import os
 import queue
 import time
+from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, override
 
@@ -17,82 +18,57 @@ if TYPE_CHECKING:
     from ssh import Sshcp
 
 
+@dataclass
 class ValidateRequest:
     """Request to validate a file by comparing local and remote checksums."""
 
-    def __init__(
-        self,
-        name: str,
-        is_dir: bool,
-        pair_id: str | None,
-        local_path: str,
-        remote_path: str,
-        algorithm: str,
-        remote_address: str,
-        remote_username: str,
-        remote_password: str | None,
-        remote_port: int,
-    ):
-        self.name = name
-        self.is_dir = is_dir
-        self.pair_id = pair_id
-        self.local_path = local_path
-        self.remote_path = remote_path
-        self.algorithm = algorithm
-        self.remote_address = remote_address
-        self.remote_username = remote_username
-        self.remote_password = remote_password
-        self.remote_port = remote_port
+    name: str
+    is_dir: bool
+    pair_id: str | None
+    local_path: str
+    remote_path: str
+    algorithm: str
+    remote_address: str
+    remote_username: str
+    remote_password: str | None
+    remote_port: int
 
 
+@dataclass
 class ValidateStatus:
     """Status of an in-progress validation."""
 
     class State(Enum):
         VALIDATING = 0
 
-    def __init__(self, name: str, is_dir: bool, state: ValidateStatus.State, pair_id: str | None = None):
-        self.name = name
-        self.is_dir = is_dir
-        self.state = state
-        self.pair_id = pair_id
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ValidateStatus):
-            return NotImplemented
-        return self.__dict__ == other.__dict__
+    name: str
+    is_dir: bool
+    state: ValidateStatus.State
+    pair_id: str | None = None
 
 
+@dataclass
 class ValidateStatusResult:
-    def __init__(self, timestamp: datetime.datetime, statuses: list[ValidateStatus]):
-        self.timestamp = timestamp
-        self.statuses = statuses
+    timestamp: datetime.datetime
+    statuses: list[ValidateStatus]
 
 
+@dataclass
 class ValidateCompletedResult:
-    def __init__(self, timestamp: datetime.datetime, name: str, is_dir: bool, pair_id: str | None = None):
-        self.timestamp = timestamp
-        self.name = name
-        self.is_dir = is_dir
-        self.pair_id = pair_id
+    timestamp: datetime.datetime
+    name: str
+    is_dir: bool
+    pair_id: str | None = None
 
 
+@dataclass
 class ValidateFailedResult:
-    def __init__(
-        self,
-        timestamp: datetime.datetime,
-        name: str,
-        is_dir: bool,
-        pair_id: str | None = None,
-        error_message: str | None = None,
-        is_checksum_mismatch: bool = False,
-    ):
-        self.timestamp = timestamp
-        self.name = name
-        self.is_dir = is_dir
-        self.pair_id = pair_id
-        self.error_message = error_message
-        self.is_checksum_mismatch = is_checksum_mismatch
+    timestamp: datetime.datetime
+    name: str
+    is_dir: bool
+    pair_id: str | None = None
+    error_message: str | None = None
+    is_checksum_mismatch: bool = False
 
 
 class ChecksumMismatchError(ValueError):

--- a/src/python/lftp/job_status.py
+++ b/src/python/lftp/job_status.py
@@ -34,31 +34,15 @@ class LftpJobStatus:
         eta: int | None
 
     def __init__(self, job_id: int, job_type: Type, state: State, name: str, flags: str):
-        self.__id = job_id
-        self.__type = job_type
-        self.__state = state
-        self.__name = name
-        self.__flags = flags
+        self.id = job_id
+        self.type = job_type
+        self.state = state
+        self.name = name
+        self.flags = flags
         self.__total_transfer_state = LftpJobStatus.TransferState(None, None, None, None, None)
         # dict of active file transfer states, maps filename to their transfer state
         # there's no hierarchical info for now
         self.__active_files_state: dict[str, LftpJobStatus.TransferState] = {}
-
-    @property
-    def id(self) -> int:
-        return self.__id
-
-    @property
-    def type(self) -> Type:
-        return self.__type
-
-    @property
-    def state(self) -> "LftpJobStatus.State":
-        return self.__state
-
-    @property
-    def name(self) -> str:
-        return self.__name
 
     @property
     def total_transfer_state(self) -> TransferState:
@@ -66,12 +50,12 @@ class LftpJobStatus:
 
     @total_transfer_state.setter
     def total_transfer_state(self, total_transfer_state: TransferState):
-        if self.__state == LftpJobStatus.State.QUEUED:
+        if self.state == LftpJobStatus.State.QUEUED:
             raise TypeError("Cannot set transfer state on job of type queue")
         self.__total_transfer_state = total_transfer_state
 
     def add_active_file_transfer_state(self, filename: str, transfer_state: TransferState):
-        if self.__state == LftpJobStatus.State.QUEUED:
+        if self.state == LftpJobStatus.State.QUEUED:
             raise TypeError("Cannot set transfer state on job of type queue")
         self.__active_files_state[filename] = transfer_state
 

--- a/src/python/model/diff.py
+++ b/src/python/model/diff.py
@@ -1,5 +1,6 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
+from dataclasses import dataclass
 from enum import Enum
 
 # my libs
@@ -7,6 +8,7 @@ from .file import ModelFile
 from .model import Model
 
 
+@dataclass(frozen=True)
 class ModelDiff:
     """
     Represents a single change in the model
@@ -17,30 +19,9 @@ class ModelDiff:
         REMOVED = 1
         UPDATED = 2
 
-    def __init__(self, change: Change, old_file: ModelFile | None, new_file: ModelFile | None):
-        self.__change = change
-        self.__old_file = old_file
-        self.__new_file = new_file
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ModelDiff):
-            return NotImplemented
-        return self.__dict__ == other.__dict__
-
-    def __repr__(self) -> str:
-        return str(self.__dict__)
-
-    @property
-    def change(self) -> Change:
-        return self.__change
-
-    @property
-    def old_file(self) -> ModelFile | None:
-        return self.__old_file
-
-    @property
-    def new_file(self) -> ModelFile | None:
-        return self.__new_file
+    change: Change
+    old_file: ModelFile | None
+    new_file: ModelFile | None
 
 
 class ModelDiffUtil:

--- a/src/python/system/file.py
+++ b/src/python/system/file.py
@@ -19,12 +19,12 @@ class SystemFile:
     ):
         if size < 0:
             raise ValueError("File size must be non-negative")
-        self.__name = name
-        self.__size = size  # in bytes
-        self.__is_dir = is_dir
-        self.__timestamp_created = time_created
-        self.__timestamp_modified = time_modified
-        self.__children: list[SystemFile] = []
+        self.name = name
+        self.size = size  # in bytes
+        self.is_dir = is_dir
+        self.timestamp_created = time_created
+        self.timestamp_modified = time_modified
+        self.children: list[SystemFile] = []
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SystemFile):
@@ -34,43 +34,19 @@ class SystemFile:
     def __repr__(self) -> str:
         return str(self.__dict__)
 
-    @property
-    def name(self) -> str:
-        return self.__name
-
-    @property
-    def size(self) -> int:
-        return self.__size
-
-    @property
-    def is_dir(self) -> bool:
-        return self.__is_dir
-
-    @property
-    def timestamp_created(self) -> datetime | None:
-        return self.__timestamp_created
-
-    @property
-    def timestamp_modified(self) -> datetime | None:
-        return self.__timestamp_modified
-
-    @property
-    def children(self) -> list["SystemFile"]:
-        return self.__children
-
     def add_child(self, file: "SystemFile"):
-        if not self.__is_dir:
+        if not self.is_dir:
             raise TypeError("Cannot add children to a file")
-        self.__children.append(file)
+        self.children.append(file)
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "name": self.__name,
-            "size": self.__size,
-            "is_dir": self.__is_dir,
-            "time_created": self.__timestamp_created.isoformat() if self.__timestamp_created else None,
-            "time_modified": self.__timestamp_modified.isoformat() if self.__timestamp_modified else None,
-            "children": [child.to_dict() for child in self.__children],
+            "name": self.name,
+            "size": self.size,
+            "is_dir": self.is_dir,
+            "time_created": self.timestamp_created.isoformat() if self.timestamp_created else None,
+            "time_modified": self.timestamp_modified.isoformat() if self.timestamp_modified else None,
+            "children": [child.to_dict() for child in self.children],
         }
 
     @staticmethod

--- a/src/python/web/serialize/serialize_auto_queue.py
+++ b/src/python/web/serialize/serialize_auto_queue.py
@@ -6,12 +6,6 @@ from controller import AutoQueuePattern
 
 
 class SerializeAutoQueue:
-    __KEY_PATTERN = "pattern"
-
     @staticmethod
     def patterns(patterns: list[AutoQueuePattern]) -> str:
-        patterns_list: list[dict[str, str]] = []
-        for pattern in patterns:
-            patterns_list.append({SerializeAutoQueue.__KEY_PATTERN: pattern.pattern})
-
-        return json.dumps(patterns_list)
+        return json.dumps([{"pattern": p.pattern} for p in patterns])

--- a/src/python/web/serialize/serialize_log_record.py
+++ b/src/python/web/serialize/serialize_log_record.py
@@ -12,33 +12,23 @@ class SerializeLogRecord(Serialize):
     and the EventSource client frontend for the log stream.
     """
 
-    # Event keys
-    __EVENT_RECORD = "log-record"
-
-    # Data keys
-    __KEY_TIME = "time"
-    __KEY_LEVEL_NAME = "level_name"
-    __KEY_LOGGER_NAME = "logger_name"
-    __KEY_MESSAGE = "message"
-    __KEY_EXCEPTION_TRACEBACK = "exc_tb"
-
     def __init__(self):
         super().__init__()
         # logging formatter to generate exception traceback
         self.__log_formatter = logging.Formatter()
 
     def record(self, record: logging.LogRecord) -> str:
-        json_dict: dict[str, str | None] = {}
-        json_dict[SerializeLogRecord.__KEY_TIME] = str(record.created)
-        json_dict[SerializeLogRecord.__KEY_LEVEL_NAME] = record.levelname
-        json_dict[SerializeLogRecord.__KEY_LOGGER_NAME] = record.name
-        json_dict[SerializeLogRecord.__KEY_MESSAGE] = record.getMessage()
         exc_text = None
         if record.exc_text:
             exc_text = record.exc_text
         elif record.exc_info:
             exc_text = self.__log_formatter.formatException(record.exc_info)
-        json_dict[SerializeLogRecord.__KEY_EXCEPTION_TRACEBACK] = exc_text
 
-        record_json = json.dumps(json_dict)
-        return self._sse_pack(event=SerializeLogRecord.__EVENT_RECORD, data=record_json)
+        json_dict = {
+            "time": str(record.created),
+            "level_name": record.levelname,
+            "logger_name": record.name,
+            "message": record.getMessage(),
+            "exc_tb": exc_text,
+        }
+        return self._sse_pack(event="log-record", data=json.dumps(json_dict))

--- a/src/python/web/serialize/serialize_status.py
+++ b/src/python/web/serialize/serialize_status.py
@@ -1,7 +1,6 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
 import json
-from typing import Any
 
 from common import Status
 
@@ -9,52 +8,30 @@ from .serialize import Serialize
 
 
 class SerializeStatusJson:
-    # Data keys
-    __KEY_SERVER = "server"
-    __KEY_SERVER_UP = "up"
-    __KEY_SERVER_ERROR_MSG = "error_msg"
-    __KEY_CONTROLLER = "controller"
-    __KEY_CONTROLLER_LATEST_LOCAL_SCAN_TIME = "latest_local_scan_time"
-    __KEY_CONTROLLER_LATEST_REMOTE_SCAN_TIME = "latest_remote_scan_time"
-    __KEY_CONTROLLER_LATEST_REMOTE_SCAN_FAILED = "latest_remote_scan_failed"
-    __KEY_CONTROLLER_LATEST_REMOTE_SCAN_ERROR = "latest_remote_scan_error"
-    __KEY_CONTROLLER_NO_ENABLED_PAIRS = "no_enabled_pairs"
-
     @staticmethod
     def status(status: Status) -> str:
-        json_dict: dict[str, Any] = {}
-
-        json_dict[SerializeStatusJson.__KEY_SERVER] = {}
-        json_dict[SerializeStatusJson.__KEY_SERVER][SerializeStatusJson.__KEY_SERVER_UP] = status.server.up
-        json_dict[SerializeStatusJson.__KEY_SERVER][SerializeStatusJson.__KEY_SERVER_ERROR_MSG] = (
-            status.server.error_msg
-        )
-
-        json_dict[SerializeStatusJson.__KEY_CONTROLLER] = {}
-        json_dict[SerializeStatusJson.__KEY_CONTROLLER][SerializeStatusJson.__KEY_CONTROLLER_LATEST_LOCAL_SCAN_TIME] = (
-            str(status.controller.latest_local_scan_time.timestamp())
-            if status.controller.latest_local_scan_time
-            else None
-        )
-        json_dict[SerializeStatusJson.__KEY_CONTROLLER][
-            SerializeStatusJson.__KEY_CONTROLLER_LATEST_REMOTE_SCAN_TIME
-        ] = (
-            str(status.controller.latest_remote_scan_time.timestamp())
-            if status.controller.latest_remote_scan_time
-            else None
-        )
-        json_dict[SerializeStatusJson.__KEY_CONTROLLER][
-            SerializeStatusJson.__KEY_CONTROLLER_LATEST_REMOTE_SCAN_FAILED
-        ] = status.controller.latest_remote_scan_failed
-        json_dict[SerializeStatusJson.__KEY_CONTROLLER][
-            SerializeStatusJson.__KEY_CONTROLLER_LATEST_REMOTE_SCAN_ERROR
-        ] = status.controller.latest_remote_scan_error
-        json_dict[SerializeStatusJson.__KEY_CONTROLLER][SerializeStatusJson.__KEY_CONTROLLER_NO_ENABLED_PAIRS] = (
-            status.controller.no_enabled_pairs
-        )
-
-        status_json = json.dumps(json_dict)
-        return status_json
+        json_dict = {
+            "server": {
+                "up": status.server.up,
+                "error_msg": status.server.error_msg,
+            },
+            "controller": {
+                "latest_local_scan_time": (
+                    str(status.controller.latest_local_scan_time.timestamp())
+                    if status.controller.latest_local_scan_time
+                    else None
+                ),
+                "latest_remote_scan_time": (
+                    str(status.controller.latest_remote_scan_time.timestamp())
+                    if status.controller.latest_remote_scan_time
+                    else None
+                ),
+                "latest_remote_scan_failed": status.controller.latest_remote_scan_failed,
+                "latest_remote_scan_error": status.controller.latest_remote_scan_error,
+                "no_enabled_pairs": status.controller.no_enabled_pairs,
+            },
+        }
+        return json.dumps(json_dict)
 
 
 class SerializeStatus(Serialize):
@@ -63,9 +40,6 @@ class SerializeStatus(Serialize):
     and the EventSource client frontend for the status stream.
     """
 
-    # Event keys
-    __EVENT_STATUS = "status"
-
     def status(self, status: Status) -> str:
         status_json = SerializeStatusJson.status(status)
-        return self._sse_pack(event=SerializeStatus.__EVENT_STATUS, data=status_json)
+        return self._sse_pack(event="status", data=status_json)


### PR DESCRIPTION
## Summary

Closes #667 (Phase 3 of the over-engineering audit, tracking issue #682).

- Convert 11 pure-data classes with hand-written `__init__` assignment lists to `@dataclass`: `ExtractStatusResult`/`ExtractCompletedResult`/`ExtractFailedResult`/`ExtractRequest`, `MoveFailedResult`, `ValidateRequest`/`ValidateStatus`/`ValidateStatusResult`/`ValidateCompletedResult`/`ValidateFailedResult`, `ScannerResult`, plus `ExtractDispatch._Task` and `PairContext` (with `field(default_factory=...)` for container defaults).
- `ExtractStatus` and `ModelDiff` become `@dataclass(frozen=True)` (were read-only property blocks).
- `SystemFile` and `LftpJobStatus` keep their hand-written `__init__` but drop getter-only property blocks in favor of plain public attributes. Rationale: `SystemFile`'s ctor kwargs (`time_created`) differ from its attribute names (`timestamp_created`) and are used by the synced `scan_fs.py` copy and many tests; `LftpJobStatus` has a guarded `total_transfer_state` setter (TypeError on QUEUED jobs) that a dataclass can't express. Both keep their `__dict__`-based `__eq__`.
- Serializer `__KEY_*`/`__EVENT_*` once-used constants collapsed into dict literals in `SerializeStatusJson`, `SerializeLogRecord`, `SerializeAutoQueue`. Key order and wire format unchanged.

Net: **−168 lines** (173 insertions, 341 deletions).

## Contract notes

- **Wire format locked by existing specs**: `test_serialize_status` asserts every status key (`no_enabled_pairs` covered by the integration handler test), `test_serialize_log_record` all five log keys, `test_serialize_auto_queue` the `pattern` key — no golden tests needed to be added; all pass unmodified.
- **Multiprocessing round-trips**: the converted result/request classes cross process boundaries via `PipeStream`/`mp.Queue`; dataclasses pickle identically and the extract/validate/scanner worker tests pass unmodified.
- **One behavior-neutral relocation**: `ExtractRequest` previously resolved `out_dir_path_fallback or out_dir_path` in its ctor; it now stores the value as passed and the two consumers in `ExtractDispatch` resolve the fallback with `or`. Same observable behavior (pyright strict rejected assigning to a same-named `InitVar` attribute).

## Intentionally skipped

- `ValidateStatus` kept as plain (non-frozen) `@dataclass` — it already had public attrs; freezing would add hashability it never had.
- `MoveProcess.file_name`/`pair_id` properties untouched — `MoveProcess` is a process class, not a data class, and outside the issue's findings.

## Test plan

- [x] `uv run ruff check .` and `uv run ruff format --check .` — pass
- [x] `uv run pyright` (source packages) — 0 errors
- [x] `PYTHONPATH=. uv run pytest tests/unittests` — 982 passed; only known local-only failure (`test_scan_file_with_latin_chars`, macOS APFS) plus `test_multiprocessing_logger::test_logger_levels` which is flaky under full-suite load and passes in isolation (untouched by this diff)
- [x] `PYTHONPATH=. uv run pytest tests/integration` — 157 passed; only known local-only failures (`test_extract`, missing `rar` locally)
- [x] Field test: `make build && make run` — container healthy; `/server/status` and `/server/stream` emit the exact expected JSON shape; autoqueue add/get/remove round-trip returns `[{"pattern": "\"test-pattern\""}]`; UI serves 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of extraction output locations when no fallback directory is configured, providing more consistent file placement.

- **Refactor**
  - Streamlined internal status, request, result, file, and job data handling for greater consistency and reliability.
  - Preserved existing extraction, validation, scanning, transfer, and serialization behavior while simplifying maintenance.
  - Improved consistency of status and error information returned during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->