### PR TITLE
refactor(python): replace notifier thread bookkeeping with ThreadPoolExecutor (#669)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ Soft targets: file ≤ 500 lines, class ≤ 300, function ≤ 40, complexity ≤
 - Conventional commits with scope: `feat(angular):`, `fix(python):`, `chore(build):`, `refactor(python):`, `docs:`, `ci:`. Reference issues (`(#123)`) in the subject or body.
 - **Never add AI attribution, advertising, or co-author lines** to commits, PR bodies, or comments. No `Co-Authored-By: Claude`, no "Generated with …" footers.
 - PR body: short summary, what was intentionally skipped and why, a test-plan checklist, and any size-delta or contract notes the issue asked for. Tick the corresponding checklist item in the tracking issue when a PR merges.
-- CodeRabbit incremental reviews are off; trigger with a `@coderabbitai review` comment when a PR is ready.
+- CodeRabbit incremental reviews are off. Do not trigger reviews (no `@coderabbitai review` comments) — the user triggers them.
 - Inline review comments must anchor to lines in the diff; verify a finding against current code before posting it.
 - Before each commit, review the diff for over-engineering. If the ponytail plugin (<https://github.com/DietrichGebert/ponytail>) is installed, use its `ponytail:ponytail-review` skill; otherwise do a trim pass: remove speculative config, unused state, single-caller layers, and duplicate helpers.
 

--- a/src/python/controller/arr_notifier.py
+++ b/src/python/controller/arr_notifier.py
@@ -2,8 +2,8 @@ import json
 import logging
 import os
 import threading
-import time
 import urllib.request
+from concurrent.futures import Future, ThreadPoolExecutor, wait
 
 from common import ArrInstance, IntegrationsConfig, PathPair, PathPairsConfig
 from model import IModelListener, ModelFile
@@ -32,9 +32,9 @@ class ArrNotifier(IModelListener):
         self._integrations_config = integrations_config
         self._path_pairs_config = path_pairs_config
         self._logger = logger.getChild("ArrNotifier")
-        self._shutdown_flag = False
-        self._active_threads: set[threading.Thread] = set()
-        self._lock = threading.Lock()
+        self._executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="ArrNotifier")
+        self._pending: set[Future[None]] = set()
+        self._pending_lock = threading.Lock()
 
     def file_added(self, file: ModelFile):
         pass
@@ -79,32 +79,25 @@ class ArrNotifier(IModelListener):
             )
 
     def shutdown(self, timeout: float = 5):
-        """Drain in-flight threads and prevent new ones."""
-        with self._lock:
-            self._shutdown_flag = True
-            threads = list(self._active_threads)
+        """Drain in-flight sends and prevent new ones."""
+        self._executor.shutdown(wait=False, cancel_futures=True)
+        with self._pending_lock:
+            pending = [f for f in self._pending if not f.done()]
 
-        if not threads:
-            self._logger.debug("Arr notifier shutdown: no in-flight threads")
+        if not pending:
+            self._logger.debug("Arr notifier shutdown: no in-flight sends")
             return
 
-        self._logger.info("Arr notifier shutting down, waiting for %d in-flight thread(s)", len(threads))
-        deadline = time.monotonic() + timeout
-        for thread in threads:
-            remaining = max(0, deadline - time.monotonic())
-            thread.join(timeout=remaining)
-
-        with self._lock:
-            still_alive = [t for t in self._active_threads if t.is_alive()]
-
-        if still_alive:
+        self._logger.info("Arr notifier shutting down, waiting for %d in-flight send(s)", len(pending))
+        not_done = wait(pending, timeout=timeout).not_done
+        if not_done:
             self._logger.warning(
-                "Arr notifier shutdown: %d thread(s) did not complete within %.1fs timeout",
-                len(still_alive),
+                "Arr notifier shutdown: %d send(s) did not complete within %.1fs timeout",
+                len(not_done),
                 timeout,
             )
         else:
-            self._logger.info("Arr notifier shutdown: all threads completed")
+            self._logger.info("Arr notifier shutdown: all sends completed")
 
     @staticmethod
     def _resolve_local_path(pair: PathPair, file: ModelFile) -> str:
@@ -112,27 +105,21 @@ class ArrNotifier(IModelListener):
         return os.path.join(base, file.full_path) if base else file.full_path
 
     def _fire_scan(self, service: str, base_url: str, api_key: str, command_name: str, path: str):
-        """Fire-and-forget POST in a daemon thread."""
+        """Fire-and-forget POST on the executor."""
         url = base_url.rstrip("/") + "/api/v3/command"
         payload = {"name": command_name, "path": path}
-        thread = threading.Thread(
-            target=self._thread_wrapper,
-            args=(service, url, api_key, payload),
-            daemon=True,
-        )
-        with self._lock:
-            if self._shutdown_flag:
-                self._logger.debug("%s scan suppressed during shutdown: %s", service, path)
-                return
-            thread.start()
-            self._active_threads.add(thread)
-
-    def _thread_wrapper(self, service: str, url: str, api_key: str, payload: dict[str, str]) -> None:
         try:
-            self._send_post(service, url, api_key, payload)
-        finally:
-            with self._lock:
-                self._active_threads.discard(threading.current_thread())
+            future = self._executor.submit(self._send_post, service, url, api_key, payload)
+        except RuntimeError:
+            self._logger.debug("%s scan suppressed during shutdown: %s", service, path)
+            return
+        with self._pending_lock:
+            self._pending.add(future)
+        future.add_done_callback(self._discard_pending)
+
+    def _discard_pending(self, future: Future[None]) -> None:
+        with self._pending_lock:
+            self._pending.discard(future)
 
     def _send_post(self, service: str, url: str, api_key: str, payload: dict[str, str]) -> None:
         if not url.startswith(("http://", "https://")):

--- a/src/python/controller/notifier.py
+++ b/src/python/controller/notifier.py
@@ -1,8 +1,8 @@
 import json
 import logging
 import threading
-import time
 import urllib.request
+from concurrent.futures import Future, ThreadPoolExecutor, wait
 from datetime import UTC, datetime
 
 from common import Config
@@ -16,9 +16,9 @@ class WebhookNotifier(IModelListener):
     def __init__(self, config: Config, logger: logging.Logger):
         self._config = config
         self._logger = logger.getChild("WebhookNotifier")
-        self._shutdown_flag = False
-        self._active_threads: set[threading.Thread] = set()
-        self._lock = threading.Lock()
+        self._executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="WebhookNotifier")
+        self._pending: set[Future[None]] = set()
+        self._pending_lock = threading.Lock()
 
     def file_added(self, file: ModelFile):
         pass
@@ -61,32 +61,25 @@ class WebhookNotifier(IModelListener):
         return None
 
     def shutdown(self, timeout: float = 5):
-        """Drain in-flight webhook threads and prevent new ones from being queued."""
-        with self._lock:
-            self._shutdown_flag = True
-            threads = list(self._active_threads)
+        """Drain in-flight webhook sends and prevent new ones from being queued."""
+        self._executor.shutdown(wait=False, cancel_futures=True)
+        with self._pending_lock:
+            pending = [f for f in self._pending if not f.done()]
 
-        if not threads:
-            self._logger.debug("Webhook notifier shutdown: no in-flight threads")
+        if not pending:
+            self._logger.debug("Webhook notifier shutdown: no in-flight sends")
             return
 
-        self._logger.info("Webhook notifier shutting down, waiting for %d in-flight thread(s)", len(threads))
-        deadline = time.monotonic() + timeout
-        for thread in threads:
-            remaining = max(0, deadline - time.monotonic())
-            thread.join(timeout=remaining)
-
-        with self._lock:
-            still_alive = [t for t in self._active_threads if t.is_alive()]
-
-        if still_alive:
+        self._logger.info("Webhook notifier shutting down, waiting for %d in-flight send(s)", len(pending))
+        not_done = wait(pending, timeout=timeout).not_done
+        if not_done:
             self._logger.warning(
-                "Webhook notifier shutdown: %d thread(s) did not complete within %.1fs timeout",
-                len(still_alive),
+                "Webhook notifier shutdown: %d send(s) did not complete within %.1fs timeout",
+                len(not_done),
                 timeout,
             )
         else:
-            self._logger.info("Webhook notifier shutdown: all threads completed")
+            self._logger.info("Webhook notifier shutdown: all sends completed")
 
     def _fire_webhook(
         self,
@@ -141,26 +134,19 @@ class WebhookNotifier(IModelListener):
         self._fire_raw("Telegram", url, headers, body)
 
     def _fire_raw(self, label: str, url: str, headers: dict[str, str], body: bytes):
-        """Fire-and-forget POST in a daemon thread."""
-        thread = threading.Thread(target=self._thread_wrapper, args=(label, url, headers, body), daemon=True)
-        with self._lock:
-            if self._shutdown_flag:
-                self._logger.debug("%s notification suppressed during shutdown", label)
-                return
-            self._active_threads.add(thread)
+        """Fire-and-forget POST on the executor."""
         try:
-            thread.start()
+            future = self._executor.submit(self._send_post, label, url, headers, body)
         except RuntimeError:
-            with self._lock:
-                self._active_threads.discard(thread)
-            self._logger.exception("%s notification thread failed to start", label)
+            self._logger.debug("%s notification suppressed during shutdown", label)
+            return
+        with self._pending_lock:
+            self._pending.add(future)
+        future.add_done_callback(self._discard_pending)
 
-    def _thread_wrapper(self, label: str, url: str, headers: dict[str, str], body: bytes) -> None:
-        try:
-            self._send_post(label, url, headers, body)
-        finally:
-            with self._lock:
-                self._active_threads.discard(threading.current_thread())
+    def _discard_pending(self, future: Future[None]) -> None:
+        with self._pending_lock:
+            self._pending.discard(future)
 
     def _send_post(self, label: str, url: str, headers: dict[str, str], body: bytes) -> None:
         if not url.startswith(("http://", "https://")):

--- a/src/python/tests/unittests/test_controller/test_arr_notifier.py
+++ b/src/python/tests/unittests/test_controller/test_arr_notifier.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+import time
 import unittest
 from unittest.mock import patch
 
@@ -236,25 +237,23 @@ class TestArrNotifier(unittest.TestCase):
         notifier, _, _ = self._build_notifier(instances=[inst], pairs=[pair])
         barrier = threading.Event()
         started = threading.Event()
+        finished = threading.Event()
 
         def slow_send(*_args, **_kwargs):
             started.set()
             barrier.wait(timeout=5)
+            finished.set()
 
         with patch.object(notifier, "_send_post", side_effect=slow_send):
             self._trigger(notifier, pair_id=pair.id)
             self.assertTrue(started.wait(timeout=5))
 
-            with notifier._lock:
-                self.assertEqual(len(notifier._active_threads), 1)
-
             barrier.set()
             notifier.shutdown(timeout=2)
 
-            with notifier._lock:
-                self.assertEqual(len(notifier._active_threads), 0)
+            self.assertTrue(finished.is_set())
 
-    def test_thread_cleaned_up_on_exception(self):
+    def test_shutdown_completes_after_send_exception(self):
         inst = ArrInstance(name="Sonarr", kind="sonarr", url="http://s", api_key="k")
         pair = self._make_pair(arr_target_ids=[inst.id])
         notifier, _, _ = self._build_notifier(instances=[inst], pairs=[pair])
@@ -267,10 +266,12 @@ class TestArrNotifier(unittest.TestCase):
         with patch.object(notifier, "_send_post", side_effect=failing_send):
             self._trigger(notifier, pair_id=pair.id)
             self.assertTrue(started.wait(timeout=5))
-            notifier.shutdown(timeout=2)
 
-            with notifier._lock:
-                self.assertEqual(len(notifier._active_threads), 0)
+            start = time.monotonic()
+            notifier.shutdown(timeout=2)
+            elapsed = time.monotonic() - start
+
+            self.assertLess(elapsed, 1.0)
 
     # ------------------------------------------------------------------
     # Scheme guard

--- a/src/python/tests/unittests/test_controller/test_notifier.py
+++ b/src/python/tests/unittests/test_controller/test_notifier.py
@@ -52,27 +52,25 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
             notifier._fire_webhook("download_complete", "test.txt", "2026-01-01T00:00:00+00:00")
             mock_send.assert_not_called()
 
-    def test_shutdown_waits_for_inflight_threads(self):
+    def test_shutdown_waits_for_inflight_sends(self):
         notifier = self._make_notifier()
         barrier = threading.Event()
         started = threading.Event()
+        finished = threading.Event()
 
         def slow_send(*_args):
             started.set()
             barrier.wait(timeout=5)
+            finished.set()
 
         with patch.object(notifier, "_send_post", side_effect=slow_send):
             notifier._fire_webhook("download_complete", "test.txt", "2026-01-01T00:00:00+00:00")
             started.wait(timeout=5)
 
-            with notifier._lock:
-                self.assertEqual(len(notifier._active_threads), 1)
-
             barrier.set()
             notifier.shutdown(timeout=2)
 
-            with notifier._lock:
-                self.assertEqual(len(notifier._active_threads), 0)
+            self.assertTrue(finished.is_set())
 
     def test_shutdown_timeout_respected(self):
         notifier = self._make_notifier()
@@ -95,7 +93,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
 
         barrier.set()
 
-    def test_thread_removed_on_exception(self):
+    def test_shutdown_completes_after_send_exception(self):
         notifier = self._make_notifier()
         started = threading.Event()
 
@@ -106,12 +104,14 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
         with patch.object(notifier, "_send_post", side_effect=failing_send):
             notifier._fire_webhook("download_complete", "test.txt", "2026-01-01T00:00:00+00:00")
             started.wait(timeout=5)
+
+            start = time.monotonic()
             notifier.shutdown(timeout=2)
+            elapsed = time.monotonic() - start
 
-            with notifier._lock:
-                self.assertEqual(len(notifier._active_threads), 0)
+            self.assertLess(elapsed, 1.0)
 
-    def test_shutdown_flag_and_registration_atomic(self):
+    def test_shutdown_suppresses_all_subsequent_fires(self):
         notifier = self._make_notifier()
         notifier.shutdown(timeout=0)
 
@@ -120,10 +120,10 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
                 notifier._fire_webhook("download_complete", f"file{i}.txt", "2026-01-01T00:00:00+00:00")
 
             mock_send.assert_not_called()
-            with notifier._lock:
-                self.assertEqual(len(notifier._active_threads), 0)
 
-    def test_total_timeout_not_per_thread(self):
+    def test_total_timeout_not_per_send(self):
+        # 4 concurrent hung sends fill the executor; shutdown's deadline must
+        # apply to the batch, not per send.
         notifier = self._make_notifier()
         barriers: list[threading.Event] = []
         all_started = threading.Event()
@@ -136,12 +136,12 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
             barriers.append(b)
             with started_lock:
                 started_count += 1
-                if started_count >= 5:
+                if started_count >= 4:
                     all_started.set()
             b.wait(timeout=10)
 
         with patch.object(notifier, "_send_post", side_effect=slow_send):
-            for i in range(5):
+            for i in range(4):
                 notifier._fire_webhook("download_complete", f"file{i}.txt", "2026-01-01T00:00:00+00:00")
             all_started.wait(timeout=5)
 

--- a/src/python/tests/unittests/test_controller/test_notifier.py
+++ b/src/python/tests/unittests/test_controller/test_notifier.py
@@ -65,7 +65,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
 
         with patch.object(notifier, "_send_post", side_effect=slow_send):
             notifier._fire_webhook("download_complete", "test.txt", "2026-01-01T00:00:00+00:00")
-            started.wait(timeout=5)
+            self.assertTrue(started.wait(timeout=5))
 
             barrier.set()
             notifier.shutdown(timeout=2)
@@ -83,7 +83,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
 
         with patch.object(notifier, "_send_post", side_effect=stuck_send):
             notifier._fire_webhook("download_complete", "test.txt", "2026-01-01T00:00:00+00:00")
-            started.wait(timeout=5)
+            self.assertTrue(started.wait(timeout=5))
 
             start = time.monotonic()
             notifier.shutdown(timeout=0.2)
@@ -103,7 +103,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
 
         with patch.object(notifier, "_send_post", side_effect=failing_send):
             notifier._fire_webhook("download_complete", "test.txt", "2026-01-01T00:00:00+00:00")
-            started.wait(timeout=5)
+            self.assertTrue(started.wait(timeout=5))
 
             start = time.monotonic()
             notifier.shutdown(timeout=2)
@@ -143,7 +143,7 @@ class TestWebhookNotifierShutdown(unittest.TestCase):
         with patch.object(notifier, "_send_post", side_effect=slow_send):
             for i in range(4):
                 notifier._fire_webhook("download_complete", f"file{i}.txt", "2026-01-01T00:00:00+00:00")
-            all_started.wait(timeout=5)
+            self.assertTrue(all_started.wait(timeout=5))
 
             start = time.monotonic()
             notifier.shutdown(timeout=0.3)


### PR DESCRIPTION
## Summary

Closes #669 (Phase 3 of the over-engineering audit, tracking issue #682). Also carries a one-line AGENTS.md update: CodeRabbit reviews are user-triggered; agents must not post `@coderabbitai review` comments.

- `WebhookNotifier` and `ArrNotifier` drop their byte-for-byte duplicated thread bookkeeping (`_active_threads` set, `_lock`, `_shutdown_flag`, `_thread_wrapper`, manual join-with-deadline loop) for a `ThreadPoolExecutor(max_workers=4)` plus a small pending-futures set.
- Fire-and-forget send → `executor.submit`; a submit after shutdown raises `RuntimeError`, which is caught and logged with the same "suppressed during shutdown" debug message as before.
- `shutdown(timeout)` preserves the total-deadline semantics: non-blocking `executor.shutdown(wait=False, cancel_futures=True)` (rejects new sends, cancels queued ones), then `futures.wait(pending, timeout=timeout)` with the same info/warning logging.
- Notification behavior (URL scheme guard, payloads, error swallowing/logging) untouched.

Net: **−26 lines** in the notifiers, plus simpler tests.

## Behavior notes

- Concurrency is now capped at 4 in-flight sends per notifier (was unbounded thread-per-send). Sends have 5–10 s socket timeouts, so a slow endpoint delays later notifications by at most that.
- Executor threads are non-daemon (stdlib behavior); a send stuck in `urlopen` at interpreter exit is joined, bounded by the socket timeout. Previously daemon threads were abandoned.
- Container `docker stop` exits 137 — verified **pre-existing**: the published `ghcr.io/nitrobass24/seedsync:develop` image (without this change) does the same in 1.2 s; the entrypoint's signal handling never reaches the graceful path. Not a regression from this PR; possibly worth a separate issue.

## Tests

- Shutdown tests rewritten behavior-based per the issue (Event-blocked fake senders; no `_active_threads` internals): drain-waits-for-inflight asserts the send actually finished; hung-sender deadline test unchanged; multi-send total-deadline test now uses 4 concurrent hung sends (pool size); exception-in-send test asserts shutdown still completes within deadline. No `time.sleep` anywhere.

## Test plan

- [x] `uv run ruff check .` + `uv run ruff format --check .` — pass
- [x] `uv run pyright` (source packages) — 0 errors
- [x] Notifier suites — 37 passed in 0.7 s
- [x] Full unit suite ×4 — 983 passed each run; only known local-only failure (`test_scan_file_with_latin_chars`). One earlier run saw the pre-existing `test_multiprocessing_logger` flake fail and the pytest process then hang at interpreter exit; investigated — the hang tracks that flake's stuck child process, not this diff (4/4 subsequent full runs exit cleanly; notifier workers are all timeout-bounded)
- [x] Integration suite — 157 passed; only known local `test_extract` failures (missing `rar`)
- [x] Field test: `make build && make run` — container healthy, UI 200. The drain-under-load path itself needs a configured seedbox + webhook endpoint to exercise live, so the closest checks are the deterministic shutdown unit tests above plus the baseline `docker stop` comparison

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when delivering webhook and scan notifications.
  * Shutdown now cancels queued notifications and waits for active deliveries within the configured timeout.
  * Prevented new notification attempts after shutdown begins.
  * Improved handling and cleanup when notification delivery fails.
  * Added safeguards to prevent notification activity from exceeding configured concurrency limits.

* **Tests**
  * Expanded coverage for shutdown timing, failed deliveries, and concurrent notification handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->