### PR TITLE
refactor(python): replace status.py property metaprogramming with dataclasses (#671)

### DIFF
--- a/src/python/common/__init__.py
+++ b/src/python/common/__init__.py
@@ -10,9 +10,7 @@ from .localization import Localization as Localization
 from .multiprocessing_logger import MultiprocessingLogger as MultiprocessingLogger
 from .status import (
     Status as Status,
-    IStatusListener as IStatusListener,
     StatusComponent as StatusComponent,
-    IStatusComponentListener as IStatusComponentListener,
 )
 from .app_process import AppProcess as AppProcess, AppOneShotProcess as AppOneShotProcess
 from .pipe_primitives import PipeStream as PipeStream, PipeFlag as PipeFlag

--- a/src/python/common/status.py
+++ b/src/python/common/status.py
@@ -1,82 +1,48 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
-from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass, field, fields
+from datetime import datetime
 from threading import Lock
-from typing import Any, TypeVar, override
+from typing import TypeVar
 
 T = TypeVar("T", bound="StatusComponent")
 
-
-class IStatusComponentListener(ABC):
-    @abstractmethod
-    def notify(self, name: str):
-        """
-        Called when a property is changed
-        :param name:
-        :return:
-        """
-        pass
+type ComponentListener = Callable[[str], None]
 
 
-class BaseStatus:
+@dataclass(eq=False)
+class StatusComponent:
     """
-    Provides functionality to dynamically create properties
+    Base class for status of a single component.
+    Assigning any public field notifies listeners with the field name.
     """
 
-    # noinspection PyProtectedMember
-    @classmethod
-    def _create_property(cls, name: str) -> property:
-        return property(fget=lambda s: s._get_property(name), fset=lambda s, v: s._set_property(name, v))
+    _listeners: list[ComponentListener] = field(default_factory=list[ComponentListener], init=False, repr=False)
 
-    def _get_property(self, name: str) -> Any:
-        return getattr(self, "__" + name, None)
+    def add_listener(self, listener: ComponentListener):
+        if listener not in self._listeners:
+            self._listeners.append(listener)
 
-    def _set_property(self, name: str, value: Any):
-        setattr(self, "__" + name, value)
-
-
-class StatusComponent(BaseStatus):
-    """
-    Base class for status of a single component
-    """
-
-    def __init__(self):
-        self.__listeners: list[IStatusComponentListener] = []
-        self.__properties: list[str] = []  # names of properties created
-
-    def add_listener(self, listener: IStatusComponentListener):
-        if listener not in self.__listeners:
-            self.__listeners.append(listener)
-
-    def remove_listener(self, listener: IStatusComponentListener):
-        if listener in self.__listeners:
-            self.__listeners.remove(listener)
+    def remove_listener(self, listener: ComponentListener):
+        if listener in self._listeners:
+            self._listeners.remove(listener)
 
     @classmethod
     def copy(cls: type[T], src: T, dst: T) -> None:
-        property_names = [p for p in dir(cls) if isinstance(getattr(cls, p), property)]
-        for prop in property_names:
-            setattr(dst, "__" + prop, getattr(src, "__" + prop))
+        """Copy field values (but not listeners) from src to dst."""
+        for f in fields(src):
+            if not f.name.startswith("_"):
+                setattr(dst, f.name, getattr(src, f.name))
 
-    @override
-    def _set_property(self, name: str, value: Any):
-        super()._set_property(name, value)
-        # Notify listeners
-        for listener in self.__listeners:
-            listener.notify(name)
-
-
-class IStatusListener(ABC):
-    @abstractmethod
-    def notify(self):
-        """
-        Called when any property of a component is changed
-        :return:
-        """
-        pass
+    def __setattr__(self, name: str, value: object):
+        object.__setattr__(self, name, value)
+        if not name.startswith("_"):
+            for listener in self._listeners:
+                listener(name)
 
 
-class Status(BaseStatus):
+class Status:
     """
     This class tracks the status of all components across the server
     This is meant to be one-way communication - i.e. only one component
@@ -87,91 +53,56 @@ class Status(BaseStatus):
     any change, or to each component for component-specific changes.
     """
 
-    class CompListener(IStatusComponentListener):
-        """Propagates notifications from component to status listeners"""
-
-        def __init__(self, status: "Status"):
-            self.status = status
-
-        def notify(self, name: str):
-            self.status._listeners_lock.acquire()
-            for listener in self.status._listeners:
-                listener.notify()
-            self.status._listeners_lock.release()
-
     # ----- Start of component definition -----
+    @dataclass(eq=False)
     class ServerStatus(StatusComponent):
-        up = StatusComponent._create_property("up")
-        error_msg = StatusComponent._create_property("error_msg")
+        up: bool = True
+        error_msg: str | None = None
 
-        def __init__(self):
-            super().__init__()
-            self.up = True
-            self.error_msg = None
-
+    @dataclass(eq=False)
     class ControllerStatus(StatusComponent):
-        latest_local_scan_time = StatusComponent._create_property("latest_local_scan_time")
-        latest_remote_scan_time = StatusComponent._create_property("latest_remote_scan_time")
-        latest_remote_scan_failed = StatusComponent._create_property("latest_remote_scan_failed")
-        latest_remote_scan_error = StatusComponent._create_property("latest_remote_scan_error")
-        no_enabled_pairs = StatusComponent._create_property("no_enabled_pairs")
-
-        def __init__(self):
-            super().__init__()
-            self.latest_local_scan_time = None
-            self.latest_remote_scan_time = None
-            self.latest_remote_scan_failed = None
-            self.latest_remote_scan_error = None
-            self.no_enabled_pairs = False
+        latest_local_scan_time: datetime | None = None
+        latest_remote_scan_time: datetime | None = None
+        latest_remote_scan_failed: bool | None = None
+        latest_remote_scan_error: str | None = None
+        no_enabled_pairs: bool = False
 
     # ----- End of component definition -----
 
-    # Component registration
-    server = BaseStatus._create_property("server")
-    controller = BaseStatus._create_property("controller")
-
     def __init__(self):
-        self._listeners: list[IStatusListener] = []
+        self._listeners: list[Callable[[], None]] = []
         self._listeners_lock = Lock()
-        self.__comp_listener = Status.CompListener(self)
 
         # Component initialization
-        self.server = self.__create_component(Status.ServerStatus)
-        self.controller = self.__create_component(Status.ControllerStatus)
+        self.server = Status.ServerStatus()
+        self.controller = Status.ControllerStatus()
+        self.server.add_listener(self._on_component_changed)
+        self.controller.add_listener(self._on_component_changed)
+
+    def __setattr__(self, name: str, value: object):
+        """Components can only be set once"""
+        if name in ("server", "controller") and hasattr(self, name):
+            raise ValueError("Cannot reassign component")
+        object.__setattr__(self, name, value)
+
+    def _on_component_changed(self, _name: str) -> None:
+        """Propagates notifications from component to status listeners"""
+        with self._listeners_lock:
+            for listener in self._listeners:
+                listener()
 
     def copy(self) -> "Status":
         copy = Status()
-        cls = Status
-        property_names = [p for p in dir(cls) if isinstance(getattr(cls, p), property)]
-        for prop in property_names:
-            src_comp = self._get_property(prop)
-            dst_comp = copy._get_property(prop)
-            src_comp.__class__.copy(src_comp, dst_comp)
+        StatusComponent.copy(self.server, copy.server)
+        StatusComponent.copy(self.controller, copy.controller)
         return copy
 
-    def add_listener(self, listener: IStatusListener):
-        self._listeners_lock.acquire()
-        if listener not in self._listeners:
-            self._listeners.append(listener)
-        self._listeners_lock.release()
+    def add_listener(self, listener: Callable[[], None]):
+        with self._listeners_lock:
+            if listener not in self._listeners:
+                self._listeners.append(listener)
 
-    def remove_listener(self, listener: IStatusListener):
-        self._listeners_lock.acquire()
-        if listener in self._listeners:
-            self._listeners.remove(listener)
-        self._listeners_lock.release()
-
-    def __create_component(self, comp_cls: type[T]) -> T:
-        """Create a component and register our listener with it"""
-        # PyCharm is confused and complains about the ctor
-        # noinspection PyCallingNonCallable
-        comp = comp_cls()
-        comp.add_listener(self.__comp_listener)
-        return comp
-
-    @override
-    def _set_property(self, name: str, value: Any):
-        """Override set property so that it can only be set once"""
-        if self._get_property(name) is not None:
-            raise ValueError("Cannot reassign component")
-        super()._set_property(name, value)
+    def remove_listener(self, listener: Callable[[], None]):
+        with self._listeners_lock:
+            if listener in self._listeners:
+                self._listeners.remove(listener)

--- a/src/python/common/status.py
+++ b/src/python/common/status.py
@@ -81,7 +81,7 @@ class Status:
 
     def __setattr__(self, name: str, value: object):
         """Components can only be set once"""
-        if name in ("server", "controller") and hasattr(self, name):
+        if isinstance(getattr(self, name, None), StatusComponent):
             raise ValueError("Cannot reassign component")
         object.__setattr__(self, name, value)
 

--- a/src/python/tests/unittests/test_common/test_status.py
+++ b/src/python/tests/unittests/test_common/test_status.py
@@ -1,33 +1,18 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
 import unittest
+from dataclasses import dataclass
 from datetime import datetime
-from typing import override
+from typing import Any
 from unittest.mock import MagicMock
 
-from common import IStatusComponentListener, IStatusListener, Status, StatusComponent
+from common import Status, StatusComponent
 
 
+@dataclass(eq=False)
 class DummyStatusComponent(StatusComponent):
-    a = StatusComponent._create_property("a")
-    b = StatusComponent._create_property("b")
-
-    def __init__(self):
-        super().__init__()
-        self.a = None
-        self.b = None
-
-
-class DummyStatusComponentListener(IStatusComponentListener):
-    @override
-    def notify(self, name):
-        pass
-
-
-class DummyStatusListener(IStatusListener):
-    @override
-    def notify(self):
-        pass
+    a: Any = None
+    b: Any = None
 
 
 class TestStatusComponent(unittest.TestCase):
@@ -39,23 +24,22 @@ class TestStatusComponent(unittest.TestCase):
         self.assertEqual(33, d.b)
 
     def test_listeners(self):
-        listener = DummyStatusComponentListener()
-        listener.notify = MagicMock()
+        listener = MagicMock()
         d = DummyStatusComponent()
         d.add_listener(listener)
         d.a = "hello world"
-        listener.notify.assert_called_once_with("a")
-        listener.notify.reset_mock()
+        listener.assert_called_once_with("a")
+        listener.reset_mock()
         d.b = 44
-        listener.notify.assert_called_once_with("b")
+        listener.assert_called_once_with("b")
 
         # remove listener
-        listener.notify.reset_mock()
+        listener.reset_mock()
         d.remove_listener(listener)
         d.a = "bye world"
-        listener.notify.assert_not_called()
+        listener.assert_not_called()
         d.b = 22
-        listener.notify.assert_not_called()
+        listener.assert_not_called()
 
     def test_copy_values(self):
         d = DummyStatusComponent()
@@ -87,19 +71,18 @@ class TestStatusComponent(unittest.TestCase):
         d = DummyStatusComponent()
         d.a = "hello world"
         d.b = 55
-        listener = DummyStatusComponentListener()
-        listener.notify = MagicMock()
+        listener = MagicMock()
         d.add_listener(listener)
 
         e = DummyStatusComponent()
         DummyStatusComponent.copy(d, e)
 
         d.a = "bye world"
-        listener.notify.assert_called_once_with("a")
-        listener.notify.reset_mock()
+        listener.assert_called_once_with("a")
+        listener.reset_mock()
 
         e.a = "copied world"
-        listener.notify.assert_not_called()
+        listener.assert_not_called()
 
 
 class TestStatus(unittest.TestCase):
@@ -111,15 +94,14 @@ class TestStatus(unittest.TestCase):
         self.assertEqual("Everything's good", status.server.error_msg)
 
     def test_listeners(self):
-        listener = DummyStatusListener()
-        listener.notify = MagicMock()
+        listener = MagicMock()
         status = Status()
         status.add_listener(listener)
         status.server.up = False
-        listener.notify.assert_called_once_with()
-        listener.notify.reset_mock()
+        listener.assert_called_once_with()
+        listener.reset_mock()
         status.server.error_msg = "Everything's good"
-        listener.notify.assert_called_once_with()
+        listener.assert_called_once_with()
 
     def test_cannot_replace_component(self):
         status = Status()
@@ -181,14 +163,13 @@ class TestStatus(unittest.TestCase):
 
     def test_copy_doesnt_copy_listeners(self):
         status = Status()
-        listener = DummyStatusListener()
-        listener.notify = MagicMock()
+        listener = MagicMock()
         status.add_listener(listener)
         copy = status.copy()
 
         status.server.error_msg = "a"
-        listener.notify.assert_called_once_with()
-        listener.notify.reset_mock()
+        listener.assert_called_once_with()
+        listener.reset_mock()
 
         copy.server.error_msg = "b"
-        listener.notify.assert_not_called()
+        listener.assert_not_called()

--- a/src/python/web/handler/stream_status.py
+++ b/src/python/web/handler/stream_status.py
@@ -3,14 +3,14 @@
 
 from typing import override
 
-from common import IStatusListener, Status
+from common import Status
 
 from ..serialize import SerializeStatus
 from ..utils import StreamQueue
 from ..web_app import IStreamHandler
 
 
-class StatusListener(IStatusListener, StreamQueue[Status]):
+class StatusListener(StreamQueue[Status]):
     """
     Status listener used by status streams to listen to status updates
     """
@@ -19,7 +19,6 @@ class StatusListener(IStatusListener, StreamQueue[Status]):
         super().__init__()
         self.__status = status
 
-    @override
     def notify(self):
         self.put(self.__status.copy())
 
@@ -33,7 +32,7 @@ class StatusStreamHandler(IStreamHandler):
 
     @override
     def setup(self):
-        self.status.add_listener(self.status_listener)
+        self.status.add_listener(self.status_listener.notify)
 
     @override
     def get_value(self) -> str | None:
@@ -49,4 +48,4 @@ class StatusStreamHandler(IStreamHandler):
     @override
     def cleanup(self):
         if self.status_listener:
-            self.status.remove_listener(self.status_listener)
+            self.status.remove_listener(self.status_listener.notify)


### PR DESCRIPTION
## Summary

Closes #671 (Phase 3 of the over-engineering audit, tracking issue #682). `common/status.py` goes from 177 to 111 lines with no reflection left.

- `BaseStatus._create_property`/`_get_property`/`_set_property` and the `dir()`+`isinstance(property)` mangling are gone. `StatusComponent` is now a dataclass base whose `__setattr__` notifies listeners on public-field assignment; `ServerStatus`/`ControllerStatus` are dataclasses with typed fields (`eq=False` to keep the original identity-equality semantics).
- `IStatusListener` / `IStatusComponentListener` ABCs (one implementation each) are replaced with plain callables — `add_listener` takes `Callable[[], None]` / `Callable[[str], None]`. `Status.CompListener` collapses into the bound method `_on_component_changed`. `web/handler/stream_status.py` registers `status_listener.notify` directly.
- `StatusComponent.copy(src, dst)` keeps its signature but iterates `dataclasses.fields`; `Status.copy()` calls it explicitly for the two components. Copies carry values, never listeners (spec-tested).
- The cannot-reassign-component guard moves to `Status.__setattr__` with the same `ValueError("Cannot reassign component")`.

## Contract notes

Listener-firing semantics are unchanged and spec-locked: every assignment notifies (no equality suppression — verified the old code had none), component listeners receive the field name, status-level listeners fire under `_listeners_lock`, and the SSE status stream serializes the same JSON (existing serializer + handler tests unchanged and passing).

## Intentionally skipped

- `copy.deepcopy(self)` (issue's suggestion) was not used: `Status` holds a `threading.Lock`, which deepcopy can't handle without extra `__deepcopy__` machinery — the explicit two-component field copy is smaller and keeps the exclude-listeners behavior obvious.

## Test plan

- [x] `uv run ruff check .` + `uv run ruff format --check .` — pass
- [x] `uv run pyright` (source packages) — 0 errors
- [x] `PYTHONPATH=. uv run pytest tests/unittests` — 982 passed; known local-only `latin_chars` failure; the `test_logger_levels` flake reproduced once and was root-caused to a pre-existing listener-thread leak in that test, now filed as #703 (faulthandler dump shows no involvement of this change)
- [x] `PYTHONPATH=. uv run pytest tests/integration` — 157 passed; known local `test_extract` failures (missing `rar`)
- [x] Field test: `make build && make run` — `/server/status` and the `/server/stream` SSE emit byte-identical JSON through the new listener chain; container healthy, UI 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated status tracking with typed, dataclass-based components for clearer and more consistent status information.
  - Improved status and component change notifications through direct callbacks.
  - Preserved listener registration, removal, copying, and update propagation behavior.
  - Updated streamed status handling to register and unregister callbacks directly.
  - Simplified the public status API by removing obsolete listener interfaces while maintaining existing status update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->