### PR TITLE
test(python): stop MPLogger listener on timeout in logger tests (#703)

### DIFF
--- a/src/python/tests/unittests/test_common/test_multiprocessing_logger.py
+++ b/src/python/tests/unittests/test_common/test_multiprocessing_logger.py
@@ -52,7 +52,12 @@ class TestMultiprocessingLogger(unittest.TestCase):
         formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
         handler.setFormatter(formatter)
 
-    def _run_child_logger(self, target=_child_process, drain_secs: float = 0.5):
+    # Must exceed the listener's 0.5s poll interval: the listener does not do a
+    # final drain on shutdown, so stop() must come after at least one full poll
+    # cycle or queued records are dropped.
+    _DRAIN_SECS = 0.6
+
+    def _run_child_logger(self, target=_child_process):
         """Run target in a child process wired to a fresh MultiprocessingLogger.
 
         Stops the logger even if the timeout-decorator exception fires
@@ -65,15 +70,15 @@ class TestMultiprocessingLogger(unittest.TestCase):
             p = multiprocessing.Process(target=target, args=(mp_logger.queue, mp_logger.log_level, "process_1"))
             p.start()
             p.join()
-            # Brief wait for listener thread to drain remaining queue items
-            time.sleep(drain_secs)
+            # Wait for the listener thread to drain remaining queue items
+            time.sleep(self._DRAIN_SECS)
         finally:
             mp_logger.stop()
 
     @timeout_decorator.timeout(10)
     def test_main_logger_receives_records(self):
         with LogCapture("TestMultiprocessingLogger.MPLogger.process_1") as log_capture:
-            self._run_child_logger(drain_secs=0.2)
+            self._run_child_logger()
 
             log_capture.check(
                 ("process_1", "DEBUG", "Debug line"),

--- a/src/python/tests/unittests/test_common/test_multiprocessing_logger.py
+++ b/src/python/tests/unittests/test_common/test_multiprocessing_logger.py
@@ -3,9 +3,11 @@
 import logging
 import multiprocessing
 import sys
+import threading
 import time
 import unittest
 from logging.handlers import QueueHandler
+from unittest.mock import patch
 
 import timeout_decorator
 from testfixtures import LogCapture
@@ -50,18 +52,28 @@ class TestMultiprocessingLogger(unittest.TestCase):
         formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
         handler.setFormatter(formatter)
 
-    @timeout_decorator.timeout(5)
-    def test_main_logger_receives_records(self):
-        mp_logger = MultiprocessingLogger(self.logger)
-        p_1 = multiprocessing.Process(target=_child_process, args=(mp_logger.queue, mp_logger.log_level, "process_1"))
+    def _run_child_logger(self, target=_child_process, drain_secs: float = 0.5):
+        """Run target in a child process wired to a fresh MultiprocessingLogger.
 
-        with LogCapture("TestMultiprocessingLogger.MPLogger.process_1") as log_capture:
-            p_1.start()
-            mp_logger.start()
-            p_1.join()
+        Stops the logger even if the timeout-decorator exception fires
+        mid-block — a leaked (non-daemon) listener thread hangs pytest at
+        interpreter exit (#703).
+        """
+        mp_logger = MultiprocessingLogger(self.logger)
+        mp_logger.start()
+        try:
+            p = multiprocessing.Process(target=target, args=(mp_logger.queue, mp_logger.log_level, "process_1"))
+            p.start()
+            p.join()
             # Brief wait for listener thread to drain remaining queue items
-            time.sleep(0.2)
+            time.sleep(drain_secs)
+        finally:
             mp_logger.stop()
+
+    @timeout_decorator.timeout(10)
+    def test_main_logger_receives_records(self):
+        with LogCapture("TestMultiprocessingLogger.MPLogger.process_1") as log_capture:
+            self._run_child_logger(drain_secs=0.2)
 
             log_capture.check(
                 ("process_1", "DEBUG", "Debug line"),
@@ -70,19 +82,10 @@ class TestMultiprocessingLogger(unittest.TestCase):
                 ("process_1", "ERROR", "Error line"),
             )
 
-    @timeout_decorator.timeout(5)
+    @timeout_decorator.timeout(10)
     def test_children_names(self):
-        mp_logger = MultiprocessingLogger(self.logger)
-        p_1 = multiprocessing.Process(
-            target=_child_process_with_children, args=(mp_logger.queue, mp_logger.log_level, "process_1")
-        )
-
         with LogCapture("TestMultiprocessingLogger.MPLogger.process_1") as log_capture:
-            p_1.start()
-            mp_logger.start()
-            p_1.join()
-            time.sleep(0.5)
-            mp_logger.stop()
+            self._run_child_logger(target=_child_process_with_children)
 
             log_capture.check(
                 ("process_1", "DEBUG", "Debug line"),
@@ -90,73 +93,38 @@ class TestMultiprocessingLogger(unittest.TestCase):
                 ("process_1.child_1_1", "DEBUG", "Debug line"),
             )
 
-    @timeout_decorator.timeout(5)
+    @timeout_decorator.timeout(10)
+    def test_listener_stopped_when_run_interrupted(self):
+        # Regression for #703: an exception mid-run (e.g. the timeout decorator
+        # firing under load) must not leak the non-daemon listener thread,
+        # which would hang pytest at interpreter exit.
+        real_sleep = time.sleep
+        main_thread = threading.main_thread()
+
+        def raise_in_main_thread(secs: float):
+            # SIGALRM-driven timeouts only interrupt the main thread
+            if threading.current_thread() is main_thread:
+                raise RuntimeError("simulated timeout")
+            real_sleep(secs)
+
+        with patch("time.sleep", side_effect=raise_in_main_thread):
+            with self.assertRaises(RuntimeError):
+                self._run_child_logger()
+        self.assertFalse(any(t.name == "MPLoggerListener" for t in threading.enumerate()))
+
+    @timeout_decorator.timeout(20)
     def test_logger_levels(self):
-        # Debug level
-        self.logger.setLevel(logging.DEBUG)
-        with LogCapture("TestMultiprocessingLogger.MPLogger.process_1") as log_capture:
-            mp_logger = MultiprocessingLogger(self.logger)
-            p_1 = multiprocessing.Process(
-                target=_child_process, args=(mp_logger.queue, mp_logger.log_level, "process_1")
-            )
-            p_1.start()
-            mp_logger.start()
-            p_1.join()
-            time.sleep(0.5)
-            mp_logger.stop()
+        cases = [
+            (logging.DEBUG, ["DEBUG", "INFO", "WARNING", "ERROR"]),
+            (logging.INFO, ["INFO", "WARNING", "ERROR"]),
+            (logging.WARNING, ["WARNING", "ERROR"]),
+            (logging.ERROR, ["ERROR"]),
+        ]
+        lines = {"DEBUG": "Debug line", "INFO": "Info line", "WARNING": "Warning line", "ERROR": "Error line"}
+        for level, expected_levels in cases:
+            with self.subTest(level=logging.getLevelName(level)):
+                self.logger.setLevel(level)
+                with LogCapture("TestMultiprocessingLogger.MPLogger.process_1") as log_capture:
+                    self._run_child_logger()
 
-            log_capture.check(
-                ("process_1", "DEBUG", "Debug line"),
-                ("process_1", "INFO", "Info line"),
-                ("process_1", "WARNING", "Warning line"),
-                ("process_1", "ERROR", "Error line"),
-            )
-
-        # Info level
-        self.logger.setLevel(logging.INFO)
-        with LogCapture("TestMultiprocessingLogger.MPLogger.process_1") as log_capture:
-            mp_logger = MultiprocessingLogger(self.logger)
-            p_1 = multiprocessing.Process(
-                target=_child_process, args=(mp_logger.queue, mp_logger.log_level, "process_1")
-            )
-            p_1.start()
-            mp_logger.start()
-            p_1.join()
-            time.sleep(0.5)
-            mp_logger.stop()
-
-            log_capture.check(
-                ("process_1", "INFO", "Info line"),
-                ("process_1", "WARNING", "Warning line"),
-                ("process_1", "ERROR", "Error line"),
-            )
-
-        # Warning level
-        self.logger.setLevel(logging.WARNING)
-        with LogCapture("TestMultiprocessingLogger.MPLogger.process_1") as log_capture:
-            mp_logger = MultiprocessingLogger(self.logger)
-            p_1 = multiprocessing.Process(
-                target=_child_process, args=(mp_logger.queue, mp_logger.log_level, "process_1")
-            )
-            p_1.start()
-            mp_logger.start()
-            p_1.join()
-            time.sleep(0.5)
-            mp_logger.stop()
-
-            log_capture.check(("process_1", "WARNING", "Warning line"), ("process_1", "ERROR", "Error line"))
-
-        # Error level
-        self.logger.setLevel(logging.ERROR)
-        with LogCapture("TestMultiprocessingLogger.MPLogger.process_1") as log_capture:
-            mp_logger = MultiprocessingLogger(self.logger)
-            p_1 = multiprocessing.Process(
-                target=_child_process, args=(mp_logger.queue, mp_logger.log_level, "process_1")
-            )
-            p_1.start()
-            mp_logger.start()
-            p_1.join()
-            time.sleep(0.5)
-            mp_logger.stop()
-
-            log_capture.check(("process_1", "ERROR", "Error line"))
+                    log_capture.check(*(("process_1", lvl, lines[lvl]) for lvl in expected_levels))


### PR DESCRIPTION
## Summary

Closes #703. `test_logger_levels` ran four start/stop lifecycle blocks inside a 5 s `timeout_decorator` budget. Under full-suite load the SIGALRM-driven timeout exception could land between `mp_logger.start()` and `mp_logger.stop()`, leaking the non-daemon `MPLoggerListener` thread — `threading._shutdown` then joins it forever and the pytest process hangs after printing its summary (faulthandler dump in #703).

- Per-block lifecycle extracted into a `_run_child_logger` helper that always stops the logger via `try/finally` (logger started before the `try` so `stop()` never joins an unstarted thread).
- Timeout budgets raised to realistic values: 10 s for the single-block tests, 20 s for the four-block `test_logger_levels` (four spawn-per-block cycles routinely brushed the old 5 s ceiling under load — that's what made the flake fire at all). The timeouts still catch a genuinely hung queue.
- `test_logger_levels`' four copy-pasted blocks collapse into a `subTest` loop over (level → expected records).
- New regression test `test_listener_stopped_when_run_interrupted` simulates the failure: patches `time.sleep` to raise in the main thread only (matching SIGALRM delivery) mid-run, and asserts no `MPLoggerListener` thread survives. Note it exercises the new helper's guard — the pre-fix structure it protects against no longer exists, so it can't literally "fail before the fix"; it pins the guard against regression.
- Production `MultiprocessingLogger` is untouched.

## Test plan

- [x] `uv run ruff check` + `ruff format --check` — pass
- [x] `pytest tests/unittests/test_common/test_multiprocessing_logger.py` — 4 passed, no warnings
- [x] Full `tests/unittests` — 984 passed, prompt interpreter exit (no hang); only the known local-only `latin_chars` failure
- [x] No live/container behavior involved (test-only change), so no field test applies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging reliability when processes are interrupted.
  * Ensured logging listener threads stop cleanly after interrupted sessions, preventing lingering background activity.
  * Improved handling across different logger levels.

* **Tests**
  * Expanded coverage for interruption cleanup and logger-level behavior.
  * Increased test timeouts to improve reliability across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->