### PR TITLE
refactor(angular): thread FileAction through one command path (#674)

### DIFF
--- a/src/angular/src/app/models/file-action.ts
+++ b/src/angular/src/app/models/file-action.ts
@@ -1,0 +1,61 @@
+import { ViewFile } from './view-file';
+
+/** The six per-file commands the backend exposes. */
+export enum FileAction {
+  QUEUE,
+  STOP,
+  EXTRACT,
+  VALIDATE,
+  DELETE_LOCAL,
+  DELETE_REMOTE
+}
+
+export interface FileActionSpec {
+  /** URL verb in `/server/command/<verb>/<file>` — a backend contract. */
+  readonly urlSegment: string;
+  /** Noun used in debug logs ("<noun> model file: ..."). */
+  readonly logNoun: string;
+  /** Capability flag gating the action for a view file. */
+  readonly isAllowed: (file: ViewFile) => boolean;
+  /** Max concurrent requests for the bulk variant. */
+  readonly bulkConcurrency: number;
+}
+
+export const FILE_ACTIONS: Record<FileAction, FileActionSpec> = {
+  [FileAction.QUEUE]: {
+    urlSegment: 'queue',
+    logNoun: 'Queue',
+    isAllowed: (f) => f.isQueueable,
+    bulkConcurrency: Infinity,
+  },
+  [FileAction.STOP]: {
+    urlSegment: 'stop',
+    logNoun: 'Stop',
+    isAllowed: (f) => f.isStoppable,
+    bulkConcurrency: Infinity,
+  },
+  [FileAction.EXTRACT]: {
+    urlSegment: 'extract',
+    logNoun: 'Extract',
+    isAllowed: (f) => f.isExtractable && f.isArchive,
+    bulkConcurrency: Infinity,
+  },
+  [FileAction.VALIDATE]: {
+    urlSegment: 'validate',
+    logNoun: 'Validate',
+    isAllowed: (f) => f.isValidatable,
+    bulkConcurrency: Infinity,
+  },
+  [FileAction.DELETE_LOCAL]: {
+    urlSegment: 'delete_local',
+    logNoun: 'Locally delete',
+    isAllowed: (f) => f.isLocallyDeletable,
+    bulkConcurrency: 4,
+  },
+  [FileAction.DELETE_REMOTE]: {
+    urlSegment: 'delete_remote',
+    logNoun: 'Remotely delete',
+    isAllowed: (f) => f.isRemotelyDeletable,
+    bulkConcurrency: 4,
+  },
+};

--- a/src/angular/src/app/pages/files/bulk-action-bar.component.spec.ts
+++ b/src/angular/src/app/pages/files/bulk-action-bar.component.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { BulkActionBarComponent } from './bulk-action-bar.component';
+import { FileAction } from '../../models/file-action';
 
 describe('BulkActionBarComponent', () => {
   let fixture: ComponentFixture<BulkActionBarComponent>;
@@ -45,52 +46,52 @@ describe('BulkActionBarComponent', () => {
     expect(countSpan.textContent).toContain('7 selected');
   });
 
-  it('should emit queueEvent when Queue button is clicked', () => {
-    let emitted = false;
-    component.queueEvent.subscribe(() => (emitted = true));
+  it('should emit QUEUE when Queue button is clicked', () => {
+    let emitted: FileAction | null = null;
+    component.actionEvent.subscribe((a) => (emitted = a));
 
     const btn = findButtonByText('Queue');
     btn.click();
 
-    expect(emitted).toBe(true);
+    expect(emitted).toBe(FileAction.QUEUE);
   });
 
-  it('should emit stopEvent when Stop button is clicked', () => {
-    let emitted = false;
-    component.stopEvent.subscribe(() => (emitted = true));
+  it('should emit STOP when Stop button is clicked', () => {
+    let emitted: FileAction | null = null;
+    component.actionEvent.subscribe((a) => (emitted = a));
 
     const btn = findButtonByText('Stop');
     btn.click();
 
-    expect(emitted).toBe(true);
+    expect(emitted).toBe(FileAction.STOP);
   });
 
-  it('should emit deleteLocalEvent only on the second Delete Local click', () => {
-    let emitCount = 0;
-    component.deleteLocalEvent.subscribe(() => (emitCount += 1));
+  it('should emit DELETE_LOCAL only on the second Delete Local click', () => {
+    const emitted: FileAction[] = [];
+    component.actionEvent.subscribe((a) => emitted.push(a));
 
     // First click arms the confirm, does NOT emit
     findButtonByText('Delete Local').click();
-    expect(emitCount).toBe(0);
+    expect(emitted).toEqual([]);
 
     // Second click emits
     fixture.detectChanges();
     findButtonByText('Confirm?').click();
-    expect(emitCount).toBe(1);
+    expect(emitted).toEqual([FileAction.DELETE_LOCAL]);
   });
 
-  it('should emit deleteRemoteEvent only on the second Delete Remote click', () => {
-    let emitCount = 0;
-    component.deleteRemoteEvent.subscribe(() => (emitCount += 1));
+  it('should emit DELETE_REMOTE only on the second Delete Remote click', () => {
+    const emitted: FileAction[] = [];
+    component.actionEvent.subscribe((a) => emitted.push(a));
 
     // First click arms the confirm, does NOT emit
     findButtonByText('Delete Remote').click();
-    expect(emitCount).toBe(0);
+    expect(emitted).toEqual([]);
 
     // Second click emits
     fixture.detectChanges();
     findButtonByText('Confirm?').click();
-    expect(emitCount).toBe(1);
+    expect(emitted).toEqual([FileAction.DELETE_REMOTE]);
   });
 
   it('should emit clearEvent when Clear button is clicked', () => {
@@ -140,7 +141,7 @@ describe('BulkActionBarComponent inline bulk delete confirmation', () => {
   }
 
   it('first click on Delete Local sets confirming state and does not emit', () => {
-    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+    const spy = vi.spyOn(component.actionEvent, 'emit');
 
     component.onDeleteLocal();
 
@@ -149,7 +150,7 @@ describe('BulkActionBarComponent inline bulk delete confirmation', () => {
   });
 
   it('second click on Delete Local emits event and clears state', () => {
-    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+    const spy = vi.spyOn(component.actionEvent, 'emit');
 
     component.onDeleteLocal();
     expect(component.confirmingDelete).toBe('local');
@@ -160,7 +161,7 @@ describe('BulkActionBarComponent inline bulk delete confirmation', () => {
   });
 
   it('first click on Delete Remote sets confirming state and does not emit', () => {
-    const spy = vi.spyOn(component.deleteRemoteEvent, 'emit');
+    const spy = vi.spyOn(component.actionEvent, 'emit');
 
     component.onDeleteRemote();
 
@@ -169,7 +170,7 @@ describe('BulkActionBarComponent inline bulk delete confirmation', () => {
   });
 
   it('second click on Delete Remote emits event and clears state', () => {
-    const spy = vi.spyOn(component.deleteRemoteEvent, 'emit');
+    const spy = vi.spyOn(component.actionEvent, 'emit');
 
     component.onDeleteRemote();
     expect(component.confirmingDelete).toBe('remote');

--- a/src/angular/src/app/pages/files/bulk-action-bar.component.ts
+++ b/src/angular/src/app/pages/files/bulk-action-bar.component.ts
@@ -2,6 +2,7 @@ import {
     Component, ChangeDetectionStrategy, ChangeDetectorRef, OnDestroy, input, output, inject
 } from '@angular/core';
 import { DoubleClickConfirm } from '../../common/double-click-confirm';
+import { FileAction } from '../../models/file-action';
 
 @Component({
     selector: 'app-bulk-action-bar',
@@ -9,8 +10,8 @@ import { DoubleClickConfirm } from '../../common/double-click-confirm';
     template: `
         <div class="bulk-bar">
             <span class="count">{{ count() }} selected</span>
-            <button class="btn btn-sm btn-outline-primary" (click)="queueEvent.emit()">Queue</button>
-            <button class="btn btn-sm btn-outline-warning" (click)="stopEvent.emit()">Stop</button>
+            <button class="btn btn-sm btn-outline-primary" (click)="actionEvent.emit(FileAction.QUEUE)">Queue</button>
+            <button class="btn btn-sm btn-outline-warning" (click)="actionEvent.emit(FileAction.STOP)">Stop</button>
             <button class="btn btn-sm btn-outline-danger"
                     [class.confirming]="confirmingDelete === 'local'"
                     (click)="onDeleteLocal()">
@@ -46,13 +47,11 @@ import { DoubleClickConfirm } from '../../common/double-click-confirm';
 })
 export class BulkActionBarComponent implements OnDestroy {
     private readonly cdr = inject(ChangeDetectorRef);
+    FileAction = FileAction;
 
     count = input.required<number>();
 
-    queueEvent = output<void>();
-    stopEvent = output<void>();
-    deleteLocalEvent = output<void>();
-    deleteRemoteEvent = output<void>();
+    actionEvent = output<FileAction>();
     clearEvent = output<void>();
 
     private readonly deleteConfirm = new DoubleClickConfirm<'local' | 'remote'>(() => this.cdr.markForCheck());
@@ -67,13 +66,13 @@ export class BulkActionBarComponent implements OnDestroy {
 
     onDeleteLocal(): void {
         if (this.deleteConfirm.confirm('local')) {
-            this.deleteLocalEvent.emit();
+            this.actionEvent.emit(FileAction.DELETE_LOCAL);
         }
     }
 
     onDeleteRemote(): void {
         if (this.deleteConfirm.confirm('remote')) {
-            this.deleteRemoteEvent.emit();
+            this.actionEvent.emit(FileAction.DELETE_REMOTE);
         }
     }
 }

--- a/src/angular/src/app/pages/files/file-list.component.html
+++ b/src/angular/src/app/pages/files/file-list.component.html
@@ -14,10 +14,7 @@
       @if (checked.size) {
         <app-bulk-action-bar
             [count]="checked.size"
-            (queueEvent)="onBulkQueue()"
-            (stopEvent)="onBulkStop()"
-            (deleteLocalEvent)="onBulkDeleteLocal()"
-            (deleteRemoteEvent)="onBulkDeleteRemote()"
+            (actionEvent)="onBulkAction($event)"
             (clearEvent)="onUncheckAll()">
         </app-bulk-action-bar>
       }
@@ -29,12 +26,7 @@
                 [options]="options"
                 (click)="onSelect(file)"
                 (checkEvent)="onCheck($event)"
-                (queueEvent)="onQueue($event)"
-                (stopEvent)="onStop($event)"
-                (extractEvent)="onExtract($event)"
-                (validateEvent)="onValidate($event)"
-                (deleteLocalEvent)="onDeleteLocal($event)"
-                (deleteRemoteEvent)="onDeleteRemote($event)">
+                (actionEvent)="onAction($event)">
             </app-file>
         </div>
     </ng-template>

--- a/src/angular/src/app/pages/files/file-list.component.spec.ts
+++ b/src/angular/src/app/pages/files/file-list.component.spec.ts
@@ -13,26 +13,19 @@ import { ViewFile, ViewFileStatus } from '../../models/view-file';
 import { ViewFileOptions, SortMethod } from '../../models/view-file-options';
 import { fileKey } from '../../services/files/file-key';
 import { FileActionEvent } from './file.component';
+import { FileAction } from '../../models/file-action';
 
 interface MockViewFileService {
   filteredFiles$: Observable<ViewFile[]>;
   checked$: Observable<Set<string>>;
   setSelected: ReturnType<typeof vi.fn>;
   unsetSelected: ReturnType<typeof vi.fn>;
-  queue: ReturnType<typeof vi.fn>;
-  stop: ReturnType<typeof vi.fn>;
-  extract: ReturnType<typeof vi.fn>;
-  validate: ReturnType<typeof vi.fn>;
-  deleteLocal: ReturnType<typeof vi.fn>;
-  deleteRemote: ReturnType<typeof vi.fn>;
+  command: ReturnType<typeof vi.fn>;
   toggleCheck: ReturnType<typeof vi.fn>;
   shiftCheck: ReturnType<typeof vi.fn>;
   checkAll: ReturnType<typeof vi.fn>;
   uncheckAll: ReturnType<typeof vi.fn>;
-  bulkQueue: ReturnType<typeof vi.fn>;
-  bulkStop: ReturnType<typeof vi.fn>;
-  bulkDeleteLocal: ReturnType<typeof vi.fn>;
-  bulkDeleteRemote: ReturnType<typeof vi.fn>;
+  bulkCommand: ReturnType<typeof vi.fn>;
 }
 
 interface MockNotificationService {
@@ -40,8 +33,8 @@ interface MockNotificationService {
   hide: ReturnType<typeof vi.fn>;
 }
 
-function makeActionEvent(file: ViewFile): FileActionEvent {
-  return { file, clearActiveAction: vi.fn() };
+function makeActionEvent(file: ViewFile, action: FileAction = FileAction.QUEUE): FileActionEvent {
+  return { action, file, clearActiveAction: vi.fn() };
 }
 
 function makeViewFile(overrides: Partial<ViewFile> = {}): ViewFile {
@@ -101,20 +94,12 @@ describe('FileListComponent', () => {
       checked$: checkedSubject.asObservable(),
       setSelected: vi.fn(),
       unsetSelected: vi.fn(),
-      queue: vi.fn().mockReturnValue(EMPTY),
-      stop: vi.fn().mockReturnValue(EMPTY),
-      extract: vi.fn().mockReturnValue(EMPTY),
-      validate: vi.fn().mockReturnValue(EMPTY),
-      deleteLocal: vi.fn().mockReturnValue(EMPTY),
-      deleteRemote: vi.fn().mockReturnValue(EMPTY),
+      command: vi.fn().mockReturnValue(EMPTY),
       toggleCheck: vi.fn(),
       shiftCheck: vi.fn(),
       checkAll: vi.fn(),
       uncheckAll: vi.fn(),
-      bulkQueue: vi.fn().mockReturnValue(EMPTY),
-      bulkStop: vi.fn().mockReturnValue(EMPTY),
-      bulkDeleteLocal: vi.fn().mockReturnValue(EMPTY),
-      bulkDeleteRemote: vi.fn().mockReturnValue(EMPTY),
+      bulkCommand: vi.fn().mockReturnValue(EMPTY),
     };
 
     mockNotifService = { show: vi.fn(), hide: vi.fn() };
@@ -349,58 +334,20 @@ describe('FileListComponent', () => {
 
   // --- Individual file actions ---
 
-  it('should call viewFileService.queue on onQueue', () => {
-    const file = makeViewFile({ name: 'queue-me.txt' });
-    mockViewFileService.queue.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
+  it.each([
+    ['QUEUE', FileAction.QUEUE],
+    ['STOP', FileAction.STOP],
+    ['EXTRACT', FileAction.EXTRACT],
+    ['VALIDATE', FileAction.VALIDATE],
+    ['DELETE_LOCAL', FileAction.DELETE_LOCAL],
+    ['DELETE_REMOTE', FileAction.DELETE_REMOTE],
+  ] as const)('should dispatch %s through viewFileService.command on onAction', (_label, action) => {
+    const file = makeViewFile({ name: 'act-on-me.txt' });
+    mockViewFileService.command.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
 
-    component.onQueue(makeActionEvent(file));
+    component.onAction(makeActionEvent(file, action));
 
-    expect(mockViewFileService.queue).toHaveBeenCalledWith(file);
-  });
-
-  it('should call viewFileService.stop on onStop', () => {
-    const file = makeViewFile({ name: 'stop-me.txt' });
-    mockViewFileService.stop.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
-
-    component.onStop(makeActionEvent(file));
-
-    expect(mockViewFileService.stop).toHaveBeenCalledWith(file);
-  });
-
-  it('should call viewFileService.extract on onExtract', () => {
-    const file = makeViewFile({ name: 'extract-me.txt' });
-    mockViewFileService.extract.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
-
-    component.onExtract(makeActionEvent(file));
-
-    expect(mockViewFileService.extract).toHaveBeenCalledWith(file);
-  });
-
-  it('should call viewFileService.validate on onValidate', () => {
-    const file = makeViewFile({ name: 'validate-me.txt' });
-    mockViewFileService.validate.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
-
-    component.onValidate(makeActionEvent(file));
-
-    expect(mockViewFileService.validate).toHaveBeenCalledWith(file);
-  });
-
-  it('should call viewFileService.deleteLocal on onDeleteLocal', () => {
-    const file = makeViewFile({ name: 'del-local.txt' });
-    mockViewFileService.deleteLocal.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
-
-    component.onDeleteLocal(makeActionEvent(file));
-
-    expect(mockViewFileService.deleteLocal).toHaveBeenCalledWith(file);
-  });
-
-  it('should call viewFileService.deleteRemote on onDeleteRemote', () => {
-    const file = makeViewFile({ name: 'del-remote.txt' });
-    mockViewFileService.deleteRemote.mockReturnValue(of({ success: true, data: 'ok', errorMessage: null }));
-
-    component.onDeleteRemote(makeActionEvent(file));
-
-    expect(mockViewFileService.deleteRemote).toHaveBeenCalledWith(file);
+    expect(mockViewFileService.command).toHaveBeenCalledWith(action, file);
   });
 
   // --- Single-file action error surfacing (#513) ---
@@ -408,11 +355,11 @@ describe('FileListComponent', () => {
   it('shows a DANGER banner and clears activeAction when an action fails', () => {
     const file = makeViewFile({ name: 'fail-me.txt' });
     const event = makeActionEvent(file);
-    mockViewFileService.queue.mockReturnValue(
+    mockViewFileService.command.mockReturnValue(
       of({ success: false, data: null, errorMessage: 'Boom' }),
     );
 
-    component.onQueue(event);
+    component.onAction(event);
 
     expect(mockNotifService.show).toHaveBeenCalledTimes(1);
     const notif = mockNotifService.show.mock.calls[0][0];
@@ -423,11 +370,11 @@ describe('FileListComponent', () => {
 
   it('falls back to a generic message when a failed reaction has no errorMessage', () => {
     const event = makeActionEvent(makeViewFile());
-    mockViewFileService.stop.mockReturnValue(
+    mockViewFileService.command.mockReturnValue(
       of({ success: false, data: null, errorMessage: null }),
     );
 
-    component.onStop(event);
+    component.onAction(event);
 
     expect(mockNotifService.show).toHaveBeenCalledTimes(1);
     expect(mockNotifService.show.mock.calls[0][0].text).toBe('Action failed');
@@ -437,11 +384,11 @@ describe('FileListComponent', () => {
   it('does not show a banner or clear activeAction on a successful action', () => {
     const logger = TestBed.inject(LoggerService);
     const event = makeActionEvent(makeViewFile());
-    mockViewFileService.validate.mockReturnValue(
+    mockViewFileService.command.mockReturnValue(
       of({ success: true, data: 'ok', errorMessage: null }),
     );
 
-    component.onValidate(event);
+    component.onAction(event);
 
     expect(mockNotifService.show).not.toHaveBeenCalled();
     expect(event.clearActiveAction).not.toHaveBeenCalled();
@@ -450,11 +397,11 @@ describe('FileListComponent', () => {
 
   it('shows a DANGER banner and clears activeAction when the action stream errors', () => {
     const event = makeActionEvent(makeViewFile());
-    mockViewFileService.deleteRemote.mockReturnValue(
+    mockViewFileService.command.mockReturnValue(
       throwError(() => new Error('net')),
     );
 
-    component.onDeleteRemote(event);
+    component.onAction(event);
 
     expect(mockNotifService.show).toHaveBeenCalledTimes(1);
     expect(mockNotifService.show.mock.calls[0][0].level).toBe(NotificationLevel.DANGER);
@@ -463,36 +410,17 @@ describe('FileListComponent', () => {
 
   // --- Bulk actions ---
 
-  it('should call viewFileService.bulkQueue on onBulkQueue', () => {
-    mockViewFileService.bulkQueue.mockReturnValue(of([]));
+  it.each([
+    ['QUEUE', FileAction.QUEUE],
+    ['STOP', FileAction.STOP],
+    ['DELETE_LOCAL', FileAction.DELETE_LOCAL],
+    ['DELETE_REMOTE', FileAction.DELETE_REMOTE],
+  ] as const)('should dispatch bulk %s through viewFileService.bulkCommand on onBulkAction', (_label, action) => {
+    mockViewFileService.bulkCommand.mockReturnValue(of([]));
 
-    component.onBulkQueue();
+    component.onBulkAction(action);
 
-    expect(mockViewFileService.bulkQueue).toHaveBeenCalled();
-  });
-
-  it('should call viewFileService.bulkStop on onBulkStop', () => {
-    mockViewFileService.bulkStop.mockReturnValue(of([]));
-
-    component.onBulkStop();
-
-    expect(mockViewFileService.bulkStop).toHaveBeenCalled();
-  });
-
-  it('should call viewFileService.bulkDeleteLocal on onBulkDeleteLocal', () => {
-    mockViewFileService.bulkDeleteLocal.mockReturnValue(of([]));
-
-    component.onBulkDeleteLocal();
-
-    expect(mockViewFileService.bulkDeleteLocal).toHaveBeenCalled();
-  });
-
-  it('should call viewFileService.bulkDeleteRemote on onBulkDeleteRemote', () => {
-    mockViewFileService.bulkDeleteRemote.mockReturnValue(of([]));
-
-    component.onBulkDeleteRemote();
-
-    expect(mockViewFileService.bulkDeleteRemote).toHaveBeenCalled();
+    expect(mockViewFileService.bulkCommand).toHaveBeenCalledWith(action);
   });
 
   // --- Track-by function ---
@@ -511,12 +439,12 @@ describe('FileListComponent', () => {
 
   it('should log failures and show a DANGER banner from bulk action responses', () => {
     const logger = TestBed.inject(LoggerService);
-    mockViewFileService.bulkQueue.mockReturnValue(of([
+    mockViewFileService.bulkCommand.mockReturnValue(of([
       { success: true, data: 'ok', errorMessage: null },
       { success: false, data: null, errorMessage: 'Failed' },
     ]));
 
-    component.onBulkQueue();
+    component.onBulkAction(FileAction.QUEUE);
 
     expect(logger.error).toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalled();
@@ -527,23 +455,23 @@ describe('FileListComponent', () => {
   });
 
   it('should not show a banner when all bulk items succeed', () => {
-    mockViewFileService.bulkDeleteLocal.mockReturnValue(of([
+    mockViewFileService.bulkCommand.mockReturnValue(of([
       { success: true, data: 'ok', errorMessage: null },
       { success: true, data: 'ok2', errorMessage: null },
     ]));
 
-    component.onBulkDeleteLocal();
+    component.onBulkAction(FileAction.DELETE_LOCAL);
 
     expect(mockNotifService.show).not.toHaveBeenCalled();
   });
 
   it('should log info for successful bulk items', () => {
     const logger = TestBed.inject(LoggerService);
-    mockViewFileService.bulkStop.mockReturnValue(of([
+    mockViewFileService.bulkCommand.mockReturnValue(of([
       { success: true, data: 'stopped', errorMessage: null },
     ]));
 
-    component.onBulkStop();
+    component.onBulkAction(FileAction.STOP);
 
     expect(logger.info).toHaveBeenCalledWith('stopped');
   });

--- a/src/angular/src/app/pages/files/file-list.component.ts
+++ b/src/angular/src/app/pages/files/file-list.component.ts
@@ -24,6 +24,7 @@ import { LoggerService } from '../../services/utils/logger.service';
 import { NotificationService } from '../../services/utils/notification.service';
 import { NotificationLevel, createNotification } from '../../models/notification';
 import { fileKey } from '../../services/files/file-key';
+import { FileAction } from '../../models/file-action';
 import { FileComponent, FileActionEvent } from './file.component';
 import { BulkActionBarComponent } from './bulk-action-bar.component';
 
@@ -144,53 +145,8 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  onQueue(event: FileActionEvent): void {
-    this.viewFileService.queue(event.file).pipe(
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe({
-      next: (data) => this.handleActionResponse(data, event),
-      error: (err) => this.handleActionError(err, event),
-    });
-  }
-
-  onStop(event: FileActionEvent): void {
-    this.viewFileService.stop(event.file).pipe(
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe({
-      next: (data) => this.handleActionResponse(data, event),
-      error: (err) => this.handleActionError(err, event),
-    });
-  }
-
-  onExtract(event: FileActionEvent): void {
-    this.viewFileService.extract(event.file).pipe(
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe({
-      next: (data) => this.handleActionResponse(data, event),
-      error: (err) => this.handleActionError(err, event),
-    });
-  }
-
-  onValidate(event: FileActionEvent): void {
-    this.viewFileService.validate(event.file).pipe(
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe({
-      next: (data) => this.handleActionResponse(data, event),
-      error: (err) => this.handleActionError(err, event),
-    });
-  }
-
-  onDeleteLocal(event: FileActionEvent): void {
-    this.viewFileService.deleteLocal(event.file).pipe(
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe({
-      next: (data) => this.handleActionResponse(data, event),
-      error: (err) => this.handleActionError(err, event),
-    });
-  }
-
-  onDeleteRemote(event: FileActionEvent): void {
-    this.viewFileService.deleteRemote(event.file).pipe(
+  onAction(event: FileActionEvent): void {
+    this.viewFileService.command(event.action, event.file).pipe(
       takeUntilDestroyed(this.destroyRef),
     ).subscribe({
       next: (data) => this.handleActionResponse(data, event),
@@ -236,10 +192,9 @@ export class FileListComponent implements AfterViewInit, OnDestroy {
     this.viewFileService.uncheckAll();
   }
 
-  onBulkQueue(): void { this.handleBulkResponse(this.viewFileService.bulkQueue()); }
-  onBulkStop(): void { this.handleBulkResponse(this.viewFileService.bulkStop()); }
-  onBulkDeleteLocal(): void { this.handleBulkResponse(this.viewFileService.bulkDeleteLocal()); }
-  onBulkDeleteRemote(): void { this.handleBulkResponse(this.viewFileService.bulkDeleteRemote()); }
+  onBulkAction(action: FileAction): void {
+    this.handleBulkResponse(this.viewFileService.bulkCommand(action));
+  }
 
   private handleBulkResponse(action$: Observable<WebReaction[]>): void {
     action$.pipe(

--- a/src/angular/src/app/pages/files/file.component.html
+++ b/src/angular/src/app/pages/files/file.component.html
@@ -141,41 +141,41 @@
     <!-- actions div, visible on selection -->
     <div class="actions">
         <button type="button" class="button" appClickStopPropagation
-             [disabled]="!isQueueable()"
-             (click)="onQueue(file())"
+             [disabled]="!canDo(FileAction.QUEUE)"
+             (click)="onAction(FileAction.QUEUE, file())"
              [class.loading]="activeAction === FileAction.QUEUE">
             <span class="loader"></span>
             <img src="assets/icons/queue.svg" alt="" aria-hidden="true" />
             <span class="text">Queue</span>
         </button>
         <button type="button" class="button" appClickStopPropagation
-             [disabled]="!isStoppable()"
-             (click)="onStop(file())"
+             [disabled]="!canDo(FileAction.STOP)"
+             (click)="onAction(FileAction.STOP, file())"
              [class.loading]="activeAction === FileAction.STOP">
             <span class="loader"></span>
             <img src="assets/icons/stop.svg" alt="" aria-hidden="true" />
             <span class="text">Stop</span>
         </button>
         <button type="button" class="button" appClickStopPropagation
-             [disabled]="!isExtractable()"
-             (click)="onExtract(file())"
+             [disabled]="!canDo(FileAction.EXTRACT)"
+             (click)="onAction(FileAction.EXTRACT, file())"
              [class.loading]="activeAction === FileAction.EXTRACT">
             <span class="loader"></span>
             <img src="assets/icons/extract.svg" alt="" aria-hidden="true" />
             <span class="text">Extract</span>
         </button>
         <button type="button" class="button" appClickStopPropagation
-             [disabled]="!isValidatable()"
+             [disabled]="!canDo(FileAction.VALIDATE)"
              [title]="file().validateTooltip ?? ''"
-             (click)="onValidate(file())"
+             (click)="onAction(FileAction.VALIDATE, file())"
              [class.loading]="activeAction === FileAction.VALIDATE">
             <span class="loader"></span>
             <img src="assets/icons/validate.svg" alt="" aria-hidden="true" />
             <span class="text">Validate</span>
         </button>
         <button type="button" class="button" appClickStopPropagation
-             [disabled]="!isLocallyDeletable()"
-             (click)="onDeleteLocal(file())"
+             [disabled]="!canDo(FileAction.DELETE_LOCAL)"
+             (click)="onAction(FileAction.DELETE_LOCAL, file())"
              [class.loading]="activeAction === FileAction.DELETE_LOCAL"
              [class.confirming]="confirmingDelete === 'local'">
             <span class="loader"></span>
@@ -183,8 +183,8 @@
             <span class="text">{{ confirmingDelete === 'local' ? 'Confirm?' : 'Delete Local' }}</span>
         </button>
         <button type="button" class="button" appClickStopPropagation
-             [disabled]="!isRemotelyDeletable()"
-             (click)="onDeleteRemote(file())"
+             [disabled]="!canDo(FileAction.DELETE_REMOTE)"
+             (click)="onAction(FileAction.DELETE_REMOTE, file())"
              [class.loading]="activeAction === FileAction.DELETE_REMOTE"
              [class.confirming]="confirmingDelete === 'remote'">
             <span class="loader"></span>

--- a/src/angular/src/app/pages/files/file.component.spec.ts
+++ b/src/angular/src/app/pages/files/file.component.spec.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { SimpleChange } from '@angular/core';
-import { FileComponent, FileAction } from './file.component';
+import { FileComponent } from './file.component';
+import { FileAction } from '../../models/file-action';
 import { ViewFile, ViewFileStatus } from '../../models/view-file';
 import { of } from 'rxjs';
 
@@ -160,36 +161,36 @@ describe('FileComponent inline delete confirmation', () => {
   });
 
   it('first click on delete local sets confirming state', () => {
-    component.onDeleteLocal(makeViewFile());
+    component.onAction(FileAction.DELETE_LOCAL, makeViewFile());
     expect(component.confirmingDelete).toBe('local');
     expect(component.activeAction).toBeNull();
   });
 
   it('second click on delete local emits event and clears state', () => {
     const file = makeViewFile();
-    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+    const spy = vi.spyOn(component.actionEvent, 'emit');
 
-    component.onDeleteLocal(file);
+    component.onAction(FileAction.DELETE_LOCAL, file);
     expect(component.confirmingDelete).toBe('local');
 
-    component.onDeleteLocal(file);
+    component.onAction(FileAction.DELETE_LOCAL, file);
     expect(component.confirmingDelete).toBeNull();
     expect(component.activeAction).toBe(FileAction.DELETE_LOCAL);
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ file }));
   });
 
   it('first click on delete remote sets confirming state', () => {
-    component.onDeleteRemote(makeViewFile());
+    component.onAction(FileAction.DELETE_REMOTE, makeViewFile());
     expect(component.confirmingDelete).toBe('remote');
     expect(component.activeAction).toBeNull();
   });
 
   it('second click on delete remote emits event and clears state', () => {
     const file = makeViewFile();
-    const spy = vi.spyOn(component.deleteRemoteEvent, 'emit');
+    const spy = vi.spyOn(component.actionEvent, 'emit');
 
-    component.onDeleteRemote(file);
-    component.onDeleteRemote(file);
+    component.onAction(FileAction.DELETE_REMOTE, file);
+    component.onAction(FileAction.DELETE_REMOTE, file);
 
     expect(component.confirmingDelete).toBeNull();
     expect(component.activeAction).toBe(FileAction.DELETE_REMOTE);
@@ -197,7 +198,7 @@ describe('FileComponent inline delete confirmation', () => {
   });
 
   it('confirming state auto-resets after 3 seconds', () => {
-    component.onDeleteLocal(makeViewFile());
+    component.onAction(FileAction.DELETE_LOCAL, makeViewFile());
     expect(component.confirmingDelete).toBe('local');
 
     vi.advanceTimersByTime(3000);
@@ -205,15 +206,15 @@ describe('FileComponent inline delete confirmation', () => {
   });
 
   it('clicking delete local while confirming remote switches to local', () => {
-    component.onDeleteRemote(makeViewFile());
+    component.onAction(FileAction.DELETE_REMOTE, makeViewFile());
     expect(component.confirmingDelete).toBe('remote');
 
-    component.onDeleteLocal(makeViewFile());
+    component.onAction(FileAction.DELETE_LOCAL, makeViewFile());
     expect(component.confirmingDelete).toBe('local');
   });
 
   it('should reset confirmingDelete when bound file changes', () => {
-    component.onDeleteLocal(makeViewFile());
+    component.onAction(FileAction.DELETE_LOCAL, makeViewFile());
     expect(component.confirmingDelete).toBe('local');
 
     const oldFile = makeViewFile({ status: ViewFileStatus.DOWNLOADED });
@@ -232,7 +233,7 @@ describe('FileComponent inline delete confirmation', () => {
   });
 
   it('should reset confirmingDelete when file name changes', () => {
-    component.onDeleteRemote(makeViewFile());
+    component.onAction(FileAction.DELETE_REMOTE, makeViewFile());
     expect(component.confirmingDelete).toBe('remote');
 
     const oldFile = makeViewFile({ name: 'file-a.txt' });
@@ -247,7 +248,7 @@ describe('FileComponent inline delete confirmation', () => {
   });
 
   it('ngOnDestroy clears the confirm timer', () => {
-    component.onDeleteLocal(makeViewFile());
+    component.onAction(FileAction.DELETE_LOCAL, makeViewFile());
     expect(component.confirmingDelete).toBe('local');
 
     component.ngOnDestroy();
@@ -280,20 +281,21 @@ describe('FileComponent action events', () => {
   });
 
   it.each([
-    ['onQueue', 'queueEvent'],
-    ['onStop', 'stopEvent'],
-    ['onExtract', 'extractEvent'],
-    ['onValidate', 'validateEvent'],
+    ['QUEUE', FileAction.QUEUE],
+    ['STOP', FileAction.STOP],
+    ['EXTRACT', FileAction.EXTRACT],
+    ['VALIDATE', FileAction.VALIDATE],
   ] as const)(
-    '%s emits an event carrying the file and a clearActiveAction callback',
-    (method, eventName) => {
+    'onAction(%s) emits an event carrying the action, file and a clearActiveAction callback',
+    (_label, action) => {
       const file = makeViewFile();
-      const spy = vi.spyOn(component[eventName], 'emit');
+      const spy = vi.spyOn(component.actionEvent, 'emit');
 
-      component[method](file);
+      component.onAction(action, file);
 
       expect(spy).toHaveBeenCalledTimes(1);
       const payload = spy.mock.calls[0][0];
+      expect(payload.action).toBe(action);
       expect(payload.file).toBe(file);
       expect(typeof payload.clearActiveAction).toBe('function');
 
@@ -306,11 +308,11 @@ describe('FileComponent action events', () => {
 
   it('delete emits a clearActiveAction callback that resets activeAction', () => {
     const file = makeViewFile();
-    const spy = vi.spyOn(component.deleteLocalEvent, 'emit');
+    const spy = vi.spyOn(component.actionEvent, 'emit');
 
     // Double-click to confirm and emit.
-    component.onDeleteLocal(file);
-    component.onDeleteLocal(file);
+    component.onAction(FileAction.DELETE_LOCAL, file);
+    component.onAction(FileAction.DELETE_LOCAL, file);
 
     expect(component.activeAction).toBe(FileAction.DELETE_LOCAL);
     const payload = spy.mock.calls[0][0];

--- a/src/angular/src/app/pages/files/file.component.ts
+++ b/src/angular/src/app/pages/files/file.component.ts
@@ -6,6 +6,7 @@ import { AsyncPipe, DatePipe } from '@angular/common';
 
 import { ViewFile, ViewFileStatus } from '../../models/view-file';
 import { ViewFileOptions } from '../../models/view-file-options';
+import { FileAction, FILE_ACTIONS } from '../../models/file-action';
 import { FileSizePipe } from '../../common/file-size.pipe';
 import { EtaPipe } from '../../common/eta.pipe';
 import { CapitalizePipe } from '../../common/capitalize.pipe';
@@ -13,22 +14,15 @@ import { ClickStopPropagationDirective } from '../../common/click-stop-propagati
 import { DoubleClickConfirm } from '../../common/double-click-confirm';
 import { Observable } from 'rxjs';
 
-export enum FileAction {
-  QUEUE,
-  STOP,
-  EXTRACT,
-  VALIDATE,
-  DELETE_LOCAL,
-  DELETE_REMOTE
-}
-
-// Payload emitted for each single-file action. Carries the target file plus a
-// callback the parent invokes to clear this child's activeAction when the
-// backend rejects the request — the file model never changes on failure, so
-// ngOnChanges cannot recover the row on its own. The callback is necessary
-// because <app-file> is rendered inside *cdkVirtualFor, which recycles
-// instances and prevents the parent from keying a @ViewChildren to a file.
+// Payload emitted for each single-file action. Carries the action, the target
+// file, plus a callback the parent invokes to clear this child's activeAction
+// when the backend rejects the request — the file model never changes on
+// failure, so ngOnChanges cannot recover the row on its own. The callback is
+// necessary because <app-file> is rendered inside *cdkVirtualFor, which
+// recycles instances and prevents the parent from keying a @ViewChildren to a
+// file.
 export interface FileActionEvent {
+  action: FileAction;
   file: ViewFile;
   clearActiveAction: () => void;
 }
@@ -60,12 +54,7 @@ export class FileComponent implements OnChanges, OnDestroy {
   options = input.required<Observable<ViewFileOptions>>();
 
   checkEvent = output<{file: ViewFile, shiftKey: boolean}>();
-  queueEvent = output<FileActionEvent>();
-  stopEvent = output<FileActionEvent>();
-  extractEvent = output<FileActionEvent>();
-  deleteLocalEvent = output<FileActionEvent>();
-  validateEvent = output<FileActionEvent>();
-  deleteRemoteEvent = output<FileActionEvent>();
+  actionEvent = output<FileActionEvent>();
 
   activeAction: FileAction | null = null;
 
@@ -119,28 +108,8 @@ export class FileComponent implements OnChanges, OnDestroy {
     this.checkEvent.emit({file, shiftKey});
   }
 
-  isQueueable(): boolean {
-    return this.activeAction == null && this.file().isQueueable;
-  }
-
-  isStoppable(): boolean {
-    return this.activeAction == null && this.file().isStoppable;
-  }
-
-  isExtractable(): boolean {
-    return this.activeAction == null && this.file().isExtractable && this.file().isArchive;
-  }
-
-  isValidatable(): boolean {
-    return this.activeAction == null && this.file().isValidatable;
-  }
-
-  isLocallyDeletable(): boolean {
-    return this.activeAction == null && this.file().isLocallyDeletable;
-  }
-
-  isRemotelyDeletable(): boolean {
-    return this.activeAction == null && this.file().isRemotelyDeletable;
+  canDo(action: FileAction): boolean {
+    return this.activeAction == null && FILE_ACTIONS[action].isAllowed(this.file());
   }
 
   // Cleared by the parent when an action's backend request fails or errors.
@@ -164,43 +133,15 @@ export class FileComponent implements OnChanges, OnDestroy {
     this.cdr.markForCheck();
   }
 
-  private actionEvent(file: ViewFile): FileActionEvent {
-    const action = this.activeAction;
-    return { file, clearActiveAction: () => this.clearActiveAction(file, action) };
-  }
-
-  onQueue(file: ViewFile): void {
-    this.activeAction = FileAction.QUEUE;
-    this.queueEvent.emit(this.actionEvent(file));
-  }
-
-  onStop(file: ViewFile): void {
-    this.activeAction = FileAction.STOP;
-    this.stopEvent.emit(this.actionEvent(file));
-  }
-
-  onExtract(file: ViewFile): void {
-    this.activeAction = FileAction.EXTRACT;
-    this.extractEvent.emit(this.actionEvent(file));
-  }
-
-  onValidate(file: ViewFile): void {
-    this.activeAction = FileAction.VALIDATE;
-    this.validateEvent.emit(this.actionEvent(file));
-  }
-
-  onDeleteLocal(file: ViewFile): void {
-    if (this.deleteConfirm.confirm('local')) {
-      this.activeAction = FileAction.DELETE_LOCAL;
-      this.deleteLocalEvent.emit(this.actionEvent(file));
+  onAction(action: FileAction, file: ViewFile): void {
+    if (action === FileAction.DELETE_LOCAL && !this.deleteConfirm.confirm('local')) {
+      return;
     }
-  }
-
-  onDeleteRemote(file: ViewFile): void {
-    if (this.deleteConfirm.confirm('remote')) {
-      this.activeAction = FileAction.DELETE_REMOTE;
-      this.deleteRemoteEvent.emit(this.actionEvent(file));
+    if (action === FileAction.DELETE_REMOTE && !this.deleteConfirm.confirm('remote')) {
+      return;
     }
+    this.activeAction = action;
+    this.actionEvent.emit({ action, file, clearActiveAction: () => this.clearActiveAction(file, action) });
   }
 
   private static isElementInViewport(el: HTMLElement): boolean {

--- a/src/angular/src/app/services/files/model-file.service.spec.ts
+++ b/src/angular/src/app/services/files/model-file.service.spec.ts
@@ -6,6 +6,7 @@ import { StreamDispatchService } from "../base/stream-dispatch.service";
 import { LoggerService } from "../utils/logger.service";
 import { RestService } from "../utils/rest.service";
 import { ModelFile } from "../../models/model-file";
+import { FileAction } from "../../models/file-action";
 
 function makeFileJson(name: string, state = "DEFAULT") {
   return {
@@ -174,58 +175,35 @@ describe("ModelFileService", () => {
     expect(result!.size).toBe(0);
   });
 
-  it("should call RestService.sendRequest with double-encoded filename for queue", () => {
+  // The URL verb per action is a backend contract — cover all six.
+  const urlVerbCases: [string, FileAction, string][] = [
+    ["queue", FileAction.QUEUE, "queue"],
+    ["stop", FileAction.STOP, "stop"],
+    ["extract", FileAction.EXTRACT, "extract"],
+    ["validate", FileAction.VALIDATE, "validate"],
+    ["deleteLocal", FileAction.DELETE_LOCAL, "delete_local"],
+    ["deleteRemote", FileAction.DELETE_REMOTE, "delete_remote"],
+  ];
+  for (const [label, action, verb] of urlVerbCases) {
+    it(`should call RestService.sendRequest with double-encoded filename for ${label}`, () => {
+      mockRestService.sendRequest.mockReturnValue(of({}));
+      const file = { name: "my file/test" } as ModelFile;
+      service.command(action, file);
+
+      const encoded = encodeURIComponent(encodeURIComponent("my file/test"));
+      expect(mockRestService.sendRequest).toHaveBeenCalledWith(
+        "/server/command/" + verb + "/" + encoded,
+      );
+    });
+  }
+
+  it("should append pair_id as a query param when the file has one", () => {
     mockRestService.sendRequest.mockReturnValue(of({}));
-    const file = { name: "my file/test" } as ModelFile;
-    service.queue(file);
+    const file = { name: "file1", pair_id: "pair a" } as ModelFile;
+    service.command(FileAction.QUEUE, file);
 
-    const encoded = encodeURIComponent(encodeURIComponent("my file/test"));
     expect(mockRestService.sendRequest).toHaveBeenCalledWith(
-      "/server/command/queue/" + encoded,
-    );
-  });
-
-  it("should call RestService.sendRequest with double-encoded filename for stop", () => {
-    mockRestService.sendRequest.mockReturnValue(of({}));
-    const file = { name: "my file/test" } as ModelFile;
-    service.stop(file);
-
-    const encoded = encodeURIComponent(encodeURIComponent("my file/test"));
-    expect(mockRestService.sendRequest).toHaveBeenCalledWith(
-      "/server/command/stop/" + encoded,
-    );
-  });
-
-  it("should call RestService.sendRequest with double-encoded filename for extract", () => {
-    mockRestService.sendRequest.mockReturnValue(of({}));
-    const file = { name: "my file/test" } as ModelFile;
-    service.extract(file);
-
-    const encoded = encodeURIComponent(encodeURIComponent("my file/test"));
-    expect(mockRestService.sendRequest).toHaveBeenCalledWith(
-      "/server/command/extract/" + encoded,
-    );
-  });
-
-  it("should call RestService.sendRequest with double-encoded filename for deleteLocal", () => {
-    mockRestService.sendRequest.mockReturnValue(of({}));
-    const file = { name: "my file/test" } as ModelFile;
-    service.deleteLocal(file);
-
-    const encoded = encodeURIComponent(encodeURIComponent("my file/test"));
-    expect(mockRestService.sendRequest).toHaveBeenCalledWith(
-      "/server/command/delete_local/" + encoded,
-    );
-  });
-
-  it("should call RestService.sendRequest with double-encoded filename for deleteRemote", () => {
-    mockRestService.sendRequest.mockReturnValue(of({}));
-    const file = { name: "my file/test" } as ModelFile;
-    service.deleteRemote(file);
-
-    const encoded = encodeURIComponent(encodeURIComponent("my file/test"));
-    expect(mockRestService.sendRequest).toHaveBeenCalledWith(
-      "/server/command/delete_remote/" + encoded,
+      "/server/command/queue/file1?pair_id=" + encodeURIComponent("pair a"),
     );
   });
 

--- a/src/angular/src/app/services/files/model-file.service.ts
+++ b/src/angular/src/app/services/files/model-file.service.ts
@@ -5,6 +5,7 @@ import { StreamEventHandler, StreamDispatchService } from '../base/stream-dispat
 import { LoggerService } from '../utils/logger.service';
 import { RestService, WebReaction } from '../utils/rest.service';
 import { ModelFile, ModelFileJson, modelFileFromJson } from '../../models/model-file';
+import { FileAction, FILE_ACTIONS } from '../../models/file-action';
 import { fileKey } from './file-key';
 
 @Injectable({ providedIn: 'root' })
@@ -30,34 +31,10 @@ export class ModelFileService implements StreamEventHandler {
     return [this.EVENT_INIT, this.EVENT_ADDED, this.EVENT_UPDATED, this.EVENT_REMOVED];
   }
 
-  queue(file: ModelFile): Observable<WebReaction> {
-    this.logger.debug('Queue model file: ' + file.name);
-    return this.restService.sendRequest(this.commandUrl('queue', file));
-  }
-
-  stop(file: ModelFile): Observable<WebReaction> {
-    this.logger.debug('Stop model file: ' + file.name);
-    return this.restService.sendRequest(this.commandUrl('stop', file));
-  }
-
-  extract(file: ModelFile): Observable<WebReaction> {
-    this.logger.debug('Extract model file: ' + file.name);
-    return this.restService.sendRequest(this.commandUrl('extract', file));
-  }
-
-  deleteLocal(file: ModelFile): Observable<WebReaction> {
-    this.logger.debug('Delete locally model file: ' + file.name);
-    return this.restService.sendRequest(this.commandUrl('delete_local', file));
-  }
-
-  deleteRemote(file: ModelFile): Observable<WebReaction> {
-    this.logger.debug('Delete remotely model file: ' + file.name);
-    return this.restService.sendRequest(this.commandUrl('delete_remote', file));
-  }
-
-  validate(file: ModelFile): Observable<WebReaction> {
-    this.logger.debug('Validate model file: ' + file.name);
-    return this.restService.sendRequest(this.commandUrl('validate', file));
+  command(action: FileAction, file: ModelFile): Observable<WebReaction> {
+    const spec = FILE_ACTIONS[action];
+    this.logger.debug(spec.logNoun + ' model file: ' + file.name);
+    return this.restService.sendRequest(this.commandUrl(spec.urlSegment, file));
   }
 
   private commandUrl(action: string, file: ModelFile): string {

--- a/src/angular/src/app/services/files/view-file-command.service.spec.ts
+++ b/src/angular/src/app/services/files/view-file-command.service.spec.ts
@@ -9,6 +9,7 @@ import { LoggerService } from '../utils/logger.service';
 import { ModelFile, ModelFileState } from '../../models/model-file';
 import { ViewFile, ViewFileStatus } from '../../models/view-file';
 import { WebReaction } from '../utils/rest.service';
+import { FileAction } from '../../models/file-action';
 import { fileKey } from './file-key';
 
 function makeModelFile(overrides: Partial<ModelFile> & { name: string }): ModelFile {
@@ -66,22 +67,12 @@ describe('ViewFileCommandService', () => {
   let service: ViewFileCommandService;
   let selection: ViewFileSelectionService;
   let mockModelFileService: {
-    queue: ReturnType<typeof vi.fn>;
-    stop: ReturnType<typeof vi.fn>;
-    extract: ReturnType<typeof vi.fn>;
-    deleteLocal: ReturnType<typeof vi.fn>;
-    deleteRemote: ReturnType<typeof vi.fn>;
-    validate: ReturnType<typeof vi.fn>;
+    command: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
     mockModelFileService = {
-      queue: vi.fn().mockReturnValue(of(OK)),
-      stop: vi.fn().mockReturnValue(of(OK)),
-      extract: vi.fn().mockReturnValue(of(OK)),
-      deleteLocal: vi.fn().mockReturnValue(of(OK)),
-      deleteRemote: vi.fn().mockReturnValue(of(OK)),
-      validate: vi.fn().mockReturnValue(of(OK)),
+      command: vi.fn().mockReturnValue(of(OK)),
     };
     TestBed.configureTestingModule({
       providers: [
@@ -109,47 +100,47 @@ describe('ViewFileCommandService', () => {
 
   // --- single dispatch: resolves ViewFile -> ModelFile ---
 
-  it('queue() resolves the ViewFile to its ModelFile and dispatches it', () => {
+  it('command(QUEUE) resolves the ViewFile to its ModelFile and dispatches it', () => {
     const mf = makeModelFile({ name: 'file1', remote_size: 100 });
     const vf = makeViewFile({ name: 'file1', remoteSize: 100 });
 
     let result: WebReaction | undefined;
-    service.queue(vf, resolverFor([mf])).subscribe((r) => (result = r));
+    service.command(FileAction.QUEUE, vf, resolverFor([mf])).subscribe((r) => (result = r));
 
-    expect(mockModelFileService.queue).toHaveBeenCalledWith(mf);
+    expect(mockModelFileService.command).toHaveBeenCalledWith(FileAction.QUEUE, mf);
     expect(result).toEqual(OK);
   });
 
-  it('queue() resolves the correct ModelFile when same-name files differ by pairId', () => {
+  it('command() resolves the correct ModelFile when same-name files differ by pairId', () => {
     const mfA = makeModelFile({ name: 'movie.mkv', pair_id: 'pair-a', remote_size: 100 });
     const mfB = makeModelFile({ name: 'movie.mkv', pair_id: 'pair-b', remote_size: 200 });
     const vfB = makeViewFile({ name: 'movie.mkv', pairId: 'pair-b', remoteSize: 200 });
 
-    service.queue(vfB, resolverFor([mfA, mfB])).subscribe();
+    service.command(FileAction.QUEUE, vfB, resolverFor([mfA, mfB])).subscribe();
 
-    expect(mockModelFileService.queue).toHaveBeenCalledWith(mfB);
-    expect(mockModelFileService.queue).not.toHaveBeenCalledWith(mfA);
+    expect(mockModelFileService.command).toHaveBeenCalledWith(FileAction.QUEUE, mfB);
+    expect(mockModelFileService.command).not.toHaveBeenCalledWith(FileAction.QUEUE, mfA);
   });
 
   it('returns a failure reaction (without dispatching) when the ModelFile cannot be resolved', () => {
     const vf = makeViewFile({ name: 'missing' });
 
     let result: WebReaction | undefined;
-    service.queue(vf, resolverFor([])).subscribe((r) => (result = r));
+    service.command(FileAction.QUEUE, vf, resolverFor([])).subscribe((r) => (result = r));
 
     expect(result!.success).toBe(false);
     expect(result!.errorMessage).toBe("File 'missing' not found");
-    expect(mockModelFileService.queue).not.toHaveBeenCalled();
+    expect(mockModelFileService.command).not.toHaveBeenCalled();
   });
 
   it('maps an action error to a failure reaction rather than erroring the observable', () => {
     const mf = makeModelFile({ name: 'file1' });
     const vf = makeViewFile({ name: 'file1' });
-    mockModelFileService.stop.mockReturnValue(throwError(() => new Error('boom')));
+    mockModelFileService.command.mockReturnValue(throwError(() => new Error('boom')));
 
     let result: WebReaction | undefined;
     let errored = false;
-    service.stop(vf, resolverFor([mf])).subscribe({
+    service.command(FileAction.STOP, vf, resolverFor([mf])).subscribe({
       next: (r) => (result = r),
       error: () => (errored = true),
     });
@@ -159,27 +150,29 @@ describe('ViewFileCommandService', () => {
     expect(result!.errorMessage).toBe('boom');
   });
 
-  it('each single command delegates to the matching ModelFileService method', () => {
+  it('each action is threaded through to ModelFileService.command', () => {
     const mf = makeModelFile({ name: 'file1' });
     const vf = makeViewFile({ name: 'file1' });
     const resolve = resolverFor([mf]);
+    const actions = [
+      FileAction.QUEUE,
+      FileAction.STOP,
+      FileAction.EXTRACT,
+      FileAction.VALIDATE,
+      FileAction.DELETE_LOCAL,
+      FileAction.DELETE_REMOTE,
+    ];
 
-    service.stop(vf, resolve).subscribe();
-    service.extract(vf, resolve).subscribe();
-    service.deleteLocal(vf, resolve).subscribe();
-    service.deleteRemote(vf, resolve).subscribe();
-    service.validate(vf, resolve).subscribe();
-
-    expect(mockModelFileService.stop).toHaveBeenCalledWith(mf);
-    expect(mockModelFileService.extract).toHaveBeenCalledWith(mf);
-    expect(mockModelFileService.deleteLocal).toHaveBeenCalledWith(mf);
-    expect(mockModelFileService.deleteRemote).toHaveBeenCalledWith(mf);
-    expect(mockModelFileService.validate).toHaveBeenCalledWith(mf);
+    for (const action of actions) {
+      service.command(action, vf, resolve).subscribe();
+      expect(mockModelFileService.command).toHaveBeenCalledWith(action, mf);
+    }
+    expect(mockModelFileService.command).toHaveBeenCalledTimes(actions.length);
   });
 
   // --- bulk dispatch: checked + capability filter ---
 
-  it('bulkQueue() dispatches only files that are both checked AND queueable', () => {
+  it('bulk(QUEUE) dispatches only files that are both checked AND queueable', () => {
     const queueableChecked = makeViewFile({ name: 'a', remoteSize: 100, isQueueable: true });
     const queueableUnchecked = makeViewFile({ name: 'b', remoteSize: 100, isQueueable: true });
     const notQueueableChecked = makeViewFile({ name: 'c', remoteSize: 100, isQueueable: false });
@@ -196,17 +189,18 @@ describe('ViewFileCommandService', () => {
     ];
 
     let results: WebReaction[] = [];
-    service.bulkQueue(files, resolverFor(models)).subscribe((r) => (results = r));
+    service.bulk(FileAction.QUEUE, files, resolverFor(models)).subscribe((r) => (results = r));
 
     // Only 'a' satisfies checked AND queueable.
-    expect(mockModelFileService.queue).toHaveBeenCalledTimes(1);
-    expect(mockModelFileService.queue).toHaveBeenCalledWith(
+    expect(mockModelFileService.command).toHaveBeenCalledTimes(1);
+    expect(mockModelFileService.command).toHaveBeenCalledWith(
+      FileAction.QUEUE,
       models.find((m) => m.name === 'a'),
     );
     expect(results).toEqual([OK]);
   });
 
-  it('bulkStop() applies the isStoppable capability filter', () => {
+  it('bulk(STOP) applies the isStoppable capability filter', () => {
     const stoppableChecked = makeViewFile({ name: 'dl', isStoppable: true });
     const stoppedChecked = makeViewFile({ name: 'st', isStoppable: false });
     const files = [stoppableChecked, stoppedChecked];
@@ -216,10 +210,11 @@ describe('ViewFileCommandService', () => {
 
     const models = [makeModelFile({ name: 'dl' }), makeModelFile({ name: 'st' })];
 
-    service.bulkStop(files, resolverFor(models)).subscribe();
+    service.bulk(FileAction.STOP, files, resolverFor(models)).subscribe();
 
-    expect(mockModelFileService.stop).toHaveBeenCalledTimes(1);
-    expect(mockModelFileService.stop).toHaveBeenCalledWith(
+    expect(mockModelFileService.command).toHaveBeenCalledTimes(1);
+    expect(mockModelFileService.command).toHaveBeenCalledWith(
+      FileAction.STOP,
       models.find((m) => m.name === 'dl'),
     );
   });
@@ -229,15 +224,15 @@ describe('ViewFileCommandService', () => {
     // 'a' is queueable but NOT checked.
 
     let results: WebReaction[] | undefined;
-    service.bulkQueue(files, resolverFor([makeModelFile({ name: 'a' })])).subscribe(
+    service.bulk(FileAction.QUEUE, files, resolverFor([makeModelFile({ name: 'a' })])).subscribe(
       (r) => (results = r),
     );
 
     expect(results).toEqual([]);
-    expect(mockModelFileService.queue).not.toHaveBeenCalled();
+    expect(mockModelFileService.command).not.toHaveBeenCalled();
   });
 
-  it('bulkDeleteRemote() applies the isRemotelyDeletable filter', () => {
+  it('bulk(DELETE_REMOTE) applies the isRemotelyDeletable filter', () => {
     const deletable = makeViewFile({ name: 'r', remoteSize: 100, isRemotelyDeletable: true });
     const notDeletable = makeViewFile({ name: 'x', isRemotelyDeletable: false });
     const files = [deletable, notDeletable];
@@ -249,10 +244,11 @@ describe('ViewFileCommandService', () => {
       makeModelFile({ name: 'x' }),
     ];
 
-    service.bulkDeleteRemote(files, resolverFor(models)).subscribe();
+    service.bulk(FileAction.DELETE_REMOTE, files, resolverFor(models)).subscribe();
 
-    expect(mockModelFileService.deleteRemote).toHaveBeenCalledTimes(1);
-    expect(mockModelFileService.deleteRemote).toHaveBeenCalledWith(
+    expect(mockModelFileService.command).toHaveBeenCalledTimes(1);
+    expect(mockModelFileService.command).toHaveBeenCalledWith(
+      FileAction.DELETE_REMOTE,
       models.find((m) => m.name === 'r'),
     );
   });

--- a/src/angular/src/app/services/files/view-file-command.service.ts
+++ b/src/angular/src/app/services/files/view-file-command.service.ts
@@ -7,6 +7,7 @@ import { ModelFileService } from './model-file.service';
 import { WebReaction } from '../utils/rest.service';
 import { ModelFile } from '../../models/model-file';
 import { ViewFile } from '../../models/view-file';
+import { FileAction, FILE_ACTIONS } from '../../models/file-action';
 import { fileKey } from './file-key';
 import { ViewFileSelectionService } from './view-file-selection.service';
 
@@ -40,64 +41,19 @@ export class ViewFileCommandService {
   private readonly modelFileService = inject(ModelFileService);
   private readonly selection = inject(ViewFileSelectionService);
 
-  queue(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
-    this.logger.debug('Queue view file: ' + file.name);
-    return this.createAction(file, resolve, (f) => this.modelFileService.queue(f));
+  command(action: FileAction, file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
+    this.logger.debug(FILE_ACTIONS[action].logNoun + ' view file: ' + file.name);
+    return this.createAction(file, resolve, (f) => this.modelFileService.command(action, f));
   }
 
-  stop(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
-    this.logger.debug('Stop view file: ' + file.name);
-    return this.createAction(file, resolve, (f) => this.modelFileService.stop(f));
-  }
-
-  extract(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
-    this.logger.debug('Extract view file: ' + file.name);
-    return this.createAction(file, resolve, (f) => this.modelFileService.extract(f));
-  }
-
-  deleteLocal(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
-    this.logger.debug('Locally delete view file: ' + file.name);
-    return this.createAction(file, resolve, (f) => this.modelFileService.deleteLocal(f));
-  }
-
-  deleteRemote(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
-    this.logger.debug('Remotely delete view file: ' + file.name);
-    return this.createAction(file, resolve, (f) => this.modelFileService.deleteRemote(f));
-  }
-
-  validate(file: ViewFile, resolve: ModelFileResolver): Observable<WebReaction> {
-    this.logger.debug('Validate view file: ' + file.name);
-    return this.createAction(file, resolve, (f) => this.modelFileService.validate(f));
-  }
-
-  bulkQueue(files: readonly ViewFile[], resolve: ModelFileResolver): Observable<WebReaction[]> {
-    return this.bulkAction(files, (f) => f.isQueueable, (f) => this.queue(f, resolve));
-  }
-
-  bulkStop(files: readonly ViewFile[], resolve: ModelFileResolver): Observable<WebReaction[]> {
-    return this.bulkAction(files, (f) => f.isStoppable, (f) => this.stop(f, resolve));
-  }
-
-  bulkDeleteLocal(files: readonly ViewFile[], resolve: ModelFileResolver): Observable<WebReaction[]> {
-    return this.bulkAction(files, (f) => f.isLocallyDeletable, (f) => this.deleteLocal(f, resolve), 4);
-  }
-
-  bulkDeleteRemote(files: readonly ViewFile[], resolve: ModelFileResolver): Observable<WebReaction[]> {
-    return this.bulkAction(files, (f) => f.isRemotelyDeletable, (f) => this.deleteRemote(f, resolve), 4);
-  }
-
-  private bulkAction(
-    files: readonly ViewFile[],
-    filter: (f: ViewFile) => boolean,
-    action: (f: ViewFile) => Observable<WebReaction>,
-    concurrency = Infinity,
-  ): Observable<WebReaction[]> {
-    const checked = files.filter((f) => this.selection.isChecked(viewFileKey(f)) && filter(f));
+  bulk(action: FileAction, files: readonly ViewFile[], resolve: ModelFileResolver): Observable<WebReaction[]> {
+    const spec = FILE_ACTIONS[action];
+    const checked = files.filter((f) => this.selection.isChecked(viewFileKey(f)) && spec.isAllowed(f));
     if (checked.length === 0) {
       return of([]);
     }
     return from(checked).pipe(
-      mergeMap((f) => action(f), concurrency),
+      mergeMap((f) => this.command(action, f, resolve), spec.bulkConcurrency),
       toArray(),
     );
   }

--- a/src/angular/src/app/services/files/view-file.service.spec.ts
+++ b/src/angular/src/app/services/files/view-file.service.spec.ts
@@ -8,6 +8,7 @@ import { LoggerService } from "../utils/logger.service";
 import { ModelFile, ModelFileState } from "../../models/model-file";
 import { PathPair } from "../../models/path-pair";
 import { ViewFile, ViewFileStatus } from "../../models/view-file";
+import { FileAction } from "../../models/file-action";
 import { WebReaction } from "../utils/rest.service";
 import { fileKey } from "./file-key";
 
@@ -38,11 +39,7 @@ describe("ViewFileService", () => {
   let pairsSubject: BehaviorSubject<PathPair[]>;
   let mockModelFileService: {
     files$: ReturnType<BehaviorSubject<Map<string, ModelFile>>["asObservable"]>;
-    queue: ReturnType<typeof vi.fn>;
-    stop: ReturnType<typeof vi.fn>;
-    extract: ReturnType<typeof vi.fn>;
-    deleteLocal: ReturnType<typeof vi.fn>;
-    deleteRemote: ReturnType<typeof vi.fn>;
+    command: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -50,11 +47,7 @@ describe("ViewFileService", () => {
     pairsSubject = new BehaviorSubject<PathPair[]>([]);
     mockModelFileService = {
       files$: modelFilesSubject.asObservable(),
-      queue: vi.fn(),
-      stop: vi.fn(),
-      extract: vi.fn(),
-      deleteLocal: vi.fn(),
-      deleteRemote: vi.fn(),
+      command: vi.fn(),
     };
     TestBed.configureTestingModule({
       providers: [
@@ -483,29 +476,29 @@ describe("ViewFileService", () => {
 
   // --- Action delegation ---
 
-  it("should delegate queue() to ModelFileService", () => {
+  it("should delegate command() to ModelFileService", () => {
     const mf = makeModelFile({ name: "file1", remote_size: 100 });
     emitModelFiles([mf]);
-    mockModelFileService.queue.mockReturnValue(
+    mockModelFileService.command.mockReturnValue(
       of({ success: true, data: null, errorMessage: null }),
     );
 
     const vf = latestFiles()[0];
     let result: WebReaction | undefined;
-    service.queue(vf).subscribe((r) => (result = r));
+    service.command(FileAction.QUEUE, vf).subscribe((r) => (result = r));
 
-    expect(mockModelFileService.queue).toHaveBeenCalledWith(mf);
+    expect(mockModelFileService.command).toHaveBeenCalledWith(FileAction.QUEUE, mf);
     expect(result!.success).toBe(true);
   });
 
-  it("should return error reaction when file not found for queue()", () => {
+  it("should return error reaction when file not found for command()", () => {
     emitModelFiles([]);
 
     const fakeVf = {
       name: "nonexistent",
     } as ViewFile;
     let result: WebReaction | undefined;
-    service.queue(fakeVf).subscribe((r) => (result = r));
+    service.command(FileAction.QUEUE, fakeVf).subscribe((r) => (result = r));
 
     expect(result!.success).toBe(false);
   });
@@ -552,19 +545,19 @@ describe("ViewFileService", () => {
     expect(files.find((f) => f.pairId === "pair-b")!.isChecked).toBe(false);
   });
 
-  it("should delegate queue() to the correct model file when same-name files have different pair_ids", () => {
+  it("should delegate command() to the correct model file when same-name files have different pair_ids", () => {
     const mfA = makeModelFile({ name: "movie.mkv", pair_id: "pair-a", remote_size: 100 });
     const mfB = makeModelFile({ name: "movie.mkv", pair_id: "pair-b", remote_size: 200 });
     emitModelFiles([mfA, mfB]);
-    mockModelFileService.queue.mockReturnValue(
+    mockModelFileService.command.mockReturnValue(
       of({ success: true, data: null, errorMessage: null }),
     );
 
     const vfB = latestFiles().find((f) => f.pairId === "pair-b")!;
-    service.queue(vfB).subscribe();
+    service.command(FileAction.QUEUE, vfB).subscribe();
 
-    expect(mockModelFileService.queue).toHaveBeenCalledWith(mfB);
-    expect(mockModelFileService.queue).not.toHaveBeenCalledWith(mfA);
+    expect(mockModelFileService.command).toHaveBeenCalledWith(FileAction.QUEUE, mfB);
+    expect(mockModelFileService.command).not.toHaveBeenCalledWith(FileAction.QUEUE, mfA);
   });
 
   it("should remove the correct file when same-name files have different pair_ids", () => {

--- a/src/angular/src/app/services/files/view-file.service.ts
+++ b/src/angular/src/app/services/files/view-file.service.ts
@@ -8,6 +8,7 @@ import { PathPairsService } from '../settings/path-pairs.service';
 import { WebReaction } from '../utils/rest.service';
 import { ModelFile } from '../../models/model-file';
 import { ViewFile } from '../../models/view-file';
+import { FileAction } from '../../models/file-action';
 import { fileKey } from './file-key';
 import { mapState, deriveCapabilities } from './view-file-capabilities';
 import { ViewFileSelectionService } from './view-file-selection.service';
@@ -151,32 +152,12 @@ export class ViewFileService {
     }
   }
 
-  // Thin facades over ViewFileCommandService — kept so existing consumers (and
+  // Thin facade over ViewFileCommandService — kept so existing consumers (and
   // the existing spec) target a single service. Command dispatch lives in
   // ViewFileCommandService (issue #541); this service threads in the
   // diffing-owned ModelFile resolver.
-  queue(file: ViewFile): Observable<WebReaction> {
-    return this.commands.queue(file, this.resolveModelFile);
-  }
-
-  stop(file: ViewFile): Observable<WebReaction> {
-    return this.commands.stop(file, this.resolveModelFile);
-  }
-
-  extract(file: ViewFile): Observable<WebReaction> {
-    return this.commands.extract(file, this.resolveModelFile);
-  }
-
-  deleteLocal(file: ViewFile): Observable<WebReaction> {
-    return this.commands.deleteLocal(file, this.resolveModelFile);
-  }
-
-  deleteRemote(file: ViewFile): Observable<WebReaction> {
-    return this.commands.deleteRemote(file, this.resolveModelFile);
-  }
-
-  validate(file: ViewFile): Observable<WebReaction> {
-    return this.commands.validate(file, this.resolveModelFile);
+  command(action: FileAction, file: ViewFile): Observable<WebReaction> {
+    return this.commands.command(action, file, this.resolveModelFile);
   }
 
   toggleCheck(file: ViewFile): void {
@@ -222,22 +203,10 @@ export class ViewFileService {
     this.pushViewFiles();
   }
 
-  // Thin facades over ViewFileCommandService — thread in the current display
+  // Thin facade over ViewFileCommandService — thread in the current display
   // list so the command service can apply its checked + capability filter.
-  bulkQueue(): Observable<WebReaction[]> {
-    return this.commands.bulkQueue(this.files, this.resolveModelFile);
-  }
-
-  bulkStop(): Observable<WebReaction[]> {
-    return this.commands.bulkStop(this.files, this.resolveModelFile);
-  }
-
-  bulkDeleteLocal(): Observable<WebReaction[]> {
-    return this.commands.bulkDeleteLocal(this.files, this.resolveModelFile);
-  }
-
-  bulkDeleteRemote(): Observable<WebReaction[]> {
-    return this.commands.bulkDeleteRemote(this.files, this.resolveModelFile);
+  bulkCommand(action: FileAction): Observable<WebReaction[]> {
+    return this.commands.bulk(action, this.files, this.resolveModelFile);
   }
 
   setFilterCriteria(criteria: ViewFileFilterCriteria | null): void {


### PR DESCRIPTION
## Summary

Closes #674 — the last Phase 3 item of the over-engineering audit (tracking issue #682). Net **−313 lines** (244 insertions, 557 deletions).

The six file actions (queue, stop, extract, validate, deleteLocal, deleteRemote) were written out longhand across five layers. They now flow through one `command(action)` path per layer, driven by the existing `FileAction` enum (moved from `file.component.ts` to `models/file-action.ts`) plus a single per-action spec table holding the URL verb, log noun, capability predicate, and bulk concurrency:

- `ModelFileService`: 6 methods → `command(action, file)`
- `ViewFileCommandService`: 6 single + 4 bulk → `command()` / `bulk()` (forkJoin-equivalent `from/mergeMap/toArray` semantics and the delete concurrency cap of 4 preserved via the table)
- `ViewFileService`: 10 pass-through facades → `command()` / `bulkCommand()`
- `FileComponent`: 6 `onX` + 6 `isX` guards → `onAction(action, file)` / `canDo(action)`; the double-click delete confirm stays in `onAction`; single `actionEvent` output whose payload now carries the action
- `FileListComponent`: 6 + 4 handlers → `onAction(event)` / `onBulkAction(action)`
- `BulkActionBarComponent`: 4 outputs → one `actionEvent = output<FileAction>()`; templates pass enum members

## Contract notes

- HTTP endpoints and request shapes unchanged — the URL verb per action is pinned by a parameterized spec over all six actions, which **adds** coverage for `validate` and the `pair_id` query param (neither was tested before).
- User-visible notification text unchanged. Debug-log strings are unified to one noun per action (e.g. `"Locally delete model file: ..."` instead of `"Delete locally model file: ..."`) — console-only debug text, per the issue's one-table design.
- The mutating-service contract (pipeline via `tap`/`catchError`, typed `WebReaction`, no internal subscribe) is untouched — `createAction` is unchanged.
- Mixed line endings preserved — verified the five CRLF files are still CRLF; no whole-file rewrites in the diff.

## Test plan

- [x] `npx ng test` — 564 passed (39 files); per-action coverage parameterized so no action lost a test
- [x] `npx ng lint` — clean
- [x] `npx ng build --configuration production` — succeeds (pre-existing bundle-budget warning)
- [x] Field test: `make build && make run` + full Playwright e2e suite against the container — 20 passed, 4 skipped, 0 failures
- [ ] File-action buttons against a real seedbox (queue/stop/etc. need real transfers) — visual smoke left to you if desired; unit + e2e cover the dispatch chain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified file actions such as queue, stop, extract, validate, and deletion under a consistent action model.
  * Updated individual and bulk file controls to use a shared action workflow.
  * Preserved capability checks, deletion confirmations, notifications, logging, and error handling.
* **Tests**
  * Expanded coverage for supported single-file and bulk actions, including validation and deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->