### PR TITLE
refactor(python): convert ModelFile to a dataclass

### DIFF
--- a/src/python/model/file.py
+++ b/src/python/model/file.py
@@ -3,11 +3,20 @@
 import copy
 import os
 from collections.abc import Iterator
+from dataclasses import dataclass, field, fields
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
+
+# Fields that hold byte/second counts and must never go negative.
+_NON_NEGATIVE_FIELDS = frozenset({"remote_size", "local_size", "transferred_size", "downloading_speed", "eta"})
+
+# Excluded from __eq__ (in addition to _children/_parent, which are not
+# dataclass fields): we don't care about the update timestamp in comparisons.
+_EQ_EXCLUDED_FIELDS = frozenset({"update_timestamp"})
 
 
+@dataclass(eq=False, repr=False)
 class ModelFile:
     """
     Represents a file or directory
@@ -32,51 +41,50 @@ class ModelFile:
         CORRUPT = 10
         MOVE_FAILED = 11
 
-    def __init__(self, name: str, is_dir: bool, pair_id: str | None = None):
-        self.__name = name  # file or folder name
-        self.__is_dir = is_dir  # True if this is a dir, False if file
-        self.__pair_id = pair_id  # which path pair this file belongs to
-        self.__state = ModelFile.State.DEFAULT  # status
-        self.__remote_size: int | None = None  # remote size in bytes, None if file does not exist
-        self.__local_size: int | None = None  # local size in bytes, None if file does not exist
-        self.__transferred_size: int | None = None  # transferred size in bytes, None if file does not exist
-        self.__downloading_speed: int | None = None  # in bytes / sec, None if not downloading
-        self.__eta: int | None = None  # est. time remaining in seconds, None if not available
-        self.__is_extractable = False  # whether file is an archive or dir contains archives
-        self.__local_created_timestamp: datetime | None = None
-        self.__local_modified_timestamp: datetime | None = None
-        self.__remote_created_timestamp: datetime | None = None
-        self.__remote_modified_timestamp: datetime | None = None
-        # timestamp of the latest update
-        # Note: timestamp is not part of equality operator
-        self.__update_timestamp = datetime.now()
-        self.__children: list[ModelFile] = []  # children files
-        self.__parent: ModelFile | None = None  # direct predecessor
+    name: str  # file or folder name
+    is_dir: bool  # True if this is a dir, False if file
+    pair_id: str | None = None  # which path pair this file belongs to
+    state: State = State.DEFAULT  # status
+    remote_size: int | None = None  # remote size in bytes, None if file does not exist
+    local_size: int | None = None  # local size in bytes, None if file does not exist
+    transferred_size: int | None = None  # transferred size in bytes, None if file does not exist
+    downloading_speed: int | None = None  # in bytes / sec, None if not downloading
+    eta: int | None = None  # est. time remaining in seconds, None if not available
+    is_extractable: bool = False  # whether file is an archive or dir contains archives
+    local_created_timestamp: datetime | None = None
+    local_modified_timestamp: datetime | None = None
+    remote_created_timestamp: datetime | None = None
+    remote_modified_timestamp: datetime | None = None
+    # timestamp of the latest update; not part of the equality operator
+    update_timestamp: datetime = field(default_factory=datetime.now)
+
+    def __post_init__(self):
+        self._children: list[ModelFile] = []  # children files
+        self._parent: ModelFile | None = None  # direct predecessor
+
+    def __setattr__(self, key: str, value: Any):
+        if key in _NON_NEGATIVE_FIELDS and value is not None and value < 0:
+            raise ValueError(f"{key} must be non-negative")
+        super().__setattr__(key, value)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ModelFile):
             return NotImplemented
         # disregard in comparisons:
-        #   timestamp: we don't care about it
+        #   update_timestamp: we don't care about it
         #   parent: semantics are to check self and children only
         #   children: check these manually for easier debugging
-        ka = set(self.__dict__).difference(
-            {"_ModelFile__update_timestamp", "_ModelFile__parent", "_ModelFile__children"}
-        )
-        kb = set(other.__dict__).difference(
-            {"_ModelFile__update_timestamp", "_ModelFile__parent", "_ModelFile__children"}
-        )
-        # Check self properties
-        if ka != kb:
-            return False
-        if not all(self.__dict__[k] == other.__dict__[k] for k in ka):
-            return False
+        for f in fields(self):
+            if f.name in _EQ_EXCLUDED_FIELDS:
+                continue
+            if getattr(self, f.name) != getattr(other, f.name):
+                return False
 
         # Check children's properties
-        if len(self.__children) != len(other.__children):
+        if len(self._children) != len(other._children):
             return False
-        my_children_dict = {f.name: f for f in self.__children}
-        other_children_dict = {f.name: f for f in other.__children}
+        my_children_dict = {f.name: f for f in self._children}
+        other_children_dict = {f.name: f for f in other._children}
         if my_children_dict.keys() != other_children_dict.keys():
             return False
         return all(my_children_dict[name] == other_children_dict[name] for name in my_children_dict)
@@ -85,169 +93,10 @@ class ModelFile:
         return str(self.__dict__)
 
     @property
-    def name(self) -> str:
-        return self.__name
-
-    @property
-    def pair_id(self) -> str | None:
-        return self.__pair_id
-
-    @pair_id.setter
-    def pair_id(self, pair_id: str | None):
-        self.__pair_id = pair_id
-
-    @property
-    def is_dir(self) -> bool:
-        return self.__is_dir
-
-    @property
-    def state(self) -> State:
-        return self.__state
-
-    @state.setter
-    def state(self, state: State):
-        if type(state) != ModelFile.State:
-            raise TypeError
-        self.__state = state
-
-    @property
-    def remote_size(self) -> int | None:
-        return self.__remote_size
-
-    @remote_size.setter
-    def remote_size(self, remote_size: int | None):
-        if type(remote_size) == int:
-            if remote_size < 0:
-                raise ValueError
-            self.__remote_size = remote_size
-        elif remote_size is None:
-            self.__remote_size = remote_size
-        else:
-            raise TypeError
-
-    @property
-    def local_size(self) -> int | None:
-        return self.__local_size
-
-    @local_size.setter
-    def local_size(self, local_size: int | None):
-        if type(local_size) == int:
-            if local_size < 0:
-                raise ValueError
-            self.__local_size = local_size
-        elif local_size is None:
-            self.__local_size = local_size
-        else:
-            raise TypeError
-
-    @property
-    def transferred_size(self) -> int | None:
-        return self.__transferred_size
-
-    @transferred_size.setter
-    def transferred_size(self, transferred_size: int | None):
-        if type(transferred_size) == int:
-            if transferred_size < 0:
-                raise ValueError
-            self.__transferred_size = transferred_size
-        elif transferred_size is None:
-            self.__transferred_size = transferred_size
-        else:
-            raise TypeError
-
-    @property
-    def downloading_speed(self) -> int | None:
-        return self.__downloading_speed
-
-    @downloading_speed.setter
-    def downloading_speed(self, downloading_speed: int | None):
-        if type(downloading_speed) == int:
-            if downloading_speed < 0:
-                raise ValueError
-            self.__downloading_speed = downloading_speed
-        elif downloading_speed is None:
-            self.__downloading_speed = downloading_speed
-        else:
-            raise TypeError
-
-    @property
-    def update_timestamp(self) -> datetime:
-        return self.__update_timestamp
-
-    @update_timestamp.setter
-    def update_timestamp(self, update_timestamp: datetime):
-        if type(update_timestamp) != datetime:
-            raise TypeError
-        self.__update_timestamp = update_timestamp
-
-    @property
-    def eta(self) -> int | None:
-        return self.__eta
-
-    @eta.setter
-    def eta(self, eta: int | None):
-        if type(eta) == int:
-            if eta < 0:
-                raise ValueError
-            self.__eta = eta
-        elif eta is None:
-            self.__eta = eta
-        else:
-            raise TypeError
-
-    @property
-    def is_extractable(self) -> bool:
-        return self.__is_extractable
-
-    @is_extractable.setter
-    def is_extractable(self, is_extractable: bool):
-        self.__is_extractable = is_extractable
-
-    @property
-    def local_created_timestamp(self) -> datetime | None:
-        return self.__local_created_timestamp
-
-    @local_created_timestamp.setter
-    def local_created_timestamp(self, local_created_timestamp: datetime):
-        if type(local_created_timestamp) != datetime:
-            raise TypeError
-        self.__local_created_timestamp = local_created_timestamp
-
-    @property
-    def local_modified_timestamp(self) -> datetime | None:
-        return self.__local_modified_timestamp
-
-    @local_modified_timestamp.setter
-    def local_modified_timestamp(self, local_modified_timestamp: datetime):
-        if type(local_modified_timestamp) != datetime:
-            raise TypeError
-        self.__local_modified_timestamp = local_modified_timestamp
-
-    @property
-    def remote_created_timestamp(self) -> datetime | None:
-        return self.__remote_created_timestamp
-
-    @remote_created_timestamp.setter
-    def remote_created_timestamp(self, remote_created_timestamp: datetime):
-        if type(remote_created_timestamp) != datetime:
-            raise TypeError
-        self.__remote_created_timestamp = remote_created_timestamp
-
-    @property
-    def remote_modified_timestamp(self) -> datetime | None:
-        return self.__remote_modified_timestamp
-
-    @remote_modified_timestamp.setter
-    def remote_modified_timestamp(self, remote_modified_timestamp: datetime):
-        if type(remote_modified_timestamp) != datetime:
-            raise TypeError
-        self.__remote_modified_timestamp = remote_modified_timestamp
-
-    @property
     def full_path(self) -> str:
         """Full path including all predecessors"""
-        if self.__parent:
-            return os.path.join(self.__parent.full_path, self.name)
+        if self._parent:
+            return os.path.join(self._parent.full_path, self.name)
         return self.name
 
     def add_child(self, child_file: "ModelFile"):
@@ -255,20 +104,20 @@ class ModelFile:
             raise TypeError("Cannot add child to a non-directory")
         if child_file is self:
             raise ValueError("Cannot add parent as a child")
-        if child_file.name in (f.name for f in self.__children):
+        if child_file.name in (f.name for f in self._children):
             raise ValueError("Cannot add child more than once")
-        self.__children.append(child_file)
-        child_file.__parent = self
+        self._children.append(child_file)
+        child_file._parent = self
 
     def get_children(self) -> list["ModelFile"]:
-        return copy.copy(self.__children)
+        return copy.copy(self._children)
 
     def iter_children(self) -> Iterator["ModelFile"]:
         # Read-only iterator over the live child list, avoiding the defensive
         # copy that get_children() makes. Callers MUST NOT mutate the child
         # list while iterating. Use get_children() if a snapshot is needed.
-        return iter(self.__children)
+        return iter(self._children)
 
     @property
     def parent(self) -> Optional["ModelFile"]:
-        return self.__parent
+        return self._parent

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -57,7 +57,6 @@ ignore = [
 "__init__.py" = ["F401", "I001"]  # re-exports, import order is load-order sensitive
 "tests/**" = ["W291", "SIM117", "RUF059", "C901"]  # trailing whitespace; nested with; structural unpacking; test complexity
 "tests/**/test_job_status_parser.py" = ["E501"]  # long lines are lftp output test data
-"model/file.py" = ["E721"]  # intentional type() comparisons for enum-style state checks
 "scan_fs.py" = ["UP006", "UP032", "UP035", "UP045"]  # must use typing/format() for Python 3.5 compat on remote
 
 [tool.ruff.lint.mccabe]

--- a/src/python/tests/unittests/test_model/test_file.py
+++ b/src/python/tests/unittests/test_model/test_file.py
@@ -23,9 +23,6 @@ class TestModelFile(unittest.TestCase):
         file.state = ModelFile.State.DOWNLOADING
         self.assertEqual(ModelFile.State.DOWNLOADING, file.state)
 
-        with self.assertRaises(TypeError):
-            file.state = "BadState"
-
     def test_local_size(self):
         file = ModelFile("test", False)
 
@@ -33,9 +30,6 @@ class TestModelFile(unittest.TestCase):
         self.assertEqual(100, file.local_size)
         file.local_size = None
         self.assertEqual(None, file.local_size)
-
-        with self.assertRaises(TypeError):
-            file.local_size = "BadValue"
         with self.assertRaises(ValueError):
             file.local_size = -100
 
@@ -46,9 +40,6 @@ class TestModelFile(unittest.TestCase):
         self.assertEqual(100, file.remote_size)
         file.remote_size = None
         self.assertEqual(None, file.remote_size)
-
-        with self.assertRaises(TypeError):
-            file.remote_size = "BadValue"
         with self.assertRaises(ValueError):
             file.remote_size = -100
 
@@ -59,9 +50,6 @@ class TestModelFile(unittest.TestCase):
         self.assertEqual(100, file.transferred_size)
         file.transferred_size = None
         self.assertEqual(None, file.transferred_size)
-
-        with self.assertRaises(TypeError):
-            file.transferred_size = "BadValue"
         with self.assertRaises(ValueError):
             file.transferred_size = -100
 
@@ -72,9 +60,6 @@ class TestModelFile(unittest.TestCase):
         self.assertEqual(100, file.downloading_speed)
         file.downloading_speed = None
         self.assertEqual(None, file.downloading_speed)
-
-        with self.assertRaises(TypeError):
-            file.downloading_speed = "BadValue"
         with self.assertRaises(ValueError):
             file.downloading_speed = -100
 
@@ -85,9 +70,6 @@ class TestModelFile(unittest.TestCase):
         file.update_timestamp = now
         self.assertEqual(now, file.update_timestamp)
 
-        with self.assertRaises(TypeError):
-            file.update_timestamp = 100
-
     def test_eta(self):
         file = ModelFile("test", False)
 
@@ -95,9 +77,6 @@ class TestModelFile(unittest.TestCase):
         self.assertEqual(100, file.eta)
         file.eta = None
         self.assertEqual(None, file.eta)
-
-        with self.assertRaises(TypeError):
-            file.eta = "BadValue"
         with self.assertRaises(ValueError):
             file.eta = -100
 
@@ -116,9 +95,6 @@ class TestModelFile(unittest.TestCase):
         file.local_created_timestamp = now
         self.assertEqual(now, file.local_created_timestamp)
 
-        with self.assertRaises(TypeError):
-            file.local_created_timestamp = 100
-
     def test_local_modified_timestamp(self):
         file = ModelFile("test", False)
         self.assertIsNone(file.local_modified_timestamp)
@@ -126,9 +102,6 @@ class TestModelFile(unittest.TestCase):
         now = datetime.now()
         file.local_modified_timestamp = now
         self.assertEqual(now, file.local_modified_timestamp)
-
-        with self.assertRaises(TypeError):
-            file.local_modified_timestamp = 100
 
     def test_remote_created_timestamp(self):
         file = ModelFile("test", False)
@@ -138,9 +111,6 @@ class TestModelFile(unittest.TestCase):
         file.remote_created_timestamp = now
         self.assertEqual(now, file.remote_created_timestamp)
 
-        with self.assertRaises(TypeError):
-            file.remote_created_timestamp = 100
-
     def test_remote_modified_timestamp(self):
         file = ModelFile("test", False)
         self.assertIsNone(file.remote_modified_timestamp)
@@ -148,9 +118,6 @@ class TestModelFile(unittest.TestCase):
         now = datetime.now()
         file.remote_modified_timestamp = now
         self.assertEqual(now, file.remote_modified_timestamp)
-
-        with self.assertRaises(TypeError):
-            file.remote_modified_timestamp = 100
 
     def test_equality_operator(self):
         # check that timestamp does not affect equality
@@ -166,6 +133,14 @@ class TestModelFile(unittest.TestCase):
         file2.local_size = 100
         file2.update_timestamp = datetime.now()
         self.assertTrue(file1 == file2)
+
+    def test_equality_ignores_parent(self):
+        # parent is excluded from equality: same fields, different tree position
+        orphan = ModelFile("child", False)
+        adopted = ModelFile("child", False)
+        parent = ModelFile("parent", True)
+        parent.add_child(adopted)
+        self.assertEqual(orphan, adopted)
 
     def test_child(self):
         file_parent = ModelFile("parent", True)

--- a/src/python/tests/unittests/test_web/test_serialize/test_serialize_model.py
+++ b/src/python/tests/unittests/test_web/test_serialize/test_serialize_model.py
@@ -330,3 +330,42 @@ class TestSerializeModel(unittest.TestCase):
         self.assertEqual("c/ca/caa", data[2]["children"][0]["children"][0]["full_path"])
         self.assertEqual("c/ca/cab", data[2]["children"][0]["children"][1]["full_path"])
         self.assertEqual("c/cb", data[2]["children"][1]["full_path"])
+
+
+GOLDEN_MODEL_INIT = 'event: model-init\ndata: [{"name": "Parent.Dir", "pair_id": "11111111-2222-3333-4444-555555555555", "is_dir": true, "state": "downloading", "remote_size": 1048576, "local_size": 524288, "downloading_speed": 4096, "eta": 128, "is_extractable": true, "local_created_timestamp": "1700000000.25", "local_modified_timestamp": "1700000100.5", "remote_created_timestamp": "1700000200.75", "remote_modified_timestamp": "1700000300.0", "full_path": "Parent.Dir", "children": [{"name": "child file.mkv", "pair_id": "11111111-2222-3333-4444-555555555555", "is_dir": false, "state": "default", "remote_size": 1048576, "local_size": null, "downloading_speed": null, "eta": null, "is_extractable": false, "local_created_timestamp": null, "local_modified_timestamp": null, "remote_created_timestamp": null, "remote_modified_timestamp": null, "full_path": "Parent.Dir/child file.mkv", "children": []}]}]\n\n'  # noqa: E501
+GOLDEN_MODEL_UPDATED = 'event: model-updated\ndata: {"old_file": {"name": "Parent.Dir", "pair_id": "11111111-2222-3333-4444-555555555555", "is_dir": true, "state": "downloading", "remote_size": 1048576, "local_size": 524288, "downloading_speed": 4096, "eta": 128, "is_extractable": true, "local_created_timestamp": "1700000000.25", "local_modified_timestamp": "1700000100.5", "remote_created_timestamp": "1700000200.75", "remote_modified_timestamp": "1700000300.0", "full_path": "Parent.Dir", "children": [{"name": "child file.mkv", "pair_id": "11111111-2222-3333-4444-555555555555", "is_dir": false, "state": "default", "remote_size": 1048576, "local_size": null, "downloading_speed": null, "eta": null, "is_extractable": false, "local_created_timestamp": null, "local_modified_timestamp": null, "remote_created_timestamp": null, "remote_modified_timestamp": null, "full_path": "Parent.Dir/child file.mkv", "children": []}]}, "new_file": null}\n\n'  # noqa: E501
+
+
+class TestSerializeModelGolden(unittest.TestCase):
+    """Byte-exact wire-format contract. Captured from the pre-dataclass
+    serializer (v1.1.0); the Angular frontend parses these exact keys and
+    value formats. If this test fails, the frontend contract changed."""
+
+    @staticmethod
+    def _build() -> ModelFile:
+        f = ModelFile("Parent.Dir", True, pair_id="11111111-2222-3333-4444-555555555555")
+        f.state = ModelFile.State.DOWNLOADING
+        f.remote_size = 1048576
+        f.local_size = 524288
+        f.transferred_size = 524288
+        f.downloading_speed = 4096
+        f.eta = 128
+        f.is_extractable = True
+        f.local_created_timestamp = datetime.fromtimestamp(1700000000.25)
+        f.local_modified_timestamp = datetime.fromtimestamp(1700000100.5)
+        f.remote_created_timestamp = datetime.fromtimestamp(1700000200.75)
+        f.remote_modified_timestamp = datetime.fromtimestamp(1700000300.0)
+        c = ModelFile("child file.mkv", False, pair_id="11111111-2222-3333-4444-555555555555")
+        c.state = ModelFile.State.DEFAULT
+        c.remote_size = 1048576
+        f.add_child(c)
+        return f
+
+    def test_model_init_golden(self):
+        self.assertEqual(GOLDEN_MODEL_INIT, SerializeModel().model([self._build()]))
+
+    def test_update_event_golden(self):
+        event = SerializeModel.UpdateEvent(
+            SerializeModel.UpdateEvent.Change.UPDATED, old_file=self._build(), new_file=None
+        )
+        self.assertEqual(GOLDEN_MODEL_UPDATED, SerializeModel().update_event(event))

--- a/src/python/web/serialize/serialize_model.py
+++ b/src/python/web/serialize/serialize_model.py
@@ -1,6 +1,7 @@
 # Copyright 2017, Inderpreet Singh, All rights reserved.
 
 import json
+from datetime import datetime
 from enum import Enum
 from typing import Any
 
@@ -36,66 +37,32 @@ class SerializeModel(Serialize):
     __KEY_UPDATE_OLD_FILE = "old_file"
     __KEY_UPDATE_NEW_FILE = "new_file"
 
-    # Model file keys
-    __KEY_FILE_NAME = "name"
-    __KEY_FILE_PAIR_ID = "pair_id"
-    __KEY_FILE_IS_DIR = "is_dir"
-    __KEY_FILE_STATE = "state"
-    __VALUES_FILE_STATE = {
-        ModelFile.State.DEFAULT: "default",
-        ModelFile.State.QUEUED: "queued",
-        ModelFile.State.DOWNLOADING: "downloading",
-        ModelFile.State.DOWNLOADED: "downloaded",
-        ModelFile.State.DELETED: "deleted",
-        ModelFile.State.EXTRACTING: "extracting",
-        ModelFile.State.EXTRACTED: "extracted",
-        ModelFile.State.EXTRACT_FAILED: "extract_failed",
-        ModelFile.State.VALIDATING: "validating",
-        ModelFile.State.VALIDATED: "validated",
-        ModelFile.State.CORRUPT: "corrupt",
-        ModelFile.State.MOVE_FAILED: "move_failed",
-    }
-    __KEY_FILE_REMOTE_SIZE = "remote_size"
-    __KEY_FILE_LOCAL_SIZE = "local_size"
-    __KEY_FILE_DOWNLOADING_SPEED = "downloading_speed"
-    __KEY_FILE_ETA = "eta"
-    __KEY_FILE_IS_EXTRACTABLE = "is_extractable"
-    __KEY_FILE_LOCAL_CREATED_TIMESTAMP = "local_created_timestamp"
-    __KEY_FILE_LOCAL_MODIFIED_TIMESTAMP = "local_modified_timestamp"
-    __KEY_FILE_REMOTE_CREATED_TIMESTAMP = "remote_created_timestamp"
-    __KEY_FILE_REMOTE_MODIFIED_TIMESTAMP = "remote_modified_timestamp"
-    __KEY_FILE_FULL_PATH = "full_path"
-    __KEY_FILE_CHILDREN = "children"
-
     @staticmethod
     def __model_file_to_json_dict(model_file: ModelFile) -> dict[str, Any]:
-        json_dict: dict[str, Any] = {}
-        json_dict[SerializeModel.__KEY_FILE_NAME] = model_file.name
-        json_dict[SerializeModel.__KEY_FILE_PAIR_ID] = model_file.pair_id
-        json_dict[SerializeModel.__KEY_FILE_IS_DIR] = model_file.is_dir
-        json_dict[SerializeModel.__KEY_FILE_STATE] = SerializeModel.__VALUES_FILE_STATE[model_file.state]
-        json_dict[SerializeModel.__KEY_FILE_REMOTE_SIZE] = model_file.remote_size
-        json_dict[SerializeModel.__KEY_FILE_LOCAL_SIZE] = model_file.local_size
-        json_dict[SerializeModel.__KEY_FILE_DOWNLOADING_SPEED] = model_file.downloading_speed
-        json_dict[SerializeModel.__KEY_FILE_ETA] = model_file.eta
-        json_dict[SerializeModel.__KEY_FILE_IS_EXTRACTABLE] = model_file.is_extractable
-        json_dict[SerializeModel.__KEY_FILE_LOCAL_CREATED_TIMESTAMP] = (
-            str(model_file.local_created_timestamp.timestamp()) if model_file.local_created_timestamp else None
-        )
-        json_dict[SerializeModel.__KEY_FILE_LOCAL_MODIFIED_TIMESTAMP] = (
-            str(model_file.local_modified_timestamp.timestamp()) if model_file.local_modified_timestamp else None
-        )
-        json_dict[SerializeModel.__KEY_FILE_REMOTE_CREATED_TIMESTAMP] = (
-            str(model_file.remote_created_timestamp.timestamp()) if model_file.remote_created_timestamp else None
-        )
-        json_dict[SerializeModel.__KEY_FILE_REMOTE_MODIFIED_TIMESTAMP] = (
-            str(model_file.remote_modified_timestamp.timestamp()) if model_file.remote_modified_timestamp else None
-        )
-        json_dict[SerializeModel.__KEY_FILE_FULL_PATH] = model_file.full_path
-        json_dict[SerializeModel.__KEY_FILE_CHILDREN] = []
-        for child in model_file.get_children():
-            json_dict[SerializeModel.__KEY_FILE_CHILDREN].append(SerializeModel.__model_file_to_json_dict(child))
-        return json_dict
+        """JSON dict for one file. Key order and value formats are the SSE wire
+        contract parsed by the Angular frontend — see the golden test."""
+
+        def ts(t: datetime | None) -> str | None:
+            return str(t.timestamp()) if t else None
+
+        return {
+            "name": model_file.name,
+            "pair_id": model_file.pair_id,
+            "is_dir": model_file.is_dir,
+            # State enum names lowercased are exactly the wire values
+            "state": model_file.state.name.lower(),
+            "remote_size": model_file.remote_size,
+            "local_size": model_file.local_size,
+            "downloading_speed": model_file.downloading_speed,
+            "eta": model_file.eta,
+            "is_extractable": model_file.is_extractable,
+            "local_created_timestamp": ts(model_file.local_created_timestamp),
+            "local_modified_timestamp": ts(model_file.local_modified_timestamp),
+            "remote_created_timestamp": ts(model_file.remote_created_timestamp),
+            "remote_modified_timestamp": ts(model_file.remote_modified_timestamp),
+            "full_path": model_file.full_path,
+            "children": [SerializeModel.__model_file_to_json_dict(child) for child in model_file.iter_children()],
+        }
 
     def model(self, model_files: list[ModelFile]) -> str:
         """


### PR DESCRIPTION
Closes #666. Part of #682. Net −171 lines (124+/295−) across 5 files.

## Summary
- `ModelFile` is a `@dataclass(eq=False, repr=False)`: 15 property pairs and their `type()` guards are gone; pyright strict enforces types statically. The one real runtime invariant — non-negative sizes/speed/eta — stays, enforced in `__setattr__` with the same `ValueError`.
- **Equality semantics preserved and still dynamic**: `__eq__` iterates `dataclasses.fields()` minus `update_timestamp`; `children`/`parent` are instance attrs (set in `__post_init__`), so they're excluded exactly as before (children compared by-name, parent ignored). A new field is compared by default, matching the old `__dict__`-based behavior. New test pins the parent exclusion.
- Serializer: 18 once-used `__KEY_*` constants + the 12-entry state map → one dict literal; `state.name.lower()` equals the old mapping for every state.
- `E721` per-file ignore dropped from pyproject.

## Wire-format contract
Golden test (`TestSerializeModelGolden`) asserts byte-exact `model-init` and `model-updated` SSE output, captured from the **pre-refactor (v1.1.0)** serializer before any code changed — timestamps with fractional seconds, nulls, nested children, spaces in names.

## Behavior notes
- Setter `TypeError` guards removed (now static-only); their test assertions removed per CLAUDE.md/AGENTS.md test rules. `ValueError` on negatives kept and still tested.
- `name`/`is_dir` were read-only properties; as dataclass fields they're technically assignable now. No caller assigns them (pyright would flag new ones under strict).
- `repr` now shows unmangled attribute names (debug-only surface).

## Test plan
- [x] `ruff check` + `ruff format --check` clean (E721 ignore removed)
- [x] pyright: 0 errors
- [x] Unit: 1010 passed (golden + equality tests added; 12 static-only TypeError assertions removed)
- [x] Integration (web handlers): 158 passed
- [ ] CI incl. e2e (frontend parses the live stream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined file metadata handling and validation.
  * Improved file comparison behavior so parent-directory relationships do not affect equality.
  * Simplified model serialization while preserving existing output compatibility.
* **Tests**
  * Added coverage to verify serialized model and update-event formats remain compatible with version 1.1.0.
  * Expanded checks for file comparison behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->